### PR TITLE
Fix remove most legacy upstream config madness

### DIFF
--- a/airtime_mvc/application/airtime-boot.php
+++ b/airtime_mvc/application/airtime-boot.php
@@ -51,9 +51,6 @@ set_include_path(APPLICATION_PATH . 'controllers/plugins' . PATH_SEPARATOR . get
 //Services.
 set_include_path(APPLICATION_PATH . '/services/' . PATH_SEPARATOR . get_include_path());
 
-//cloud storage directory
-set_include_path(APPLICATION_PATH . '/cloud_storage' . PATH_SEPARATOR . get_include_path());
-
 //Upgrade directory
 set_include_path(APPLICATION_PATH . '/upgrade/' . PATH_SEPARATOR . get_include_path());
 

--- a/airtime_mvc/application/configs/conf.php
+++ b/airtime_mvc/application/configs/conf.php
@@ -49,24 +49,6 @@ class Config {
             $CC_CONFIG['staticBaseDir'] = '/';
         }
 
-        // Parse separate conf file for cloud storage values
-        $cloudStorageConfig = LIBRETIME_CONF_DIR . '/' . $CC_CONFIG['dev_env']."/cloud_storage.conf";
-        if (!file_exists($cloudStorageConfig)) {
-            // If the dev env specific cloud_storage.conf doesn't exist default
-            // to the production cloud_storage.conf
-            $cloudStorageConfig = LIBRETIME_CONF_DIR . "/production/cloud_storage.conf";
-        }
-        $cloudStorageValues = parse_ini_file($cloudStorageConfig, true);
-        
-        $CC_CONFIG["supportedStorageBackends"] = array('amazon_S3');
-        foreach ($CC_CONFIG["supportedStorageBackends"] as $backend) {
-            $CC_CONFIG[$backend] = $cloudStorageValues[$backend];
-        }
-        
-        // Tells us where file uploads will be uploaded to.
-        // It will either be set to a cloud storage backend or local file storage.
-        $CC_CONFIG["current_backend"] = $cloudStorageValues["current_backend"]["storage_backend"];
-
         $CC_CONFIG['cache_ahead_hours'] = $values['general']['cache_ahead_hours'];
         
         // Database config
@@ -77,24 +59,27 @@ class Config {
         $CC_CONFIG['dsn']['database'] = $values['database']['dbname'];
 
         $CC_CONFIG['apiKey'] = array($values['general']['api_key']);
+
+        $CC_CONFIG['current_backend'] = array(
+            'storage_backend' => $values['current_backend']['storage_backend']
+        );
+        $CC_CONFIG['amazon_S3'] = array(
+            'provider' => $values['amazon_S3']['provider'],
+            'bucket' => $values['amazon_S3']['bucket'],
+            'api_key' => $values['amazon_S3']['api_key'],
+            'api_key_secret' => $values['amazon_S3']['api_key_secret']
+        );
         
         $CC_CONFIG['soundcloud-connection-retries'] = $values['soundcloud']['connection_retries'];
         $CC_CONFIG['soundcloud-connection-wait'] = $values['soundcloud']['time_between_retries'];
 
-        $globalAirtimeConfig = LIBRETIME_CONF_DIR . '/' . $CC_CONFIG['dev_env']."/airtime.conf";
-        if (!file_exists($globalAirtimeConfig)) {
-            // If the dev env specific airtime.conf doesn't exist default
-            // to the production airtime.conf
-            $globalAirtimeConfig = LIBRETIME_CONF_DIR . "/production/airtime.conf";
-        }
-        $globalAirtimeConfigValues = parse_ini_file($globalAirtimeConfig, true);
-        $CC_CONFIG['soundcloud-client-id'] = $globalAirtimeConfigValues['soundcloud']['soundcloud_client_id'];
-        $CC_CONFIG['soundcloud-client-secret'] = $globalAirtimeConfigValues['soundcloud']['soundcloud_client_secret'];
-        $CC_CONFIG['soundcloud-redirect-uri'] = $globalAirtimeConfigValues['soundcloud']['soundcloud_redirect_uri'];
-        if (isset($globalAirtimeConfigValues['facebook']['facebook_app_id'])) {
-            $CC_CONFIG['facebook-app-id'] = $globalAirtimeConfigValues['facebook']['facebook_app_id'];
-            $CC_CONFIG['facebook-app-url'] = $globalAirtimeConfigValues['facebook']['facebook_app_url'];
-            $CC_CONFIG['facebook-app-api-key'] = $globalAirtimeConfigValues['facebook']['facebook_app_api_key'];
+        $CC_CONFIG['soundcloud-client-id'] = $values['soundcloud']['soundcloud_client_id'];
+        $CC_CONFIG['soundcloud-client-secret'] = $values['soundcloud']['soundcloud_client_secret'];
+        $CC_CONFIG['soundcloud-redirect-uri'] = $values['soundcloud']['soundcloud_redirect_uri'];
+        if (isset($values['facebook']['facebook_app_id'])) {
+            $CC_CONFIG['facebook-app-id'] = $values['facebook']['facebook_app_id'];
+            $CC_CONFIG['facebook-app-url'] = $values['facebook']['facebook_app_url'];
+            $CC_CONFIG['facebook-app-api-key'] = $values['facebook']['facebook_app_api_key'];
         }
 
         // ldap config

--- a/airtime_mvc/application/models/RabbitMq.php
+++ b/airtime_mvc/application/models/RabbitMq.php
@@ -78,29 +78,11 @@ class Application_Model_RabbitMq
         self::sendMessage($exchange, 'direct', true, $data);
     }
 
-    public static function getRmqConfigPath() {
-        //Hack for Airtime Pro. The RabbitMQ settings for communicating with airtime_analyzer are global
-        //and shared between all instances on Airtime Pro.
-        //
-        // todo: rewrite me to only use the config class and not access /etc/airtime directly
-        $CC_CONFIG = Config::getConfig();
-        $devEnv = "production"; //Default
-        if (array_key_exists("dev_env", $CC_CONFIG)) {
-            $devEnv = $CC_CONFIG["dev_env"];
-        }
-        $rmq_config_path = LIBRETIME_CONF_DIR . '/' . $devEnv."/rabbitmq-analyzer.ini";
-        if (!file_exists($rmq_config_path)) {
-            // If the dev env specific rabbitmq-analyzer.ini doesn't exist default
-            // to the production rabbitmq-analyzer.ini
-            $rmq_config_path = LIBRETIME_CONF_PATH . "/production/rabbitmq-analyzer.ini";
-        }
-        return $rmq_config_path;
-    }
-
     public static function SendMessageToAnalyzer($tmpFilePath, $importedStorageDirectory, $originalFilename,
                                                 $callbackUrl, $apiKey, $storageBackend, $filePrefix)
     {
-        $config = parse_ini_file(self::getRmqConfigPath(), true);
+        $config = Config::getConfig();
+
         $conn = new \PhpAmqpLib\Connection\AMQPConnection($config["rabbitmq"]["host"],
                 $config["rabbitmq"]["port"],
                 $config["rabbitmq"]["user"],

--- a/airtime_mvc/build/airtime.example.conf
+++ b/airtime_mvc/build/airtime.example.conf
@@ -121,6 +121,19 @@ vhost = /airtime
 
 
 # ----------------------------------------------------------------------
+#                             S T O R A G E
+# ----------------------------------------------------------------------
+#
+[current_backend]
+storage_backend=file
+
+[amazon_S3]
+provider=amazon_S3
+bucket=0
+api_key=0
+api_key_secret=0
+
+# ----------------------------------------------------------------------
 #                               M O N I T
 # ----------------------------------------------------------------------
 #
@@ -349,3 +362,6 @@ groupmap_host = 'cn=host,cn=groups,cn=accounts,dc=int,dc=example,dc=org'
 groupmap_program_manager = 'cn=program_manager,cn=groups,cn=accounts,dc=int,dc=example,dc=org'
 groupmap_admin = 'cn=admins,cn=groups,cn=accounts,dc=int,dc=example,dc=org'
 groupmap_superadmin = 'cn=superadmin,cn=groups,cn=accounts,dc=int,dc=example,dc=org'
+
+
+

--- a/airtime_mvc/build/cloud_storage.conf
+++ b/airtime_mvc/build/cloud_storage.conf
@@ -1,8 +1,0 @@
-[current_backend]
-storage_backend=file
-
-[amazon_S3]
-provider=amazon_S3
-bucket=0
-api_key=0
-api_key_secret=0

--- a/airtime_mvc/build/rabbitmq-analyzer.ini
+++ b/airtime_mvc/build/rabbitmq-analyzer.ini
@@ -1,7 +1,0 @@
-[rabbitmq]
-host = 127.0.0.1
-port = 5672
-user = airtime
-password = airtime
-vhost = /airtime
-

--- a/airtime_mvc/public/setup/media-setup.php
+++ b/airtime_mvc/public/setup/media-setup.php
@@ -26,7 +26,6 @@ class MediaSetup extends Setup {
 
     const MEDIA_FOLDER = "mediaFolder";
     const LIBRETIME_CONF_FILE_NAME = "airtime.conf";
-    const RMQ_INI_FILE_NAME = "rabbitmq-analyzer.ini";
 
     static $path;
     static $message = null;
@@ -66,10 +65,6 @@ class MediaSetup extends Setup {
                 self::$message = "Error moving airtime.conf or deleting /tmp/airtime.conf.temp!";
                 self::$errors[] = "ERR";
             }
-            if (!$this->moveRmqConfig()) {
-                self::$message = "Error moving rabbitmq-analyzer.ini or deleting /tmp/rabbitmq.ini.tmp!";
-                self::$errors[] = "ERR";
-            }
 
             /* 
              * If we're upgrading from an old Airtime instance (pre-2.5.2) we rename their old 
@@ -100,16 +95,6 @@ class MediaSetup extends Setup {
     function moveAirtimeConfig() {
         return copy(AIRTIME_CONF_TEMP_PATH, LIBRETIME_CONF_DIR . '/' . self::LIBRETIME_CONF_FILE_NAME)
             && unlink(AIRTIME_CONF_TEMP_PATH);
-    }
-
-    /**
-     * Moves /tmp/airtime.conf.temp to /etc/airtime.conf and then removes it to complete setup
-     * @return boolean false if either of the copy or removal operations fail
-     */
-    function moveRmqConfig() {
-        return copy(RMQ_INI_TEMP_PATH, LIBRETIME_CONF_DIR . '/' . self::RMQ_INI_FILE_NAME)
-            && copy(RMQ_INI_TEMP_PATH, LIBRETIME_CONF_DIR . '/production/' . self::RMQ_INI_FILE_NAME)
-            && unlink(RMQ_INI_TEMP_PATH);
     }
 
     /**

--- a/airtime_mvc/public/setup/rabbitmq-setup.php
+++ b/airtime_mvc/public/setup/rabbitmq-setup.php
@@ -51,10 +51,6 @@ class RabbitMQSetup extends Setup {
             $this->identifyRMQConnectionError();
         }
 
-        if (count(self::$errors) <= 0) {
-            $this->writeToTemp();
-        }
-
         return array(
             "message" => self::$message,
             "errors" => self::$errors
@@ -81,13 +77,4 @@ class RabbitMQSetup extends Setup {
         self::$errors[] = self::RMQ_PORT;
         self::$errors[] = self::RMQ_VHOST;
     }
-
-    protected function writeToTemp() {
-        if (!file_exists(RMQ_INI_TEMP_PATH)) {
-            copy(BUILD_PATH . "rabbitmq-analyzer.ini", RMQ_INI_TEMP_PATH);
-        }
-        $this->_write(RMQ_INI_TEMP_PATH);
-        parent::writeToTemp();
-    }
-
 }

--- a/airtime_mvc/tests/conf/airtime.conf
+++ b/airtime_mvc/tests/conf/airtime.conf
@@ -23,6 +23,15 @@ base_dir = /
 cache_ahead_hours = 1
 station_id = teststation
 
+[current_backend]
+storage_backend=file
+
+[amazon_S3]
+provider=amazon_S3
+bucket=0
+api_key=0
+api_key_secret=0
+
 [monit]
 monit_user = guest
 monit_password = airtime

--- a/airtime_mvc/tests/conf/testing/cloud_storage.conf
+++ b/airtime_mvc/tests/conf/testing/cloud_storage.conf
@@ -1,3 +1,0 @@
-[amazon_S3]
-[current_backend]
-storage_backend=file

--- a/python_apps/airtime_analyzer/airtime_analyzer/cloud_storage_uploader.py
+++ b/python_apps/airtime_analyzer/airtime_analyzer/cloud_storage_uploader.py
@@ -10,7 +10,7 @@ from boto.s3.key import Key
 # https://github.com/docker/docker-registry/issues/400
 u'fix getaddrinfo deadlock'.encode('idna')
 
-CLOUD_CONFIG_PATH = os.path.join(os.getenv('LIBRETIME_CONF_DIR', '/etc/airtime'), 'cloud_storage.conf')
+CLOUD_CONFIG_PATH = os.path.join(os.getenv('LIBRETIME_CONF_DIR', '/etc/airtime'), 'airtime.conf')
 STORAGE_BACKEND_FILE = "file"
 SOCKET_TIMEOUT = 240
 

--- a/python_apps/airtime_analyzer/airtime_analyzer/cloud_storage_uploader_libcloud.py
+++ b/python_apps/airtime_analyzer/airtime_analyzer/cloud_storage_uploader_libcloud.py
@@ -6,7 +6,7 @@ from libcloud.storage.providers import get_driver
 from libcloud.storage.types import Provider, ContainerDoesNotExistError, ObjectDoesNotExistError
 
 
-CLOUD_CONFIG_PATH = os.path.join(os.getenv('LIBRETIME_CONF_DIR', '/etc/airtime'), 'cloud_storage.conf')
+CLOUD_CONFIG_PATH = os.path.join(os.getenv('LIBRETIME_CONF_DIR', '/etc/airtime'), 'airtime.conf')
 STORAGE_BACKEND_FILE = "file"
 
 class CloudStorageUploader:


### PR DESCRIPTION
This removes most of the legacy upstream config madness by not using
weird config files spread all over the place.

Should any SaaS need something similar to manage their deploys, they
can be our guest in rewriting this to proper Zend_Config and learning
to env properly.