### PR TITLE
:recycle: (utils) Remove unused make_tarball.sh

### DIFF
--- a/utils/make_tarball.sh
+++ b/utils/make_tarball.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-if [ -z "${1}" ]; then
-    echo "Usage: make_tarball.sh git_tag"
-    exit
-fi
-GIT_TAG=${1}
-git archive ${GIT_TAG} --prefix ${GIT_TAG}/ -o "${GIT_TAG}".tar.gz


### PR DESCRIPTION
More #561 cleanup. The actual release tarballs are built with `dev_tools/release/release.sh` and this isn't in the path of anything related to it.