### PR TITLE
Remove obsolete settings from master config template

### DIFF
--- a/airtime_mvc/build/airtime.example.conf
+++ b/airtime_mvc/build/airtime.example.conf
@@ -150,50 +150,6 @@ password =
 # ----------------------------------------------------------------------
 
 
-# ----------------------------------------------------------------------
-#                         M E D I A   M O N I T O R
-# ----------------------------------------------------------------------
-#
-# check_filesystem_events: How long to queue up events performed on the 
-#                            files themselves, in seconds
-#                          The default is 5
-#
-# check_airtime_events:    How long to queue metadata input from airtime,
-#                            in seconds
-#                          The default is 30
-#
-# touch_interval:          
-#                          The default is 5
-#
-# chunking_number:         
-#                          The default is 450
-#
-# request_max_wait:        The maximum request wait time, in seconds
-#                          The default is 3.0
-#
-# rmq_event_wait:          The RabbitMQ event wait time, in seconds
-#                          The default is 0.1
-#
-# logpath:                 The media monitor log file path
-#                          The default is
-#                           '/var/log/airtime/media-monitor/media-monitor.log'
-#
-# index_path:              The media monitor index path
-#                          The default is
-#                           '/var/tmp/airtime/media-monitor/last_index'
-#
-[media-monitor]
-check_filesystem_events = 5
-check_airtime_events = 30
-touch_interval = 5
-chunking_number = 450
-request_max_wait = 3.0
-rmq_event_wait = 0.1
-logpath = '/var/log/airtime/media-monitor/media-monitor.log'
-index_path = '/var/tmp/airtime/media-monitor/last_index'
-#
-# ----------------------------------------------------------------------
-
 
 # ----------------------------------------------------------------------
 #                                P Y P O

--- a/install
+++ b/install
@@ -693,8 +693,7 @@ fi
 loudCmd "./build.sh"
 if [ -f /etc/airtime/airtime.conf ]; then
     # TODO use VERSION or some other way to check for updates and handle
-    # media-monitor case on it's own and remove the section from the config
-    # file completely (it's still in the install)
+    # media-monitor case on it's own
     OLD_CONF=$(grep "[media-monitor]" /etc/airtime/airtime.conf)
     
     if [ -n "${OLD_CONF}" ]; then


### PR DESCRIPTION
Media monitor was removed and we can remove it from the install.

It is to be confirmed if this fixes #450 but we should still get rid for the `[media-monitor]` section during the install so we don't trigger the bits of code I linked in https://github.com/LibreTime/libretime/issues/450#issuecomment-369905183.