### PR TITLE
Increased podcast download timeout to 1800 seconds

### DIFF
--- a/installer/systemd/airtime-celery.service
+++ b/installer/systemd/airtime-celery.service
@@ -7,7 +7,7 @@ User=celery
 Group=celery
 Environment=RMQ_CONFIG_FILE=/etc/airtime/airtime.conf
 WorkingDirectory=/srv/airtime
-ExecStart=/usr/local/bin/celery worker -A airtime-celery.tasks:celery --time-limit=300 --concurrency=1 --config=celeryconfig -l INFO
+ExecStart=/usr/local/bin/celery worker -A airtime-celery.tasks:celery --time-limit=1800 --concurrency=1 --config=celeryconfig -l INFO
 Restart=always
 
 [Install]

--- a/python_apps/airtime-celery/install/conf/airtime-celery
+++ b/python_apps/airtime-celery/install/conf/airtime-celery
@@ -8,7 +8,7 @@ CELERY_BIN="/usr/local/bin/celery"
 CELERY_APP="airtime-celery.tasks:celery"
 
 # Extra command-line arguments to the worker
-CELERYD_OPTS="--time-limit=300 --concurrency=1 --config=celeryconfig"
+CELERYD_OPTS="--time-limit=1800 --concurrency=1 --config=celeryconfig"
 
 # %N will be replaced with the first part of the nodename.
 CELERYD_LOG_FILE="/var/log/airtime/%N.log"


### PR DESCRIPTION
This modifies the celery worker and makes it timeout at 30 minutes rather than 5 minutes. And is a proposed fix to #220. Thus the change from 1800 seconds from 300 seconds. This is being done because the default has resulted in podcasts that always fail to update. The reason I chose 1800 seconds is that this should accommodate setups with only 512Kbps internet and give the server the ability to download 100MB files without timing out. 