### PR TITLE
Installer - Add warning for the deprecation of Debian Jessie

### DIFF
--- a/install
+++ b/install
@@ -633,7 +633,7 @@ case "${dist}-${code}" in
         code="jessie"
         is_debian_dist=true
         echo -e "ERROR: Debian Jessie is archived and does not receive any security or other updates since 2018-05-17." >&2
-        echo -e "The LibreTime installer dropped support for installing LibreTime on Jessie in 3.0.0-alpha.8." >&2
+        echo -e "The LibreTime installer will drop support for installing LibreTime on Jessie in 3.0.0-alpha.8." >&2
         sleep 6
         is_debian_jessie=true
         ;;

--- a/install
+++ b/install
@@ -632,6 +632,9 @@ case "${dist}-${code}" in
     debian-8|debian-jessie)
         code="jessie"
         is_debian_dist=true
+        echo -e "ERROR: Debian Jessie is archived and does not receive any security or other updates since 2018-05-17." >&2
+        echo -e "The LibreTime installer dropped support for installing LibreTime on Jessie in 3.0.0-alpha.8." >&2
+        sleep 6
         is_debian_jessie=true
         ;;
     debian-7|debian-wheezy)


### PR DESCRIPTION
Jessie is out of security support and will be dropped inLibreTime 3.0.0-alpha.8

Fixes #684