### PR TITLE
modified jquery find for shuffle and generate buttons to not target clear button

### DIFF
--- a/airtime_mvc/public/js/airtime/playlist/smart_blockbuilder.js
+++ b/airtime_mvc/public/js/airtime/playlist/smart_blockbuilder.js
@@ -367,8 +367,8 @@ function setupUI() {
      */
     var sortable = activeTab.find('.spl_sortable'),
         plContents = sortable.children(),
-        shuffleButton = activeTab.find('button[name="shuffle_button"], #pl-bl-clear-content'),
-        generateButton = activeTab.find('button[name="generate_button"], #pl-bl-clear-content'),
+        shuffleButton = activeTab.find('button[name="shuffle_button"]'),
+        generateButton = activeTab.find('button[name="generate_button"]'),
         fadesButton = activeTab.find('#spl_crossfade, #pl-bl-clear-content');
 
     if (!plContents.hasClass('spl_empty')) {


### PR DESCRIPTION
The jquery activeTab.find included a variable that matched the css for the clear button. When I renamed the generate button this was also rewriting the HTML for the clear button thus overriding it's text.

By removing this from the identifier everything appears to be working with the text as it should be. I'm not sure why the jquery was written like that but based upon some testing the change doesn't alter the functionality.