### PR TITLE
[wip] modified the code to treat a file mutagen fails to load as a mp3

### DIFF
--- a/python_apps/airtime-celery/airtime-celery/tasks.py
+++ b/python_apps/airtime-celery/airtime-celery/tasks.py
@@ -153,8 +153,14 @@ def podcast_download(id, url, callback_url, api_key, podcast_name, album_overrid
             with tempfile.NamedTemporaryFile(mode ='wb+', delete=False) as audiofile:
                 r.raw.decode_content = True
                 shutil.copyfileobj(r.raw, audiofile)
+                # mutagen should be able to guess the write file type
                 metadata_audiofile = mutagen.File(audiofile.name, easy=True)
-                # replace album title as needed
+                # if for some reason this should fail lets try it as a mp3 specific code
+                if metadata_audiofile == None:
+                    logger.info('got a blank from mutagen')
+                    metadata_audiofile = mutagen.mp3.MP3(audiofile.name, ID3=mutagen.easyid3.EasyID3)
+                    logger.info('made a mp3')
+                #replace album title as needed
                 metadata_audiofile = podcast_override_album(metadata_audiofile, podcast_name, album_override)
                 metadata_audiofile.save()
                 filetypeinfo = metadata_audiofile.pprint()


### PR DESCRIPTION
This fixes #668

It basically attempts to treat any file that fails to be detected by Mutagen as a MP3 as the files were treated previously to work around files that might not be detected correctly for some reason.
It might make sense to add additional logic checks to determine that a file at least has mp3 filename extension etc, so I want to do that before we merge this.