### PR TITLE
Configure invite-contributors probot app

### DIFF
--- a/.github/invite-contributors.yml
+++ b/.github/invite-contributors.yml
@@ -1,0 +1,4 @@
+# invite-contributors config
+#
+# See https://probot.github.io/apps/invite-contributors/ for details
+team: Contributors


### PR DESCRIPTION
Configuring invite-contributors as per #434.

I'll activate the app as soon as the config is merged.