### PR TITLE
Stop ShoutCAST rejecting title updates

### DIFF
--- a/python_apps/pypo/liquidsoap/ls_lib.liq
+++ b/python_apps/pypo/liquidsoap/ls_lib.liq
@@ -37,8 +37,12 @@ def append_title(m) =
       elsif !stream_metadata_type == 2 then
         [("title", "#{!station_name} - #{!show_name}"), ("mapped", "true")]
       else
-        [("title", "#{m['artist']} - #{m['title']}"), ("mapped", "true")]
-      end
+        if "#{m['artist']}" == "" then
+          [("title", "#{m['title']}"), ("mapped", "true")]
+        else
+          [("title", "#{m['artist']} - #{m['title']}"), ("mapped", "true")]
+        end
+     end
   end
 end
 


### PR DESCRIPTION
When Libretime streams a webstream, the ID3 data is put into a single title field, leaving the artist field blank. When processing the ID3 data, Libretime concatenates the blank 'artist' field with the title, leaving '- title'. ShoutCAST rejects title updates that begin with punctuation for stylistic reasons (thanks guys) and so effectively ignores all ID3 data coming with the stream, falling back to the 'Station off-air' message. This PR uses the title field alone if the artist field is blank, but both when the artist data is available e.g. when streaming an MP3.