### PR TITLE
Moved display of smartblock files that meet criteria to update.phtml

### DIFF
--- a/airtime_mvc/application/controllers/PlaylistController.php
+++ b/airtime_mvc/application/controllers/PlaylistController.php
@@ -57,18 +57,20 @@ class PlaylistController extends Zend_Controller_Action
         return $obj;
     }
 
-    private function createUpdateResponse($obj)
+    private function createUpdateResponse($obj, $formIsValid = false)
     {
         $formatter = new LengthFormatter($obj->getLength());
         $this->view->length = $formatter->format();
 
         $this->view->obj = $obj;
         $this->view->contents = $obj->getContents();
+        if ($formIsValid) {
+            $this->view->poolCount = $obj->getListofFilesMeetCriteria()['count'];
+        }
         $this->view->html = $this->view->render('playlist/update.phtml');
         $this->view->name = $obj->getName();
         $this->view->description = $obj->getDescription();
         $this->view->modified = $obj->getLastModified("U");
-
         unset($this->view->obj);
     }
 
@@ -99,7 +101,6 @@ class PlaylistController extends Zend_Controller_Action
                 $form = new Application_Form_SmartBlockCriteria();
                 $form->removeDecorator('DtDdWrapper');
                 $form->startForm($obj->getId(), $formIsValid);
-
                 $this->view->form = $form;
                 $this->view->obj = $obj;
                 //$this->view->type = "sb";
