### PR TITLE
UX: collapse advanced configuration sections in Schedule Dialog

### DIFF
--- a/airtime_mvc/application/views/scripts/schedule/add-show-form.phtml
+++ b/airtime_mvc/application/views/scripts/schedule/add-show-form.phtml
@@ -11,10 +11,6 @@
     <div id="schedule-show-what" class="collapsible-content">
         <?php echo $this->what; ?>
     </div>
-    <h3 class="collapsible-header"><span class="arrow-icon"></span><?php echo _("Automatic Playlist") ?></h3>
-    <div id="schedule-show-what" class="collapsible-content">
-        <?php echo $this->autoplaylist; ?>
-    </div>
     <h3 class="collapsible-header"><span class="arrow-icon"></span><?php echo _("When") ?></h3>
     <div id="schedule-show-when" class="collapsible-content">
         <?php
@@ -28,6 +24,10 @@
         <?php echo $this->when; ?>
 
         <?php echo $this->repeats; ?>
+    </div>
+    <h3 class="collapsible-header"><span class="arrow-icon"></span><?php echo _("Automatic Playlist") ?></h3>
+    <div id="schedule-show-auto" class="collapsible-content">
+        <?php echo $this->autoplaylist; ?>
     </div>
     <h3 class="collapsible-header"><span class="arrow-icon"></span><?php echo _("Live Stream Input") ?></h3>
     <div id="live-stream-override" class="collapsible-content">

--- a/airtime_mvc/public/js/airtime/schedule/add-show.js
+++ b/airtime_mvc/public/js/airtime/schedule/add-show.js
@@ -16,6 +16,14 @@ function openAddShowForm(nowOrFuture) {
             $("#add-show-form").show();
 
             windowResize();
+
+            // collapse advanced configuration sections
+            $('#schedule-show-auto').hide();
+            $('#live-stream-override').hide();
+            $('#schedule-record-rebroadcast').hide();
+            $('#schedule-show-who').hide();
+            $('#schedule-show-style').hide();
+            
         }
         $("#schedule-show-what").show(0, function(){
             $add_show_name = $("#add_show_name");


### PR DESCRIPTION
this commit collapses by default several sections of the add/edit show dialog:

![screenshot from 2018-11-19 11-42-13](https://user-images.githubusercontent.com/36803137/48724931-3d6c8280-ebf0-11e8-8ca1-6f5cf8a6270c.png)

why?
- simplify interface. less distraction for users and less need to scroll way down to the "update show" submit button
- prerequisite to proposal i'll work on now to improve the autoplaylist UI

problems? 
- only that i would have like to have those little orange triangles rotate indicating open/closed state, but that'd require too much (crappy) code and time.