### PR TITLE
Fix to the installer to enable successful install on Raspbian 9 (stretch)

### DIFF
--- a/install
+++ b/install
@@ -599,12 +599,14 @@ case "${dist}-${code}" in
         is_debian_dist=true
         is_debian_stretch=true
         ;;
+    #Fix for Raspbian 9 (stretch)
     raspbian-9|9)
 	code="stretch"
 	dist="debian"
 	is_debian_dist=true
 	is_debian_stretch=true
 	;;
+    #End of fix
     debian-8|debian-jessie)
         code="jessie"
         is_debian_dist=true

--- a/install
+++ b/install
@@ -599,6 +599,12 @@ case "${dist}-${code}" in
         is_debian_dist=true
         is_debian_stretch=true
         ;;
+    raspbian-9|9)
+	code="stretch"
+	dist="debian"
+	is_debian_dist=true
+	is_debian_stretch=true
+	;;
     debian-8|debian-jessie)
         code="jessie"
         is_debian_dist=true


### PR DESCRIPTION
a simple addition to get the installer to recognise Raspbian 9 (stretch) as debian stretch,  which is needed for a successful install on raspberry pi under the latest OS