@@ -555,8 +556,7 @@ class PlaylistController extends Zend_Controller_Action
             if ($form->isValid($params)) {
                 $this->setPlaylistNameDescAction();
                 $bl->saveSmartBlockCriteria($params['data']);
-
-                $this->createUpdateResponse($bl);
+                $this->createUpdateResponse($bl, true);
                 $this->view->result = 0;
                 /*
                 $result['html'] = $this->createFullResponse($bl, true, true);
@@ -599,7 +599,7 @@ class PlaylistController extends Zend_Controller_Action
             if ($form->isValid($params)) {
                 $result = $bl->generateSmartBlock($params['data']);
                 $this->view->result = $result['result'];
-                $this->createUpdateResponse($bl);
+                $this->createUpdateResponse($bl, true);
                 #$this->_helper->json->sendJson(array("result"=>0, "html"=>$this->createFullResponse($bl, true, true)));
             } else {
                 $this->view->obj = $bl;
@@ -624,7 +624,7 @@ class PlaylistController extends Zend_Controller_Action
             $result = $bl->shuffleSmartBlock();
 
             $this->view->result = $result["result"];
-            $this->createUpdateResponse($bl);
+            $this->createUpdateResponse($bl,true);
 
             /*
             if ($result['result'] == 0) {
@@ -652,7 +652,7 @@ class PlaylistController extends Zend_Controller_Action
             $result = $pl->shuffle();
 
             $this->view->result = $result["result"];
-            $this->createUpdateResponse($pl);
+            $this->createUpdateResponse($pl,true);
             /*
             if ($result['result'] == 0) {
                 $this->_helper->json->sendJson(array(

--- a/airtime_mvc/application/controllers/PlaylistController.php
+++ b/airtime_mvc/application/controllers/PlaylistController.php
@@ -67,6 +67,7 @@ class PlaylistController extends Zend_Controller_Action
         if ($formIsValid) {
             $this->view->poolCount = $obj->getListofFilesMeetCriteria()['count'];
         }
+        $this->view->showPoolCount = true;
         $this->view->html = $this->view->render('playlist/update.phtml');
         $this->view->name = $obj->getName();
         $this->view->description = $obj->getDescription();

--- a/airtime_mvc/application/forms/SmartBlockCriteria.php
+++ b/airtime_mvc/application/forms/SmartBlockCriteria.php
@@ -361,8 +361,7 @@ class Application_Form_SmartBlockCriteria extends Zend_Form_SubForm
 
         $this->setDecorators(array(
                 array('ViewScript', array('viewScript' => 'form/smart-block-criteria.phtml', "openOption"=> $openSmartBlockOption,
-                        'criteriasLength' => count($this->getCriteriaOptions()), 'poolCount' => $files['count'], 'modRowMap' => $modRowMap,
-                        'showPoolCount' => $showPoolCount))
+                        'criteriasLength' => count($this->getCriteriaOptions()), 'modRowMap' => $modRowMap))
         ));
     }
 

--- a/airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml
+++ b/airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml
@@ -119,37 +119,6 @@
             
         <?php } ?>
         </dd>
-
-        <?php
-        // this will never run due to refactoring of playlist controller. it is replaced with code in update.phtml
-        if ($this->showPoolCount) { ?>
-            <div class='sp_text_font sp_text_font_bold'>
-                <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
-                <?php
-                if ($this->poolCount > 1) {
-                    echo $this->poolCount;
-                ?>
-                    <?php echo _("files meet the criteria")?>
-                    </span>
-                    <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
-                <?php
-                } else if ($this->poolCount == 1) {
-                    echo $this->poolCount;
-                ?>
-                    <?php echo _("file meets the criteria")?>
-                    </span>
-                    <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
-                <?php
-                } else {
-                ?>
-                    0 <?php echo " "._("files meet the criteria")?>
-                    </span>
-                    <span class='sp-warning-icon' id='sp_pool_count_icon'></span>
-                <?php
-                }
-                ?>
-            </div>
-        <?php } ?>
     </dl>
 
 </form>

--- a/airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml
+++ b/airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml
@@ -120,7 +120,9 @@
         <?php } ?>
         </dd>
 
-        <?php if ($this->showPoolCount) { ?>
+        <?php
+        // this will never run due to refactoring of playlist controller. it is replaced with code in update.phtml
+        if ($this->showPoolCount) { ?>
             <div class='sp_text_font sp_text_font_bold'>
                 <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
                 <?php

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -2,35 +2,29 @@
 $items = $this->contents;
 $isStaticSmartBlock = ($this->obj instanceof Application_Model_Block && $this->obj->isStatic());
 $isPlaylist = ($this->obj instanceof Application_Model_Playlist);
-if ($this->poolCount) { ?>
+?>
 <div class='sp_text_font sp_text_font_bold'>
-                <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
-                <?php
-                if ($this->poolCount > 1) {
-                echo $this->poolCount;
-                ?>
-                <?php echo _("files meet the criteria")?>
-                    </span>
+<?php
+if ($this->poolCount) { ?>
+    <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
+    <?php
+    if ($this->poolCount > 0) {
+        echo $this->poolCount;
+        echo ngettext(" file meets the criteria", " files meets the criteria", $this->poolCount);
+    }
+    ?>
+    </span>
     <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
     <?php
-    } else if ($this->poolCount == 1) {
-        echo $this->poolCount;
-        ?>
-        <?php echo _("file meets the criteria")?>
-        </span>
-        <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
-        <?php
-    } else {
-        ?>
-        0 <?php echo " "._("files meet the criteria")?>
-        </span>
-        <span class='sp-warning-icon' id='sp_pool_count_icon'></span>
-        <?php
+    }
+else if ($this->showPoolCount){
+    ?>
+    <span class='sp-warning-icon' id='sp_pool_count_icon'></span>
+    <?php    echo _("No files meet the criteria");
     }
     ?>
 </div>
-<?php }
-
+<?php
 if (count($items) && ($isStaticSmartBlock || $isPlaylist)) : ?>
 <?php $i = 0; ?>
 <?php foreach($items as $item) :

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -1,6 +1,6 @@
 <?php
 $items = $this->contents;
-$isStaticSmartBlock = ($this->obj instanceof Application_Model_Block && $this->obj->isStatic());
+$isSmartBlock = ($this->obj instanceof Application_Model_Block);
 $isPlaylist = ($this->obj instanceof Application_Model_Playlist);
 
 if (count($items) && ($isSmartBlock || $isPlaylist)) : ?>

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -2,29 +2,7 @@
 $items = $this->contents;
 $isStaticSmartBlock = ($this->obj instanceof Application_Model_Block && $this->obj->isStatic());
 $isPlaylist = ($this->obj instanceof Application_Model_Playlist);
-?>
-<div class='sp_text_font sp_text_font_bold'>
-<?php
-if ($this->poolCount) { ?>
-    <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
-    <?php
-    if ($this->poolCount > 0) {
-        echo $this->poolCount;
-        echo ngettext(" file meets the criteria", " files meets the criteria", $this->poolCount);
-    }
-    ?>
-    </span>
-    <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
-    <?php
-    }
-else if ($this->showPoolCount){
-    ?>
-    <span class='sp-warning-icon' id='sp_pool_count_icon'></span>
-    <?php    echo _("No files meet the criteria");
-    }
-    ?>
-</div>
-<?php
+
 if (count($items) && ($isStaticSmartBlock || $isPlaylist)) : ?>
 <?php $i = 0; ?>
 <?php foreach($items as $item) :

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -2,7 +2,6 @@
 $items = $this->contents;
 $isSmartBlock = ($this->obj instanceof Application_Model_Block);
 $isPlaylist = ($this->obj instanceof Application_Model_Playlist);
-
 if (count($items) && ($isSmartBlock || $isPlaylist)) : ?>
 <?php $i = 0; ?>
 <?php foreach($items as $item) :

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -3,7 +3,7 @@ $items = $this->contents;
 $isStaticSmartBlock = ($this->obj instanceof Application_Model_Block && $this->obj->isStatic());
 $isPlaylist = ($this->obj instanceof Application_Model_Playlist);
 
-if (count($items) && ($isStaticSmartBlock || $isPlaylist)) : ?>
+if (count($items) && ($isSmartBlock || $isPlaylist)) : ?>
 <?php $i = 0; ?>
 <?php foreach($items as $item) :
 $staticBlock = null;

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -2,6 +2,35 @@
 $items = $this->contents;
 $isStaticSmartBlock = ($this->obj instanceof Application_Model_Block && $this->obj->isStatic());
 $isPlaylist = ($this->obj instanceof Application_Model_Playlist);
+if ($this->poolCount) { ?>
+<div class='sp_text_font sp_text_font_bold'>
+                <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
+                <?php
+                if ($this->poolCount > 1) {
+                echo $this->poolCount;
+                ?>
+                <?php echo _("files meet the criteria")?>
+                    </span>
+    <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
+    <?php
+    } else if ($this->poolCount == 1) {
+        echo $this->poolCount;
+        ?>
+        <?php echo _("file meets the criteria")?>
+        </span>
+        <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
+        <?php
+    } else {
+        ?>
+        0 <?php echo " "._("files meet the criteria")?>
+        </span>
+        <span class='sp-warning-icon' id='sp_pool_count_icon'></span>
+        <?php
+    }
+    ?>
+</div>
+<?php }
+
 if (count($items) && ($isStaticSmartBlock || $isPlaylist)) : ?>
 <?php $i = 0; ?>
 <?php foreach($items as $item) :
@@ -120,6 +149,7 @@ if (($i < count($items) -1) && ($items[$i+1]['type'] == 0)) {
             }
 
             echo $this->partial('playlist/set-fade.phtml', $vars);
+
             ?>
         </div>
         <?php endif; ?>

--- a/airtime_mvc/public/css/styles.css
+++ b/airtime_mvc/public/css/styles.css
@@ -739,6 +739,7 @@ input.input_text.sp_extra_input_text{
 
 .sp_text_font_bold{
     font-weight: bold;
+    color: white;
 }
 
 .sp-ui-button-icon-only {
@@ -782,6 +783,8 @@ input.input_text.sp_extra_input_text{
 .sp-closed{
     border-width: 0 0 0 !important;
 }
+
+
 /***** SMART BLOCK SPECIFIC STYLES END *****/
 
 label {


### PR DESCRIPTION
Basically I recreated what originally existed in the smart-block-criteria.phtml view and put it at the top of the track listing so that it will display with update.phtml and be updated when the criteria is changed and saved.

I'm not 100% happy with how this changes the UI but it is definitely the easiest option at this point and avoids touching the javascript to try to update it. Any suggestions for UI improvements are encouraged.  It might make sense to color it with CSS to make it more distinct but otherwise I think that this reimplements the functionality requested in #366