### PR TITLE
Update ip column size to allow for IPv6 addresses

### DIFF
--- a/airtime_mvc/build/schema.xml
+++ b/airtime_mvc/build/schema.xml
@@ -450,7 +450,7 @@
   </table>
   <table name="cc_service_register" phpName="CcServiceRegister">
     <column name="name" phpName="DbName" primaryKey="true" type="VARCHAR" size="32" required="true" />
-    <column name="ip" phpName="DbIp" type="VARCHAR" size="18" required="true"/>
+    <column name="ip" phpName="DbIp" type="VARCHAR" size="45" required="true"/>
   </table>
   <table name="cc_live_log" phpName="CcLiveLog">
     <column name="id" phpName="DbId" primaryKey="true" type="INTEGER" autoIncrement="true" required="true" />

--- a/airtime_mvc/build/sql/schema.sql
+++ b/airtime_mvc/build/sql/schema.sql
@@ -516,7 +516,7 @@ DROP TABLE IF EXISTS "cc_service_register" CASCADE;
 CREATE TABLE "cc_service_register"
 (
     "name" VARCHAR(32) NOT NULL,
-    "ip" VARCHAR(18) NOT NULL,
+    "ip" VARCHAR(45) NOT NULL,
     PRIMARY KEY ("name")
 );
 


### PR DESCRIPTION
Allow for the use of IPv6 address as per [issue 428](https://github.com/LibreTime/libretime/issues/428)

45 chars are used instead of the expected 39 because of [IPv4-embedded](https://stackoverflow.com/a/1076755) addresses