### PR TITLE
Convert all line endings in the tarball to unix

### DIFF
--- a/dev_tools/release/release.sh
+++ b/dev_tools/release/release.sh
@@ -61,6 +61,7 @@ popd
 #echo "Done"
 
 pushd /tmp/
+find libretime-${suffix} -type f -exec dos2unix {} \;
 echo -n "Creating tarball..."
 tar -czf $target_file \
         --owner=root --group=root \


### PR DESCRIPTION
This is needed because quilt cannot patch line-endings correctly and the Zend framework uses some CRLF line endings instead of LF. The differences result in the package build failing.