### PR TITLE
Change dynamic smartblock to be default

### DIFF
--- a/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.7/downgrade.sql
+++ b/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.7/downgrade.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cc_block ALTER COLUMN 'type' SET DEFAULT 'static';

--- a/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.7/downgrade.sql
+++ b/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.7/downgrade.sql
@@ -1,1 +1,1 @@
-ALTER TABLE cc_block ALTER COLUMN 'type' SET DEFAULT 'static';
+ALTER TABLE cc_block ALTER COLUMN type SET DEFAULT 'static';

--- a/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.7/upgrade.sql
+++ b/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.7/upgrade.sql
@@ -1,1 +1,1 @@
-ALTER TABLE cc_block ALTER COLUMN 'type' SET DEFAULT 'dynamic';
+ALTER TABLE cc_block ALTER COLUMN type SET DEFAULT 'dynamic';

--- a/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.7/upgrade.sql
+++ b/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.7/upgrade.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cc_block ALTER COLUMN 'type' SET DEFAULT 'dynamic';

--- a/airtime_mvc/application/forms/SmartBlockCriteria.php
+++ b/airtime_mvc/application/forms/SmartBlockCriteria.php
@@ -223,7 +223,7 @@ class Application_Form_SmartBlockCriteria extends Zend_Form_SubForm
     {
         // load type
         $out = CcBlockQuery::create()->findPk($p_blockId);
-        if ($out->getDbType() == "static") {
+        if ($out->getDbType() == "dynamic") {
             $blockType = 0;
         } else {
             $blockType = 1;
@@ -233,8 +233,9 @@ class Application_Form_SmartBlockCriteria extends Zend_Form_SubForm
         $spType->setLabel(_('Type:'))
                ->setDecorators(array('viewHelper'))
                ->setMultiOptions(array(
-                    'static' => _('Static'),
-                    'dynamic' => _('Dynamic')
+                    'dynamic' => _('Dynamic'),
+                    'static' => _('Static')
+
                 ))
                ->setValue($blockType);
         $this->addElement($spType);
@@ -491,10 +492,10 @@ class Application_Form_SmartBlockCriteria extends Zend_Form_SubForm
         $generate->setAttrib('title', _('Generate playlist content and save criteria'));
         $generate->setIgnore(true);
         if ($blockType == 0) {
-            $generate->setLabel(_('Generate'));
+            $generate->setLabel(_('Preview'));
         }
         else {
-            $generate->setLabel(_('Preview'));
+            $generate->setLabel(_('Generate'));
         }
         $generate->setDecorators(array('viewHelper'));
         $this->addElement($generate);

--- a/airtime_mvc/application/models/Block.php
+++ b/airtime_mvc/application/models/Block.php
@@ -1160,7 +1160,7 @@ SQL;
     {
         $data = $this->organizeSmartPlaylistCriteria($p_criteria);
         // saving dynamic/static flag
-        $blockType = $data['etc']['sp_type'] == 0 ? 'static':'dynamic';
+        $blockType = $data['etc']['sp_type'] == 0 ? 'dynamic':'static';
         $this->saveType($blockType);
         $this->storeCriteriaIntoDb($data);
         

--- a/airtime_mvc/application/models/Block.php
+++ b/airtime_mvc/application/models/Block.php
@@ -361,10 +361,12 @@ SQL;
     {
         $result = CcBlockcriteriaQuery::create()->filterByDbBlockId($this->id)
                 ->filterByDbCriteria('limit')->findOne();
-        $modifier = $result->getDbModifier();
-        $value    = $result->getDbValue();
+        if ($result) {
+            $modifier = $result->getDbModifier();
+            $value = $result->getDbValue();
+            return array($value, $modifier);
+        }
 
-        return array($value, $modifier);
     }
 
     // this function returns sum of all track length under this block.

--- a/airtime_mvc/application/models/airtime/om/BaseCcBlock.php
+++ b/airtime_mvc/application/models/airtime/om/BaseCcBlock.php
@@ -75,7 +75,7 @@ abstract class BaseCcBlock extends BaseObject implements Persistent
 
     /**
      * The value for the type field.
-     * Note: this column has a database default value of: 'static'
+     * Note: this column has a database default value of: 'dynamic'
      * @var        string
      */
     protected $type;
@@ -151,7 +151,7 @@ abstract class BaseCcBlock extends BaseObject implements Persistent
     {
         $this->name = '';
         $this->length = '00:00:00';
-        $this->type = 'static';
+        $this->type = 'dynamic';
     }
 
     /**
@@ -494,7 +494,7 @@ abstract class BaseCcBlock extends BaseObject implements Persistent
                 return false;
             }
 
-            if ($this->type !== 'static') {
+            if ($this->type !== 'dynamic') {
                 return false;
             }
 

--- a/airtime_mvc/application/upgrade/Upgrades.php
+++ b/airtime_mvc/application/upgrade/Upgrades.php
@@ -532,3 +532,17 @@ class AirtimeUpgrader300alpha6 extends AirtimeUpgrader
         return '3.0.0-alpha.6';
     }
 }
+
+class AirtimeUpgrader300alpha7 extends AirtimeUpgrader
+{
+    protected function getSupportedSchemaVersions() {
+        return array(
+            '3.0.0-alpha.6'
+        );
+    }
+
+    public function getNewVersion() {
+        return '3.0.0-alpha.7';
+    }
+}
+

--- a/airtime_mvc/build/sql/schema.sql
+++ b/airtime_mvc/build/sql/schema.sql
@@ -299,7 +299,7 @@ CREATE TABLE "cc_block"
     "creator_id" INTEGER,
     "description" VARCHAR(512),
     "length" interval DEFAULT '00:00:00',
-    "type" VARCHAR(7) DEFAULT 'static',
+    "type" VARCHAR(7) DEFAULT 'dynamic',
     PRIMARY KEY ("id")
 );
 

--- a/airtime_mvc/public/js/airtime/library/library.js
+++ b/airtime_mvc/public/js/airtime/library/library.js
@@ -1277,7 +1277,7 @@ var AIRTIME = (function(AIRTIME) {
                     }
                     // remove 'Add to smart block' option if the current
                     // block is dynamic
-                    if ($('input:radio[name=sp_type]:checked').val() === "1") {
+                    if ($('input:radio[name=sp_type]:checked').val() === "0") {
                         delete oItems.pl_add;
                     }
                     items = oItems;

--- a/airtime_mvc/public/js/airtime/playlist/smart_blockbuilder.js
+++ b/airtime_mvc/public/js/airtime/playlist/smart_blockbuilder.js
@@ -473,7 +473,7 @@ function setupUI() {
     }
     
     if (activeTab.find('.obj_type').val() == 'block') {
-        if (playlist_type == "0") {
+        if (playlist_type == "1") {
             shuffleButton.removeAttr("disabled");
             generateButton.removeAttr("disabled");
             generateButton.html($.i18n._("Generate"));


### PR DESCRIPTION
This will make the dynamic smartblock the default choice vs. the static smartblock. Unfortunately this change requires updating the database and various changes to the default behavior. It needs testing and review to make sure the database changes take place on pre-existing instances.