### PR TITLE
Fix nonmp3 podcast download

### DIFF
--- a/python_apps/airtime-celery/airtime-celery/tasks.py
+++ b/python_apps/airtime-celery/airtime-celery/tasks.py
@@ -9,9 +9,7 @@ import posixpath
 import shutil
 import tempfile
 import traceback
-from mutagen.mp3 import MP3
-from mutagen.easyid3 import EasyID3
-import mutagen.id3
+import mutagen
 from StringIO import StringIO
 from celery import Celery
 from celery.utils.log import get_task_logger
@@ -155,15 +153,12 @@ def podcast_download(id, url, callback_url, api_key, podcast_name, album_overrid
             with tempfile.NamedTemporaryFile(mode ='wb+', delete=False) as audiofile:
                 r.raw.decode_content = True
                 shutil.copyfileobj(r.raw, audiofile)
-                # currently hardcoded for mp3s may want to add support for oggs etc
-                m = MP3(audiofile.name, ID3=EasyID3)
-                logger.debug('podcast_download loaded mp3 {0}'.format(audiofile.name))
-
+                metadata_audiofile = mutagen.File(audiofile.name, easy=True)
+                logger.debug('podcast_download loaded {0}'.format(audiofile.name))
                 # replace album title as needed
-                m = podcast_override_album(m, podcast_name, album_override)
-
-                m.save()
-                filetypeinfo = m.pprint()
+                metadata_audiofile = podcast_override_album(metadata_audiofile, podcast_name, album_override)
+                metadata_audiofile.save()
+                filetypeinfo = metadata_audiofile.pprint()
                 logger.info('filetypeinfo is {0}'.format(filetypeinfo.encode('ascii', 'ignore')))
                 re = requests.post(callback_url, files={'file': (filename, open(audiofile.name, 'rb'))}, auth=requests.auth.HTTPBasicAuth(api_key, ''))
         re.raise_for_status()

--- a/python_apps/airtime-celery/airtime-celery/tasks.py
+++ b/python_apps/airtime-celery/airtime-celery/tasks.py
@@ -154,7 +154,6 @@ def podcast_download(id, url, callback_url, api_key, podcast_name, album_overrid
                 r.raw.decode_content = True
                 shutil.copyfileobj(r.raw, audiofile)
                 metadata_audiofile = mutagen.File(audiofile.name, easy=True)
-                logger.debug('podcast_download loaded {0}'.format(audiofile.name))
                 # replace album title as needed
                 metadata_audiofile = podcast_override_album(metadata_audiofile, podcast_name, album_override)
                 metadata_audiofile.save()

--- a/python_apps/airtime_analyzer/setup.py
+++ b/python_apps/airtime_analyzer/setup.py
@@ -28,7 +28,7 @@ setup(name='airtime_analyzer',
       packages=['airtime_analyzer'],
       scripts=['bin/airtime_analyzer'],
       install_requires=[
-          'mutagen', # got rid of specific version requirement 
+          'mutagen>=1.41.1', # got rid of specific version requirement 
           'pika',
           'daemon',
           'file-magic',

--- a/python_apps/airtime_analyzer/setup.py
+++ b/python_apps/airtime_analyzer/setup.py
@@ -28,7 +28,7 @@ setup(name='airtime_analyzer',
       packages=['airtime_analyzer'],
       scripts=['bin/airtime_analyzer'],
       install_requires=[
-          'mutagen==1.31', # The Mutagen guys change stuff all the time that break our unit tests. Watch out for this.
+          'mutagen', # got rid of specific version requirement 
           'pika',
           'daemon',
           'file-magic',

--- a/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
+++ b/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
@@ -24,8 +24,7 @@ def test_mp3_mono():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-mono.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 1
-    assert metadata['bit_rate'] > 63000
-    assert metadata['bit_rate'] < 65000
+    assert metadata['bit_rate'] == 63998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3' # Not unicode because MIMEs aren't.
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -35,8 +34,7 @@ def test_mp3_jointstereo():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-jointstereo.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] < 130000
-    assert metadata['bit_rate'] > 127000
+    assert metadata['bit_rate'] == 127998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -45,8 +43,7 @@ def test_mp3_simplestereo():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-simplestereo.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] < 130000
-    assert metadata['bit_rate'] > 127000
+    assert metadata['bit_rate'] == 127998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -55,8 +52,7 @@ def test_mp3_dualmono():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-dualmono.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] < 130000
-    assert metadata['bit_rate'] > 127000
+    assert metadata['bit_rate'] == 127998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -158,8 +154,7 @@ def test_mp3_bad_channels():
     metadata = MetadataAnalyzer.analyze(filename, dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 1
-    assert metadata['bit_rate'] < 65000
-    assert metadata['bit_rate'] > 63000
+    assert metadata['bit_rate'] < 63998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3' # Not unicode because MIMEs aren't.
     assert metadata['track_total'] == u'10' # MP3s can have a track_total

--- a/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
+++ b/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
@@ -154,7 +154,7 @@ def test_mp3_bad_channels():
     metadata = MetadataAnalyzer.analyze(filename, dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 1
-    assert metadata['bit_rate'] < 63998
+    assert metadata['bit_rate'] == 63998
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3' # Not unicode because MIMEs aren't.
     assert metadata['track_total'] == u'10' # MP3s can have a track_total

--- a/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
+++ b/python_apps/airtime_analyzer/tests/metadata_analyzer_tests.py
@@ -24,7 +24,8 @@ def test_mp3_mono():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-mono.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 1
-    assert metadata['bit_rate'] == 64876
+    assert metadata['bit_rate'] > 63000
+    assert metadata['bit_rate'] < 65000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3' # Not unicode because MIMEs aren't.
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -34,7 +35,8 @@ def test_mp3_jointstereo():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-jointstereo.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] == 129757
+    assert metadata['bit_rate'] < 130000
+    assert metadata['bit_rate'] > 127000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -43,7 +45,8 @@ def test_mp3_simplestereo():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-simplestereo.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] == 129757
+    assert metadata['bit_rate'] < 130000
+    assert metadata['bit_rate'] > 127000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -52,7 +55,8 @@ def test_mp3_dualmono():
     metadata = MetadataAnalyzer.analyze(u'tests/test_data/44100Hz-16bit-dualmono.mp3', dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] == 129757
+    assert metadata['bit_rate'] < 130000
+    assert metadata['bit_rate'] > 127000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -109,7 +113,8 @@ def test_mp3_utf8():
     assert metadata['genre'] == u'Я Б Г Д Ж Й'
     assert metadata['track_number'] == u'1'
     assert metadata['channels'] == 2
-    assert metadata['bit_rate'] == 129757
+    assert metadata['bit_rate'] < 130000
+    assert metadata['bit_rate'] > 127000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3'
     assert metadata['track_total'] == u'10' # MP3s can have a track_total
@@ -153,7 +158,8 @@ def test_mp3_bad_channels():
     metadata = MetadataAnalyzer.analyze(filename, dict())
     check_default_metadata(metadata)
     assert metadata['channels'] == 1
-    assert metadata['bit_rate'] == 64876
+    assert metadata['bit_rate'] < 65000
+    assert metadata['bit_rate'] > 63000
     assert abs(metadata['length_seconds'] - 3.9) < 0.1
     assert metadata['mime'] == 'audio/mp3' # Not unicode because MIMEs aren't.
     assert metadata['track_total'] == u'10' # MP3s can have a track_total


### PR DESCRIPTION
This fixes #519 by taking away the mp3 specific code and replacing it with mutagen library as a whole which supports most filetypes except for WAV, and I don't think there are very many WAV based podcasts.
I tested it with the m4a based podcast referenced in #519 and was able to download without an issue whereas before it was failing.

Also fixes #271