### PR TITLE
removed php escape of characters that broke smartblocks

### DIFF
--- a/airtime_mvc/application/models/Block.php
+++ b/airtime_mvc/application/models/Block.php
@@ -1439,7 +1439,7 @@ SQL;
         foreach ($out as $crit) {
             $criteria = $crit->getDbCriteria();
             $modifier = $crit->getDbModifier();
-            $value = htmlspecialchars($crit->getDbValue());
+            $value = $crit->getDbValue();
             $extra = $crit->getDbExtra();
 
             if ($criteria == "limit") {


### PR DESCRIPTION

Basically there was what I think is an unnecessary escaping of the values with the php function htmlspecialchars
I don't think this is necessary as it isn't done for any of the other strings that take characters and there is escaping done later on when the query is built.
This fixes #328 and so you can find your drum and bass with D&B in both the Genre & Smartblock