### PR TITLE
Add focus to library filter input upon load

### DIFF
--- a/airtime_mvc/public/css/styles.css
+++ b/airtime_mvc/public/css/styles.css
@@ -3720,11 +3720,8 @@ button.btn-icon-text > i.icon-white {
     display: block;
 }
 
-.dashboard_sub_nav {
-    padding: 0px 0px 0px 10px;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
+.media_type_selector.dashboard_sub_nav a {
+    padding-left: 20px;
 }
 
 .wrapper {

--- a/airtime_mvc/public/js/airtime/library/library.js
+++ b/airtime_mvc/public/js/airtime/library/library.js
@@ -745,7 +745,8 @@ var AIRTIME = (function(AIRTIME) {
                         filterMessage.text("");
                     }
                     $libContent.find('.dataTables_filter input[type="text"]')
-                        .css('padding-right', $('#advanced-options').find('button').outerWidth());
+                        .css('padding-right', $('#advanced-options').find('button').outerWidth())
+                        .focus();
                 });
             },
             "fnRowCallback": AIRTIME.library.fnRowCallback,

--- a/airtime_mvc/public/js/airtime/showbuilder/main_builder.js
+++ b/airtime_mvc/public/js/airtime/showbuilder/main_builder.js
@@ -131,12 +131,6 @@ AIRTIME = (function(AIRTIME) {
         selected.parent().addClass("selected");
         $("#library_filter").text(selected.text());
 
-        // Slightly hacky way of triggering the click event when it's outside of the anchor text
-        $(".media_type_selector").on("click", function() {
-            // Need get(0) here so we don't create a stack overflow by recurring the click on the parent
-            $(this).find("a").get(0).click();
-        });
-
         $(window).on('hashchange', function() {
             var selected = $("a[href$='"+location.hash+"']"),
                 dashboardLink = $(".media_type_selector:first"),


### PR DESCRIPTION
Fixes #339

this pr is my suggestion of a better way to approach adding focus to the library search input. i'm proposing it _instead of_ #658 . 

- also removes a [wierd hack](https://github.com/LibreTime/libretime/blob/14ba51489054b91f3cfd58d1390b2dedfb32ab03/airtime_mvc/public/js/airtime/showbuilder/main_builder.js#L134) i found while reviewing #658.
- no longer dependent on resolution of #660

