### PR TITLE
Auto playlist ui

### DIFF
--- a/airtime_mvc/application/forms/AddShowAutoPlaylist.php
+++ b/airtime_mvc/application/forms/AddShowAutoPlaylist.php
@@ -15,7 +15,7 @@ class Application_Form_AddShowAutoPlaylist extends Zend_Form_SubForm
 
         // Add autoplaylist checkbox element
         $this->addElement('checkbox', 'add_show_has_autoplaylist', array(
-            'label'      => _('Auto Schedule Playlist ?'),
+            'label'      => _('Add Autoloading Playlist ?'),
             'required'   => false,
             'class'      => 'input_text',
             'decorators'  => array('ViewHelper')
@@ -29,7 +29,7 @@ class Application_Form_AddShowAutoPlaylist extends Zend_Form_SubForm
         $this->addElement($autoPlaylistSelect);
         // Add autoplaylist checkbox element
         $this->addElement('checkbox', 'add_show_autoplaylist_repeat', array(
-            'label'      => _('Repeat AutoPlaylist Until Show is Full ?'),
+            'label'      => _('Repeat Playlist Until Show is Full ?'),
             'required'   => false,
             'class'      => 'input_text',
             'decorators'  => array('ViewHelper')

--- a/airtime_mvc/application/views/scripts/form/add-show-autoplaylist.phtml
+++ b/airtime_mvc/application/views/scripts/form/add-show-autoplaylist.phtml
@@ -7,6 +7,7 @@
         </dt>
         <dd>
             <?php echo $this->element->getElement('add_show_has_autoplaylist') ?>
+            <span class="show_autoplaylist_help_icon" aria-describedby="ui-tooltip-2"></span>
         </dd>
 
 	<div id="add_show_playlist_dropdown">

--- a/airtime_mvc/application/views/scripts/form/add-show-autoplaylist.phtml
+++ b/airtime_mvc/application/views/scripts/form/add-show-autoplaylist.phtml
@@ -11,6 +11,7 @@
         </dd>
 
 	<div id="add_show_playlist_dropdown">
+        <p>Autoloading playlists' contents are added to shows one hour before the show airs. <a target='_blank' href='http://libretime.org/manual/calendar/#autoloading-playlist'>More information</a></p>
         <dt id="add_show_autoplaylist_id">
             <label for="add_show_autoplaylist_id" class="required">
                 <?php echo $this->element->getElement('add_show_autoplaylist_id')->getLabel()?>

--- a/airtime_mvc/application/views/scripts/schedule/add-show-form.phtml
+++ b/airtime_mvc/application/views/scripts/schedule/add-show-form.phtml
@@ -11,7 +11,7 @@
     <div id="schedule-show-what" class="collapsible-content">
         <?php echo $this->what; ?>
     </div>
-    <h3 class="collapsible-header"><span class="arrow-icon"></span><?php echo _("Automatic Playlist") ?></h3>
+    <h3 class="collapsible-header"><span class="arrow-icon"></span><?php echo _("Autoloading Playlist") ?></h3>
     <div id="schedule-show-what" class="collapsible-content">
         <?php echo $this->autoplaylist; ?>
     </div>

--- a/airtime_mvc/locale/ast/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ast/LC_MESSAGES/airtime.po
@@ -4934,7 +4934,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/ast/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ast/LC_MESSAGES/airtime.po
@@ -2534,7 +2534,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/az/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/az/LC_MESSAGES/airtime.po
@@ -4934,7 +4934,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/az/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/az/LC_MESSAGES/airtime.po
@@ -2534,7 +2534,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/cs_CZ/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/cs_CZ/LC_MESSAGES/airtime.po
@@ -2538,7 +2538,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Musíte počkat alespoň 1 hodinu před dalším vysíláním"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/cs_CZ/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/cs_CZ/LC_MESSAGES/airtime.po
@@ -4940,7 +4940,7 @@ msgid "What"
 msgstr "Co"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/da_DK/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/da_DK/LC_MESSAGES/airtime.po
@@ -4934,7 +4934,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/da_DK/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/da_DK/LC_MESSAGES/airtime.po
@@ -2534,7 +2534,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/de_AT/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/de_AT/LC_MESSAGES/airtime.po
@@ -4953,7 +4953,7 @@ msgid "What"
 msgstr "Was"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/de_AT/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/de_AT/LC_MESSAGES/airtime.po
@@ -2551,7 +2551,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Das Wiederholen einer Sendung ist erst nach einer Stunde Wartezeit möglich."
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/de_DE/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/de_DE/LC_MESSAGES/airtime.po
@@ -4955,7 +4955,7 @@ msgid "What"
 msgstr "Was"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr "Automatische Playlist"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/de_DE/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/de_DE/LC_MESSAGES/airtime.po
@@ -2553,7 +2553,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Das Wiederholen einer Sendung ist erst nach einer Stunde Wartezeit möglich."
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/el_GR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/el_GR/LC_MESSAGES/airtime.po
@@ -2538,7 +2538,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Πρέπει να περιμένετε τουλάχιστον 1 ώρα για την αναμετάδοση"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/el_GR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/el_GR/LC_MESSAGES/airtime.po
@@ -4940,7 +4940,7 @@ msgid "What"
 msgstr "Τι"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/en_CA/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_CA/LC_MESSAGES/airtime.po
@@ -4940,7 +4940,7 @@ msgid "What"
 msgstr "What"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/en_CA/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_CA/LC_MESSAGES/airtime.po
@@ -2538,7 +2538,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Must wait at least 1 hour to rebroadcast"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/en_GB/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_GB/LC_MESSAGES/airtime.po
@@ -2539,7 +2539,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Must wait at least 1 hour to rebroadcast"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/en_GB/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_GB/LC_MESSAGES/airtime.po
@@ -4944,7 +4944,7 @@ msgid "What"
 msgstr "What"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/en_US/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_US/LC_MESSAGES/airtime.po
@@ -4940,7 +4940,7 @@ msgid "What"
 msgstr "What"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/en_US/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_US/LC_MESSAGES/airtime.po
@@ -2538,7 +2538,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Must wait at least 1 hour to rebroadcast"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/es_ES/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/es_ES/LC_MESSAGES/airtime.po
@@ -2548,7 +2548,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Debes esperar al menos 1 hora para reprogramar"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr "¿Auto Programar Lista?"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/es_ES/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/es_ES/LC_MESSAGES/airtime.po
@@ -4966,7 +4966,7 @@ msgid "What"
 msgstr "Qué"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr "Lista de reproducción automática"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/fr_FR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/fr_FR/LC_MESSAGES/airtime.po
@@ -4940,7 +4940,7 @@ msgid "What"
 msgstr "Quoi"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/fr_FR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/fr_FR/LC_MESSAGES/airtime.po
@@ -2538,7 +2538,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Vous devez attendre au moins 1 heure pour retransmettre"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/hr_HR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hr_HR/LC_MESSAGES/airtime.po
@@ -2537,7 +2537,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Moraš čekati najmanje 1 sat za re-emitiranje"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/hr_HR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hr_HR/LC_MESSAGES/airtime.po
@@ -4939,7 +4939,7 @@ msgid "What"
 msgstr "Što"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/hu_HU/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hu_HU/LC_MESSAGES/airtime.po
@@ -2700,7 +2700,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Az újraközvetítésre legalább 1 órát kell várni"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr "Lejátszási lista automatikus ütemezése?"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/hu_HU/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hu_HU/LC_MESSAGES/airtime.po
@@ -5267,7 +5267,7 @@ msgid "What"
 msgstr "Mi"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr "Automatikus lejátszási lista"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/hy/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hy/LC_MESSAGES/airtime.po
@@ -4931,7 +4931,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/hy/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hy/LC_MESSAGES/airtime.po
@@ -2531,7 +2531,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/hy_AM/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hy_AM/LC_MESSAGES/airtime.po
@@ -4934,7 +4934,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/hy_AM/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hy_AM/LC_MESSAGES/airtime.po
@@ -2534,7 +2534,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/id_ID/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/id_ID/LC_MESSAGES/airtime.po
@@ -4934,7 +4934,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/id_ID/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/id_ID/LC_MESSAGES/airtime.po
@@ -2534,7 +2534,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/it_IT/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/it_IT/LC_MESSAGES/airtime.po
@@ -4941,7 +4941,7 @@ msgid "What"
 msgstr "Cosa"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/it_IT/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/it_IT/LC_MESSAGES/airtime.po
@@ -2539,7 +2539,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Aspettare almeno un'ora prima di ritrasmettere"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/ja/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ja/LC_MESSAGES/airtime.po
@@ -2537,7 +2537,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "再配信するには、1時間以上待たなければなりません"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/ja/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ja/LC_MESSAGES/airtime.po
@@ -4939,7 +4939,7 @@ msgid "What"
 msgstr "番組内容"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/ja_JP/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ja_JP/LC_MESSAGES/airtime.po
@@ -4932,7 +4932,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/ja_JP/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ja_JP/LC_MESSAGES/airtime.po
@@ -2532,7 +2532,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/ka/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ka/LC_MESSAGES/airtime.po
@@ -4934,7 +4934,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/ka/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ka/LC_MESSAGES/airtime.po
@@ -2534,7 +2534,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/ko_KR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ko_KR/LC_MESSAGES/airtime.po
@@ -4937,7 +4937,7 @@ msgid "What"
 msgstr "무엇"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/ko_KR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ko_KR/LC_MESSAGES/airtime.po
@@ -2535,7 +2535,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "재방송 설정까지 1시간 기간이 필요합니다"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/lt/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/lt/LC_MESSAGES/airtime.po
@@ -2535,7 +2535,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/lt/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/lt/LC_MESSAGES/airtime.po
@@ -4935,7 +4935,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/nl_NL/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/nl_NL/LC_MESSAGES/airtime.po
@@ -4943,7 +4943,7 @@ msgid "What"
 msgstr "Wat"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/nl_NL/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/nl_NL/LC_MESSAGES/airtime.po
@@ -2541,7 +2541,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Ten minste 1 uur opnieuw uitzenden moet wachten"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/pl_PL/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/pl_PL/LC_MESSAGES/airtime.po
@@ -2538,7 +2538,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Należy odczekać przynajmniej 1 godzinę przed ponownym odtworzeniem"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/pl_PL/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/pl_PL/LC_MESSAGES/airtime.po
@@ -4940,7 +4940,7 @@ msgid "What"
 msgstr "Co"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/pt_BR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/pt_BR/LC_MESSAGES/airtime.po
@@ -2539,7 +2539,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "É preciso aguardar uma hora para retransmitir"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/pt_BR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/pt_BR/LC_MESSAGES/airtime.po
@@ -4941,7 +4941,7 @@ msgid "What"
 msgstr "O que"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/ro_RO/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ro_RO/LC_MESSAGES/airtime.po
@@ -4934,7 +4934,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/ro_RO/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ro_RO/LC_MESSAGES/airtime.po
@@ -2534,7 +2534,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/ru_RU/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ru_RU/LC_MESSAGES/airtime.po
@@ -4982,7 +4982,7 @@ msgid "What"
 msgstr "Что"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr "Автоматический Плейлист"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/ru_RU/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ru_RU/LC_MESSAGES/airtime.po
@@ -2554,7 +2554,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "1 час нужно подождать до ретрансляции"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/si/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/si/LC_MESSAGES/airtime.po
@@ -4934,7 +4934,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/si/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/si/LC_MESSAGES/airtime.po
@@ -2534,7 +2534,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/sr_RS/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/sr_RS/LC_MESSAGES/airtime.po
@@ -4939,7 +4939,7 @@ msgid "What"
 msgstr "Шта"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/sr_RS/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/sr_RS/LC_MESSAGES/airtime.po
@@ -2537,7 +2537,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Мораш да чекаш најмање 1 сат за ре-емитовање"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/sr_RS@latin/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/sr_RS@latin/LC_MESSAGES/airtime.po
@@ -2537,7 +2537,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Moraš da čekaš najmanje 1 sat za re-emitovanje"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/sr_RS@latin/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/sr_RS@latin/LC_MESSAGES/airtime.po
@@ -4939,7 +4939,7 @@ msgid "What"
 msgstr "Šta"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/template/airtime.po
+++ b/airtime_mvc/locale/template/airtime.po
@@ -4934,7 +4934,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/template/airtime.po
+++ b/airtime_mvc/locale/template/airtime.po
@@ -2534,7 +2534,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/tr/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/tr/LC_MESSAGES/airtime.po
@@ -2535,7 +2535,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Tekrar yayın yapmak için en az bir saat bekleyiniz"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/tr/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/tr/LC_MESSAGES/airtime.po
@@ -4935,7 +4935,7 @@ msgid "What"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/locale/zh_CN/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/zh_CN/LC_MESSAGES/airtime.po
@@ -2537,7 +2537,7 @@ msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "至少间隔一个小时"
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
-msgid "Auto Schedule Playlist ?"
+msgid "Add Autoloading Playlist ?"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25

--- a/airtime_mvc/locale/zh_CN/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/zh_CN/LC_MESSAGES/airtime.po
@@ -4939,7 +4939,7 @@ msgid "What"
 msgstr "名称"
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "Automatic Playlist"
+msgid "Autoloading Playlist"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18

--- a/airtime_mvc/public/css/add-show.css
+++ b/airtime_mvc/public/css/add-show.css
@@ -85,6 +85,9 @@ label.wrapp-label input[type="checkbox"] {
 #schedule-add-show fieldset dd input[type="checkbox"] {
     margin-top: 6px;
 }
+#schedule-show-auto input[type="checkbox"] {
+    margin-left: 6px;
+}
 
 #add_show_day_check-element.block-display {
     margin-bottom: 15px;

--- a/airtime_mvc/public/css/styles.css
+++ b/airtime_mvc/public/css/styles.css
@@ -204,7 +204,7 @@ img.logo
 .airtime_auth_help_icon, .custom_auth_help_icon, .stream_username_help_icon,
 .playlist_type_help_icon, .repeat_tracks_help_icon, .show_linking_help_icon,
 .admin_username_help_icon, .stream_type_help_icon,
-.show_timezone_help_icon{
+.show_timezone_help_icon, .show_autoplaylist_help_icon {
         cursor: help;
         position: relative;
         display:inline-block; zoom:1;
@@ -2127,7 +2127,9 @@ span.errors.sp-errors{
     font-size:14px;
     line-height:160%;
 }
-
+.qtip.ui-tooltip-dark a {
+    color: white; 
+}
 #schedule-show-who.scrolled {
     margin-bottom: 0;
     max-height:300px;

--- a/airtime_mvc/public/css/styles.css
+++ b/airtime_mvc/public/css/styles.css
@@ -210,8 +210,9 @@ img.logo
         display:inline-block; zoom:1;
         width:14px; height:14px;
         background:url(images/icon_info.png) 0 0 no-repeat;
-        top:2px; right:7px; left: 3px;
+        left: 3px;
         line-height:16px !important;
+        vertical-align: text-top;
 }
 
 /* Clearfix */
@@ -2890,7 +2891,6 @@ dt.block-display.info-block {
     text-align:center;
     letter-spacing:-.3px;
     text-shadow: rgba(248,248,248,.3) 0 1px 0, rgba(0,0,0,.8) 0 -1px 0;
-    rgba(51,51,51,.9)
 }
 .error-content p {
     color: #acacac;

--- a/airtime_mvc/public/js/airtime/schedule/add-show.js
+++ b/airtime_mvc/public/js/airtime/schedule/add-show.js
@@ -475,7 +475,7 @@ function setAddShowEvents(form) {
 
     form.find(".show_autoplaylist_help_icon").qtip({
         content: {
-            text: $.i18n._("Autoloading playlists' contents are added to shows one hour before the show airs. <a href='http://libretime.org/manual/calendar/#autoloading-playlist'>More informaction</a>")
+            text: $.i18n._("Autoloading playlists' contents are added to shows one hour before the show airs. <a target='_blank' href='http://libretime.org/manual/calendar/#autoloading-playlist'>More information</a>")
         },
         hide: {
             delay: 500,

--- a/airtime_mvc/public/js/airtime/schedule/add-show.js
+++ b/airtime_mvc/public/js/airtime/schedule/add-show.js
@@ -473,6 +473,27 @@ function setAddShowEvents(form) {
         }
     });
 
+    form.find(".show_autoplaylist_help_icon").qtip({
+        content: {
+            text: $.i18n._("Autoloading playlists' contents are added to shows one hour before the show airs. <a href='http://libretime.org/manual/calendar/#autoloading-playlist'>More informaction</a>")
+        },
+        hide: {
+            delay: 500,
+            fixed: true
+        },
+        style: {
+            border: {
+                width: 0,
+                radius: 4
+            },
+            classes: "ui-tooltip-dark ui-tooltip-rounded"
+        },
+        position: {
+            my: "left bottom",
+            at: "right center"
+        }
+    });
+
     form.find(".airtime_auth_help_icon").qtip({
         content: {
             text: $.i18n._("This follows the same security pattern for the shows: only users assigned to the show can connect.")

--- a/airtime_mvc/public/js/airtime/schedule/add-show.js
+++ b/airtime_mvc/public/js/airtime/schedule/add-show.js
@@ -302,17 +302,6 @@ function setAddShowEvents(form) {
         $(this).blur();
         form.find("#add_show_playlist_dropdown").toggle();
         form.find("#add_show_autoplaylist_repeat").toggle();
-        
-        var checkBoxSelected = false;
-        
-        //must switch rebroadcast displays
-        if(form.find("#add_show_has_autoplaylist").attr('checked')) {
-        form.find("#add_show_playlist_dropdown").show();
-        form.find("#add_show_autoplaylist_repeat").show();
-        }
-        else {
-	form.find("#add_show_playlist_downdown").hide();
-	}
     });
 
     form.find("#add_show_repeats").click(function(){

--- a/docs/manual/calendar/index.md
+++ b/docs/manual/calendar/index.md
@@ -21,7 +21,7 @@ In the **What** box, enter the **Name**, public website **URL**, **Genre** and *
 Autoloading Playlist
 ------------------
 
-In this section, you can select a playlist that will be used for this show. The playlist must already be defined in your library. **Auto Schedule Playlist** needs to be checked for **Select Playlist** and **Repeat AutoPlaylist Until Show is Full** to be visible.
+In this section, you can select a playlist that will be used for this show. The playlist must already be defined in your library. **Add Autoloading Playlist** needs to be checked for **Select Playlist** and **Repeat Playlist Until Show is Full** to be visible.
 
 ![](static/Screenshot454-Show_playlist.png)
 

--- a/docs/manual/calendar/index.md
+++ b/docs/manual/calendar/index.md
@@ -9,7 +9,7 @@ In the top left corner of the page, you can go back or forward through the **Cal
 Adding a show
 -------------
 
-Only *Admins* and *Program Managers* can use this feature. To add a new show to the Calendar, click the **+ New Show** button in the top left corner of the page, or click on any future row or box in the Calendar which is empty. Either of these actions opens the **Add this show** box, which has seven sections, arranged vertically: **What**, **Automatic Playlist**, **When**, **Live Stream Input**, **Record & Rebroadcast**, **Who**, and **Style**. Click the small orange triangle to the left of the section name if you wish to minimize or maximize it.
+Only *Admins* and *Program Managers* can use this feature. To add a new show to the Calendar, click the **+ New Show** button in the top left corner of the page, or click on any future row or box in the Calendar which is empty. Either of these actions opens the **Add this show** box, which has seven sections, arranged vertically: **What**, **Autoloading Playlist**, **When**, **Live Stream Input**, **Record & Rebroadcast**, **Who**, and **Style**. Click the small orange triangle to the left of the section name if you wish to minimize or maximize it.
 
 What
 ----
@@ -18,7 +18,7 @@ In the **What** box, enter the **Name**, public website **URL**, **Genre** and *
 
 ![](static/Screenshot453-Show_what.png)
 
-Automatic Playlist
+Autoloading Playlist
 ------------------
 
 In this section, you can select a playlist that will be used for this show. The playlist must already be defined in your library. **Auto Schedule Playlist** needs to be checked for **Select Playlist** and **Repeat AutoPlaylist Until Show is Full** to be visible.


### PR DESCRIPTION
as of https://github.com/LibreTime/libretime/commit/b60d4581ee15da6f13a01ce981055f28cd4881e5 this is a bare-minimum solution to the problem described in #560. It does this:

![screenshot from 2018-11-20 16-19-08](https://user-images.githubusercontent.com/36803137/48806580-62d8b980-ece0-11e8-9c61-34fe5545b5ab.png)

IMO this could be merged as-is, but would be much better if we removed the checkbox. Selecting "None" with the select field would be equivalent to an unchecked checkbox. I'd love to achieve this final result:

![screenshot from 2018-11-20 16-25-37](https://user-images.githubusercontent.com/36803137/48806769-fd38fd00-ece0-11e8-8024-8b2db4cf9992.png)
 
I started attempting removing the checkbox, but ran up against an issue: selecting "None" seems to be "forgotten" by the UI. Said another way, if you 1. select a playlist, 2. save the show, 3. edit the show again and select "None", 4. save the show, 5. edit the show _again_, you'll see the show selected in step 1 still active. This behavior is present in the master branch prior to any changes in this PR. I stopped because I ran out of time and started touching so many files that I decided not to risk causing unintended side effects. All help or feedback appreciated!