### PR TITLE
Validate contents of VERSION file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,11 +17,12 @@ if [ "${git_build}" = "y" ]; then
     echo ${git_version} > VERSION
 else
     # if no file was in tarball we create one letting the user know
-    # travis should release tarballs with a pre-written VERSION file
-    # at some stage
+    # if you run in to this you should grab an enriched tarball built
+    # by travis. It already contains the VERSION file and also bundles
+    # all the PHP you vendors files making the install much faster on
+    # your part.
     if [ ! -f VERSION ]; then
-        folder_name=$(basename `pwd`)
-        echo "tarball install from folder ${folder_name}" > VERSION
+        echo "could not detect version for VERSION file" > VERSION
     fi
 fi
 


### PR DESCRIPTION
Fixes #410 by using Composer\Semver\VersionParser to validate the contents of what we got from VERSION before comparing anything.

If anyone installs from a source lacking the version file it should look like this:

![screenshot from 2018-01-19 21-04-47](https://user-images.githubusercontent.com/116588/35169316-66a9ccbc-fd5c-11e7-8c93-79a98d35b3e7.png)
