### PR TITLE
Cleanup airtime_analyzer/analyzer.py

### DIFF
--- a/python_apps/airtime_analyzer/airtime_analyzer/analyzer.py
+++ b/python_apps/airtime_analyzer/airtime_analyzer/analyzer.py
@@ -1,13 +1,10 @@
+# TODO: use an abstract base class (ie. import from abc ...) once we have python >=3.3 that supports @staticmethod with @abstractmethod
+
 
 class Analyzer:
-    """ Abstract base class fpr all "analyzers".
+    """ Abstract base class for all "analyzers".
     """
+
     @staticmethod
     def analyze(filename, metadata):
         raise NotImplementedError
-
-'''
-class AnalyzerError(Error):
-    def __init__(self):
-        super.__init__(self)
-'''


### PR DESCRIPTION
I was looking at the base class in analyzer wanting to clean it up some and ended up removing some dead code and fixing some formatting and a docs typo.

I wasn't able to refactor it into a proper abstract base class as described in [this tutorial](https://www.python-course.eu/python3_abstract_classes.php) due to us not supporting python3 yet.

I opted not to implement a [hack](https://stackoverflow.com/a/4474495) but rather to leave this be and drop a TODO that tells us [what to do](https://stackoverflow.com/a/31590500) once we can drop python2 support.