### PR TITLE
Use max upload size from php config in frontend plupload js

### DIFF
--- a/airtime_mvc/application/views/scripts/plupload/index.phtml
+++ b/airtime_mvc/application/views/scripts/plupload/index.phtml
@@ -3,6 +3,9 @@
     font-size: 200px !important;
 }
 </style>
+<script type="text/javascript">
+    var LIBRETIME_PLUPLOAD_MAX_FILE_SIZE = "<?php echo $this->uploadMaxSize; ?>";
+</script>
 <?php $upgradeLink = Application_Common_OsPath::getBaseDir() . "billing/upgrade"; ?>
 <?php if ($this->quotaLimitReached) { ?>
     <div class="errors quota-reached">

--- a/airtime_mvc/public/js/airtime/library/plupload.js
+++ b/airtime_mvc/public/js/airtime/library/plupload.js
@@ -20,7 +20,7 @@ $(document).ready(function () {
         acceptedFiles: acceptedMimeTypes.join(),
         addRemoveLinks: true,
         dictRemoveFile: $.i18n._("Remove"),
-        maxFilesize: 500, //Megabytes
+        maxFilesize:LIBRETIME_PLUPLOAD_MAX_FILE_SIZE, //Megabytes
         init: function () {
             this.on("sending", function (file, xhr, data) {
                 data.append("csrf_token", $("#csrf").val());


### PR DESCRIPTION
This grabs the upload limit for the js frontend from what is configured in php on the backend. I figured grabbing the appropriate value from the php config is simpler to handle than exposing the option in settings.

I ended up keeping the limit at 500 MiB for users that configure their server to support unlimited uploads. We could get a further estimate of the possible upload size by checking their memory_limit value but I feel like that would be going to far.

Fix #384 