### PR TITLE
adding phing 2.12.0 to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "zendframework/zendframework1": "^1.12",
         "composer/semver": "^1.4",
         "php-amqplib/php-amqplib": "^2.6"
+        "phing/phing": "2.12.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.3",


### PR DESCRIPTION
This fixes #642 

Not sure if we want to pin phing to this specific version but I know 3.x is Php 7.1 and above and 2.12.0 was installed by default by my ubuntu-xenial install. There are also 2.x versions up to  2.16.1. I also didn't test this but just wanted to toss in the code up there. 