### PR TITLE
Remove the version restriction on mutagen

### DIFF
--- a/python_apps/airtime_analyzer/setup.py
+++ b/python_apps/airtime_analyzer/setup.py
@@ -28,7 +28,7 @@ setup(name='airtime_analyzer',
       packages=['airtime_analyzer'],
       scripts=['bin/airtime_analyzer'],
       install_requires=[
-          'mutagen==1.31', # The Mutagen guys change stuff all the time that break our unit tests. Watch out for this.
+          'mutagen', # got rid of specific version requirement 
           'pika',
           'daemon',
           'file-magic',

--- a/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
+++ b/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
@@ -24,8 +24,7 @@ def test_mp3_mono():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-mono.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 1
-    assert metadata['bit_rate'] > 63000
-    assert metadata['bit_rate'] < 65000
+    assert metadata['bit_rate'] == 63998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3' # Not unicode because MIMEs aren't.
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -35,8 +34,7 @@ def test_mp3_jointstereo():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-jointstereo.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] < 130000
-    assert metadata['bit_rate'] > 127000
+    assert metadata['bit_rate'] == 127998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -45,8 +43,7 @@ def test_mp3_simplestereo():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-simplestereo.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] < 130000
-    assert metadata['bit_rate'] > 127000
+    assert metadata['bit_rate'] == 127998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -55,8 +52,7 @@ def test_mp3_dualmono():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-dualmono.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] < 130000
-    assert metadata['bit_rate'] > 127000
+    assert metadata['bit_rate'] == 127998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -158,8 +154,7 @@ def test_mp3_bad_channels():
     metadata = MetadataAnalyzer.analyze(filename, dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 1
-    assert metadata['bit_rate'] < 65000
-    assert metadata['bit_rate'] > 63000
+    assert metadata['bit_rate'] < 63998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3' # Not unicode because MIMEs aren't.
     assert metadata['track_total'] == u'10' # MP3s can have a track_total

--- a/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
+++ b/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
@@ -154,7 +154,7 @@ def test_mp3_bad_channels():
     metadata = MetadataAnalyzer.analyze(filename, dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 1
-    assert metadata['bit_rate'] < 63998
+    assert metadata['bit_rate'] == 63998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3' # Not unicode because MIMEs aren't.
     assert metadata['track_total'] == u'10' # MP3s can have a track_total

--- a/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
+++ b/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
@@ -24,7 +24,8 @@ def test_mp3_mono():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-mono.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 1
-    assert metadata['bit_rate'] == 64876
+    assert metadata['bit_rate'] > 63000
+    assert metadata['bit_rate'] < 65000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3' # Not unicode because MIMEs aren't.
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -34,7 +35,8 @@ def test_mp3_jointstereo():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-jointstereo.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] == 129757
+    assert metadata['bit_rate'] < 130000
+    assert metadata['bit_rate'] > 127000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -43,7 +45,8 @@ def test_mp3_simplestereo():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-simplestereo.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] == 129757
+    assert metadata['bit_rate'] < 130000
+    assert metadata['bit_rate'] > 127000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -52,7 +55,8 @@ def test_mp3_dualmono():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-dualmono.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] == 129757
+    assert metadata['bit_rate'] < 130000
+    assert metadata['bit_rate'] > 127000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -109,7 +113,8 @@ def test_mp3_utf8():
     assert metadata['genre'] == u'Я Б Г Д Ж Й'
     assert metadata['track_number'] == u'1'
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] == 129757
+    assert metadata['bit_rate'] < 130000
+    assert metadata['bit_rate'] > 127000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -153,7 +158,8 @@ def test_mp3_bad_channels():
     metadata = MetadataAnalyzer.analyze(filename, dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 1
-    assert metadata['bit_rate'] == 64876
+    assert metadata['bit_rate'] < 65000
+    assert metadata['bit_rate'] > 63000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3' # Not unicode because MIMEs aren't.
     assert metadata['track_total'] == u'10' # MP3s can have a track_total


### PR DESCRIPTION
This fixes #610 and possibly other issues regarding mutagen. In theory it could introduce new bugs but I suspect the version restriction wasn't necessary and was geared towards simply avoiding the need to rewrite tests.  We can respond to new issues if we are able to find them but this should fix a number of potential issues based upon the number of [bug fixes](https://mutagen.readthedocs.io/en/latest/changelog.html) from 1.31 to 1.41.