### PR TITLE
Changes made for spaz radio [wip]

### DIFF
--- a/python_apps/pypo/liquidsoap/ls_lib.liq
+++ b/python_apps/pypo/liquidsoap/ls_lib.liq
@@ -1,3 +1,6 @@
+# coding: utf-8
+%include "utils.liq"
+
 def notify(m)
   command = "timeout --signal=KILL 45 pyponotify --media-id=#{m['schedule_table_id']} &"
   log(command)
@@ -416,4 +419,18 @@ def http_fallback(~http_input_id,~http,~default)
       {connected() and source.is_ready(http) and !webstream_enabled}, http),
      ({true},default)])
 
+end
+
+
+def munge_live_hdr(m)
+  log("got headers #{m}")
+  # not setting title here because it might get set by something else
+  lm =  [("artist_clean", orn(m['ice-name'], m['icy-name'])),
+         ("artist", orn(m['ice-name'], m['icy-name'])),
+         ("mapped", "true"), # make airtime stop attempting to mangle it
+         ("url", orn(m['ice-url'], m['icy-url'])),
+         ("live", "true"),
+         ("description",  orn(m['ice-description'], m['icy-description']))]
+  log("set live_meta to #{lm}")
+  lm
 end

--- a/python_apps/pypo/liquidsoap/ls_script.liq
+++ b/python_apps/pypo/liquidsoap/ls_script.liq
@@ -1,4 +1,5 @@
 %include "/etc/airtime/liquidsoap.cfg"
+%include "utils.liq"
 
 set("log.file.path", log_file)
 set("server.telnet", true)
