### PR TITLE
Fix call with deprecated arg

### DIFF
--- a/python_apps/airtime_analyzer/airtime_analyzer/message_listener.py
+++ b/python_apps/airtime_analyzer/airtime_analyzer/message_listener.py
@@ -110,7 +110,7 @@ class MessageListener:
             port=self._port, virtual_host=self._vhost, 
             credentials=pika.credentials.PlainCredentials(self._username, self._password)))
         self._channel = self._connection.channel()
-        self._channel.exchange_declare(exchange=EXCHANGE, type=EXCHANGE_TYPE, durable=True)
+        self._channel.exchange_declare(exchange=EXCHANGE, exchange_type=EXCHANGE_TYPE, durable=True)
         result = self._channel.queue_declare(queue=QUEUE, durable=True)
 
         self._channel.queue_bind(exchange=EXCHANGE, queue=QUEUE, routing_key=ROUTING_KEY)


### PR DESCRIPTION
The plain `type` argument was deprecated somewhere around pika 0.11.0/0.12.0 (aka ages ago) and it is slowly getting removed now. I found this https://github.com/pika/pika/commit/9598b4391647ca0a9e0e48dbe87d66aa116dae50 and https://github.com/pika/pika/commit/3a99d8d0f7bb46c9ecedebdc698246e5cb912994 that work on the param I'm updating and the change needed is documented ie. https://github.com/pika/pika/issues/353#issuecomment-18845184 and elsewhere.

This was also reported in a thread in our issue tracker https://github.com/LibreTime/libretime/issues/474#issuecomment-381393754.