### PR TITLE
fix Calendar - Long titles now overlap 'files bar'

### DIFF
--- a/airtime_mvc/public/css/fullcalendar.css
+++ b/airtime_mvc/public/css/fullcalendar.css
@@ -314,9 +314,12 @@ a.fc-event {
 .fc-event-time,
 .fc-event-title {
 	padding: 0 1px;
+}
+.fc-view-month .fc-event-time,
+.fc-view-month .fc-event-title {
 	height: 12px;
 }
-	
+
 .fc .ui-resizable-handle { /*** TODO: don't use ui-resizable anymore, change class ***/
 	display: block;
 	position: absolute;


### PR DESCRIPTION
fixes #665

oops my bad, forgot to check the week view