### PR TITLE
Fix: don't show criteria matches on playlists

### DIFF
--- a/airtime_mvc/application/views/scripts/playlist/update.phtml
+++ b/airtime_mvc/application/views/scripts/playlist/update.phtml
@@ -2,7 +2,7 @@
 $items = $this->contents;
 $isSmartBlock = ($this->obj instanceof Application_Model_Block);
 $isPlaylist = ($this->obj instanceof Application_Model_Playlist);
-if ($this->showPoolCount) { ?>
+if ($isSmartBlock && $this->showPoolCount) { ?>
     <div class='sp_text_font sp_text_font_bold'>
         <span id='sp_pool_count' class='sp_text_font sp_text_font_bold'>
         <?php


### PR DESCRIPTION
This fixes an unintentional side effect of #627 where criteria was showing on non-smartblocks such as playlists.