### PR TITLE
playlist and smartblock contents pane sizing

### DIFF
--- a/airtime_mvc/public/css/dashboard.css
+++ b/airtime_mvc/public/css/dashboard.css
@@ -591,7 +591,7 @@ li.ui-state-default {
     overflow: auto;
     margin: 4px 0;
     min-height: 6em;
-    max-height: 100%;
+    max-height: calc(100% - 40px);
     padding: 5px;
     border: 1px solid #444;
     border-radius: 3px;

--- a/airtime_mvc/public/css/dashboard.css
+++ b/airtime_mvc/public/css/dashboard.css
@@ -583,16 +583,15 @@ li.ui-state-default {
 }
 
 .spl_sortable {
-    height: 100%;
+    -webkit-flex: 1 0 auto;
+    -moz-flex: 1 0 auto;
+    -ms-flex: 1 0 auto;
+    -o-flex: 1 0 auto;
+    flex: 1 0 auto;
     overflow: auto;
-    -webkit-flex: 1 0 100%;
-    -moz-flex: 1 0 100%;
-    -ms-flex: 1 0 100%;
-    -o-flex: 1 0 100%;
-    flex: 1 0 100%;
-
     margin: 4px 0;
-    min-height: 0;
+    min-height: 6em;
+    max-height: 100%;
     padding: 5px;
     border: 1px solid #444;
     border-radius: 3px;


### PR DESCRIPTION
This is just a better fix for the same https://github.com/LibreTime/libretime/issues/574 . My previous fix set the pane height at 100% at all times, this one accounts for both empty and long lists, on a range of screen heights.