### PR TITLE
remove "Record & Rebroadcast" section from show edit modal

### DIFF
--- a/airtime_mvc/application/views/scripts/schedule/add-show-form.phtml
+++ b/airtime_mvc/application/views/scripts/schedule/add-show-form.phtml
@@ -33,12 +33,6 @@
     <div id="live-stream-override" class="collapsible-content">
         <?php echo $this->live; ?>
     </div>
-    <h3 class="collapsible-header"><span class="arrow-icon"></span><?php echo _("Record & Rebroadcast")?></h3>
-    <div id="schedule-record-rebroadcast" class="collapsible-content">
-        <?php echo $this->rr; ?>
-        <?php echo $this->absoluteRebroadcast; ?>
-        <?php echo $this->rebroadcast; ?>
-    </div>
     <h3 class="collapsible-header"><span class="arrow-icon"></span><?php echo _("Who") ?></h3>
     <div id="schedule-show-who" class="collapsible-content">
         <?php echo $this->who; ?>

--- a/docs/manual/calendar/index.md
+++ b/docs/manual/calendar/index.md
@@ -64,15 +64,7 @@ A reminder of the connection **Host**, **Port** and **Mount** for the live input
 Record & Rebroadcast
 --------------------
 
-In the **Record & Rebroadcast** section, checking the **Record from Line In?** box enables automatic recording of the soundcard line input, if your LibreTime server has one, at the time of the show. Shows set for line-in recording should not also contain files or playlists. The default audio format for live recordings is 256kbps Ogg Vorbis, and the files are saved in the *recorded* folder, under the **Import Folder** path set in the **Media Folders** page on the **System** menu. See the chapter *Host configuration* for details of recorder settings.
-
-If you wish the recording to be played out at a later time, check the **Rebroadcast?** box, and then select up to ten date and time slots in the **Choose Days** box.
-
-![](static/Screenshot458-Record_and_rebroadcast.png)
-
-Shows set for rebroadcast have a white loop icon in the calendar.
-
-![](static/Screenshot92-Record_and_rebroadcast_icons.png)
+The **Record & Rebroadcast** section is currently not working, and so has been removed from the web interface. If this feature is important to you, please search for relevant issues in the [LibreTime github repository](https://github.com/LibreTime/libretime/search?q=record&type=Issues) and help us make it happen!
 
 Who
 ---


### PR DESCRIPTION
simply removes the section from the UI template. at our radio we agree that automatic recording and re-broadcasting would be a killer feature, but if it isn't yet working it shouldn't be in the UI. this should be reverted once we get recording working. #42 #291 