### PR TITLE
prevented shuffling from failing on playlists containing smartblocks

### DIFF
--- a/airtime_mvc/application/controllers/PlaylistController.php
+++ b/airtime_mvc/application/controllers/PlaylistController.php
@@ -64,7 +64,7 @@ class PlaylistController extends Zend_Controller_Action
 
         $this->view->obj = $obj;
         $this->view->contents = $obj->getContents();
-        if ($formIsValid) {
+        if ($formIsValid && $obj instanceof Application_Model_Block) {
             $this->view->poolCount = $obj->getListofFilesMeetCriteria()['count'];
         }
         $this->view->showPoolCount = true;


### PR DESCRIPTION
This fixes #646 
Basically keeps the code from calling block specific functions when a playlist isn't a block.