### PR TITLE
Make Settings menu visible to all users

### DIFF
--- a/airtime_mvc/application/configs/navigation.php
+++ b/airtime_mvc/application/configs/navigation.php
@@ -68,10 +68,9 @@ $pages[] = array(
 );
 $pages[] = array(
     'label' => _("Settings"),
-    'resource' => 'preference',
-    'action' => 'index',
+    'action' => 'edit-user',
     'module' => 'default',
-    'controller' => 'preference',
+    'controller' => 'user',
     'class' => '<i class="icon-cog icon-white"></i>',
     'title' => 'Settings',
     'pages' => array(
@@ -84,8 +83,7 @@ $pages[] = array(
         array(
             'label' => _('My Profile'),
             'controller' => 'user',
-            'action' => 'edit-user',
-            'resource' => 'usersettings'
+            'action' => 'edit-user'
         ),
         array(
             'label'      => _('Users'),


### PR DESCRIPTION
As reported in #698 we made the user edit menu unreachable in #489.

This make the main "Settings" menu item to be visible to all users and also points it straight to the profile edit page where they can change their data and password.

For admins the general settings page is still reachable through the submenu below "Settings".

Fixes #698