### PR TITLE
Version check when GitHub is not available

### DIFF
--- a/airtime_mvc/application/models/Preference.php
+++ b/airtime_mvc/application/models/Preference.php
@@ -912,7 +912,7 @@ class Application_Model_Preference
         self::setValue('latest_version', json_encode($latest));
         self::setValue('latest_version_nextcheck', strtotime('+1 week'));
         if (empty($latest)) {
-            return $config['airtime_version'];
+            return array($config['airtime_version']);
         } else {
             return $latest;
         }

--- a/airtime_mvc/application/models/Preference.php
+++ b/airtime_mvc/application/models/Preference.php
@@ -909,13 +909,13 @@ class Application_Model_Preference
             $versions[] = $item->get_title();
         }
         $latest = $versions;
-        self::setValue('latest_version', json_encode($latest));
         self::setValue('latest_version_nextcheck', strtotime('+1 week'));
         if (empty($latest)) {
             return array($config['airtime_version']);
-        } else {
-            return $latest;
         }
+
+        self::setValue('latest_version', json_encode($latest));
+        return $latest;
     }
 
     public static function SetLatestVersion($version)


### PR DESCRIPTION
This is another attempt to fix #487 (the original issue, not the regression stemming from #594) based on my hunch that it's an issue with reaching the GitHub API. This underlying issue might also be triggerable by temporary outages or potentially rate limiting on the API side but I could only simulate the obvious cases I could see in my testing.

In any case this depends on #600 getting merged so we are back to a deployable master branch.