@@ -176,13 +177,36 @@ server.register(namespace="dynamic_source",
 #                "read_stop_all",
 #                fun (s) -> begin log("dynamic_source.read_stop") destroy_dynamic_source_all() end)
 
-default = amplify(id="silence_src", 0.00001, noise())
-ref_off_air_meta = ref off_air_meta
-if !ref_off_air_meta == "" then
-    ref_off_air_meta := "LibreTime - offline"
-end
-default = rewrite_metadata([("title", !ref_off_air_meta)], default)
-ignore(output.dummy(default, fallible=true))
+
+
+
+
+
+silence = amplify(id="silence_src", 0.00001, noise())
+ignore(output.dummy(silence, fallible=true))
+
+log(off_air_meta)
+
+# check both drop and imported locations,
+# just in case something screws up via airtime
+jukebox = audio_to_stereo(id="stereoize",
+                          skip_blank(id="stor-skipblank",
+                                     playlist(id="archives",
+                                              reload=86400,
+                                              "/usr/share/airtime/public/archives")))
+
+
+
+
+
+# this is the master control for the stream right here.
+# the sources are listed in priority order
+default = fallback(id="default-switcher",
+                   track_sensitive=false,
+                   [jukebox,
+                    silence])
+
+
 
 master_dj_enabled = ref false
 live_dj_enabled = ref false
@@ -227,12 +251,17 @@ def live_dj_disconnect() =
     update_source_status("live_dj", false)
 end
 
+
+live_meta = ref []
+
 def master_dj_connect(header) =
     update_source_status("master_dj", true)
+    live_meta := munge_live_hdr(header)
 end
 
 def master_dj_disconnect() =
     update_source_status("master_dj", false)
+    live_meta := []
 end
 
 #auth function for live stream
@@ -259,7 +288,6 @@ end
 
 s = switch(id="schedule_noise_switch",
             track_sensitive=false,
-            transitions=[transition_default, transition],
             [({!scheduled_play_enabled}, stream_queue), ({true}, default)]
     )
 
@@ -278,7 +306,6 @@ s = if dj_live_stream_port != 0 and dj_live_stream_mp != "" then
 
     switch(id="show_schedule_noise_switch",
             track_sensitive=false,
-            transitions=[transition, transition],
             [({!live_dj_enabled}, dj_live), ({true}, s)]
         )
 else
@@ -286,22 +313,72 @@ else
 end
 
 s = if master_live_stream_port != 0 and master_live_stream_mp != "" then
-    master_dj =
+    master_raw =
         audio_to_stereo(
             input.harbor(id="master_harbor",
                 master_live_stream_mp,
                 port=master_live_stream_port,
                 auth=check_master_dj_client,
+                logfile="/tmp/master-buffer.log",
                 max=40.,
                 on_connect=master_dj_connect,
                 on_disconnect=master_dj_disconnect))
 
-    ignore(output.dummy(master_dj, fallible=true))
+      # we don't want dj's leaving their system on and forgetting...
+      master_dj = strip_blank(id="master-stripblank",
+                              threshold=-30.0,
+                              max_blank=60.0,
+                              master_raw)
+
+
+    dummy_up(master_dj)
+
+    pair = insert_metadata(drop_metadata(master_dj))
+    master_metadata_f = fst(pair)
+    master_meta = snd(pair)
+
+
+    spair = insert_metadata(drop_metadata(master_dj))
+    save_metadata_f = fst(spair)
+    master_save = snd(spair)
+
+
+    def force_live_metadata(_)
+      ignore(master_metadata_f(!live_meta))
+    end
+
+
+    log_metadata("SAVE metadata before output", master_save)
+
+    master_save_buffer = buffer(id="master_save_buffer",
+                         fallible=true, 
+                         on_start=fun()->ignore(save_metadata_f(format_save(!live_meta))),
+                         on_stop=fun()->ignore(save_metadata_f([])),
+                         master_save)
+
+
+    output.file(%vorbis,
+                  fallible=true,
+                  append=false,
+                  reopen_on_metadata=true,
+                  reopen_delay=30.0,
+                  "/home/streams/%Y-%m-%d-%H_%M_%S-$(artist).ogg",
+                  master_save_buffer)
+
+
+    dummy_up(on_metadata(force_live_metadata, master_raw))
+    dummy_up(on_track(force_live_metadata, master_raw))
+
+    master_buffer = buffer(id="master_dj_buffer",
+                           fallible=true,
+                           on_start=fun()->ignore(master_metadata_f(!live_meta)),
+                           on_stop=fun()->ignore(save_metadata_f([])),
+                           master_meta)
+
 
     switch(id="master_show_schedule_noise_switch",
             track_sensitive=false,
-            transitions=[transition, transition],
-            [({!master_dj_enabled}, master_dj), ({true}, s)]
+            [({!master_dj_enabled}, master_buffer), ({true}, s)]
         )
 else
     s
@@ -341,6 +418,13 @@ server.register(namespace="streams",
     usage="scheduled_play_start",
     "scheduled_play_start",
     fun (s) -> begin log("streams.scheduled_play_start") make_scheduled_play_available() "Done." end)
+
+
+post_metadata(s)
+## important debug function
+log_metadata("FINAL metadata before output", s)
+
+
 
 if output_sound_device then
     success = ref false

--- a/python_apps/pypo/liquidsoap/utils.liq
+++ b/python_apps/pypo/liquidsoap/utils.liq
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+def legal_name_fix(s)
+  string.replace(pattern='[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789]+',
+                 fun (_) -> '_',s)
+end
+
+def format_save(m)
+  [("title", list.nth(get_process_lines("date '+%Y-%m-%d'"),0)),
+   ('album', m['artist_clean']),
+   ('artist', legal_name_fix(m['artist_clean']))]
+end
+
+# returns a or b, like the clojure or function or ternary operator in c
+def orn(a,b) 
+  if a != "" then
+    a 
+  else 
+    b 
+  end
+end
+
+# Pattern used everywhere in Airtime: for side effects or sinking, 
+# send output of a stream to an ignored output.dummy
+# @category Liquidsoap
+# @param ~s A source
+def dummy_up(s)
+  ignore(output.dummy(fallible=true, s))
+end
+
+
+def post2_metadata(m)
+  mj = json_of(m)
+  log("posting: #{mj}")
+  ## horrible place for this, but this is such a mess, just want to get this done.
+  ignore(http.post(data=mj, "http://localhost:8080/now-playing"))
+end
+
+
+def post_metadata(s)
+  dummy_up(on_metadata(post2_metadata, s))
+end
+
+
+def log2_metadata(msg, m)
+  mj = json_of(m)
+  log(msg ^ " now: #{mj}")
+end
+
+def log_metadata(msg, s)
+  dummy_up(on_metadata(log2_metadata(msg), s))
+end
+


### PR DESCRIPTION
A year or two ago, someone from Libretime project asked if I would be able to share changes we made to support SPAZ Radio.

- A jukebox which plays random archive files when there are no scheduled shows
- Saves live shows and include metadata in the files saved
- Sends now playing information as JSON to our DJ Dashboard

Was finally able to whittle it down to a clean-ish patch, which is here. I don't think it is ready for application to other stations, but some of it might be useful to the project.