### PR TITLE
Smartblock criteria show # of matches fixes #541

### DIFF
--- a/airtime_mvc/application/forms/SmartBlockCriteria.php
+++ b/airtime_mvc/application/forms/SmartBlockCriteria.php
@@ -477,15 +477,6 @@ class Application_Form_SmartBlockCriteria extends Zend_Form_SubForm
             $limitValue->setValue(1);
         }
 
-        //getting block content candidate count that meets criteria
-        $bl = new Application_Model_Block($p_blockId);
-        if ($p_isValid) {
-            $files = $bl->getListofFilesMeetCriteria();
-            $showPoolCount = true;
-        } else {
-            $files = null;
-            $showPoolCount = false;
-        }
 
         $generate = new Zend_Form_Element_Button('generate_button');
         $generate->setAttrib('class', 'sp-button btn');

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -19,9 +19,6 @@ if ($this->showPoolCount) { ?>
     </div>
     <?php
 }
-else {
-    
-}
 if (count($items) && ($isSmartBlock || $isPlaylist)) : ?>
 <?php $i = 0; ?>
 <?php if ($isSmartBlock && !($this->obj->isStatic())) {

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -2,6 +2,35 @@
 $items = $this->contents;
 $isSmartBlock = ($this->obj instanceof Application_Model_Block);
 $isPlaylist = ($this->obj instanceof Application_Model_Playlist);
+if ($this->poolCount) { ?>
+    <div class='sp_text_font sp_text_font_bold'>
+                <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
+                <?php
+                if ($this->poolCount > 1) {
+                echo $this->poolCount;
+                ?>
+                <?php echo _("files meet the criteria") ?>
+                    </span>
+        <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
+        <?php
+        } else if ($this->poolCount == 1) {
+            echo $this->poolCount;
+            ?>
+            <?php echo _("file meets the criteria") ?>
+            </span>
+            <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
+            <?php
+        } else {
+            ?>
+            0 <?php echo " " . _("files meet the criteria") ?>
+            </span>
+            <span class='sp-warning-icon' id='sp_pool_count_icon'></span>
+            <?php
+        }
+        ?>
+    </div>
+    <?php
+}
 if (count($items) && ($isSmartBlock || $isPlaylist)) : ?>
 <?php $i = 0; ?>
 <?php if ($isSmartBlock && !($this->obj->isStatic())) {

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -2,27 +2,25 @@
 $items = $this->contents;
 $isSmartBlock = ($this->obj instanceof Application_Model_Block);
 $isPlaylist = ($this->obj instanceof Application_Model_Playlist);
-if ($this->poolCount) { ?>
+if ($this->showPoolCount) { ?>
     <div class='sp_text_font sp_text_font_bold'>
         <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
         <?php
-        if ($this->poolCount > 0) {
             echo $this->poolCount;
             echo ngettext(" file meets the criteria", " files meets the criteria", $this->poolCount);
         ?>
-            </span>
-        <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
-        <?php
-        } else {
-            ?>
-            0 <?php echo " " . _("files meet the criteria") ?>
-            </span>
+        </span>
+        <?php if ($this->poolCount > 0) { ?>
+            <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
+        <?php }
+        else { ?>
             <span class='sp-warning-icon' id='sp_pool_count_icon'></span>
-            <?php
-        }
-        ?>
+        <?php } ?>
     </div>
     <?php
+}
+else {
+    
 }
 if (count($items) && ($isSmartBlock || $isPlaylist)) : ?>
 <?php $i = 0; ?>

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -7,7 +7,7 @@ if ($this->showPoolCount) { ?>
         <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
         <?php
             echo $this->poolCount;
-            echo ngettext(" file meets the criteria", " files meet the criteria", $this->poolCount);
+            echo ngettext(" track matches your search criteria.", " tracks match your search criteria.", $this->poolCount);
         ?>
         </span>
         <?php if ($this->poolCount > 0) { ?>

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -7,7 +7,7 @@ if ($this->showPoolCount) { ?>
         <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
         <?php
             echo $this->poolCount;
-            echo ngettext(" file meets the criteria", " files meets the criteria", $this->poolCount);
+            echo ngettext(" file meets the criteria", " files meet the criteria", $this->poolCount);
         ?>
         </span>
         <?php if ($this->poolCount > 0) { ?>

--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -4,22 +4,15 @@ $isSmartBlock = ($this->obj instanceof Application_Model_Block);
 $isPlaylist = ($this->obj instanceof Application_Model_Playlist);
 if ($this->poolCount) { ?>
     <div class='sp_text_font sp_text_font_bold'>
-                <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
-                <?php
-                if ($this->poolCount > 1) {
-                echo $this->poolCount;
-                ?>
-                <?php echo _("files meet the criteria") ?>
-                    </span>
+        <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
+        <?php
+        if ($this->poolCount > 0) {
+            echo $this->poolCount;
+            echo ngettext(" file meets the criteria", " files meets the criteria", $this->poolCount);
+        ?>
+            </span>
         <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
         <?php
-        } else if ($this->poolCount == 1) {
-            echo $this->poolCount;
-            ?>
-            <?php echo _("file meets the criteria") ?>
-            </span>
-            <span class='checked-icon sp-checked-icon' id='sp_pool_count_icon'></span>
-            <?php
         } else {
             ?>
             0 <?php echo " " . _("files meet the criteria") ?>


### PR DESCRIPTION
This fixes #541 evidently in one of the last commits of #370 I inadvertently deleted the code from the update.phtml template that actually displayed the results of poolCount. This restores that and fixes the problem.