### PR TITLE
Remove dead Haproxy messaging code

### DIFF
--- a/airtime_mvc/application/controllers/ApiController.php
+++ b/airtime_mvc/application/controllers/ApiController.php
@@ -927,28 +927,6 @@ class ApiController extends Zend_Controller_Action
         Logging::info("Registered Component: ".$component."@".$remoteAddr);
 
         Application_Model_ServiceRegister::Register($component, $remoteAddr);
-        
-        //send ip, subdomain
-        if ($component == "pypo"){
-            $split = explode('.', $_SERVER['SERVER_NAME']);
-            $subdomain = array();
-            foreach ($split as $value) {
-                if ($value == 'airtime') {
-                    break;
-                } else {
-                    $subdomain[] = $value;
-                }
-            }
-            if (count($subdomain) > 0){
-                $subDomain = implode('.',$subdomain);
-
-                $md = array();
-                $md["sub_domain"] = $subDomain;
-                $md["pypo_ip"] = $remoteAddr;
-
-                Application_Model_RabbitMq::SendMessageToHaproxyConfigDaemon($md);
-            }
-        }
     }
 
     public function updateLiquidsoapStatusAction()

--- a/airtime_mvc/application/models/RabbitMq.php
+++ b/airtime_mvc/application/models/RabbitMq.php
@@ -129,10 +129,4 @@ class Application_Model_RabbitMq
         $conn->close();
         
     }
-    
-    
-    public static function SendMessageToHaproxyConfigDaemon($md){
-        //XXX: This function has been deprecated and is no longer needed
-    }
-
 }


### PR DESCRIPTION
Searching for [SendMessageToHaproxyConfigDaemon](https://github.com/LibreTime/libretime/search?utf8=%E2%9C%93&q=SendMessageToHaproxyConfigDaemon&type=) reveals that the code is indeed dead. The `//send ip, subdomain` has no other side-effects.