### PR TITLE
Move sql from #659 to alpha.7

### DIFF
--- a/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.7/downgrade.sql
+++ b/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.7/downgrade.sql
@@ -1,1 +1,3 @@
 ALTER TABLE cc_block ALTER COLUMN type SET DEFAULT 'static';
+ALTER TABLE podcast_episodes DROP COLUMN IF EXISTS episode_title;
+ALTER TABLE podcast_episodes DROP COLUMN IF EXISTS episode_description;

--- a/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.8/downgrade.sql
+++ b/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.8/downgrade.sql
@@ -1,2 +1,0 @@
-ALTER TABLE podcast_episodes DROP COLUMN IF EXISTS episode_title;
-ALTER TABLE podcast_episodes DROP COLUMN IF EXISTS episode_description;

--- a/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.7/upgrade.sql
+++ b/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.7/upgrade.sql
@@ -1,1 +1,3 @@
 ALTER TABLE cc_block ALTER COLUMN type SET DEFAULT 'dynamic';
+ALTER TABLE podcast_episodes ADD COLUMN episode_title VARCHAR(4096);
+ALTER TABLE podcast_episodes ADD COLUMN episode_description VARCHAR(4096);

--- a/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.8/upgrade.sql
+++ b/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.8/upgrade.sql
@@ -1,2 +1,0 @@
-ALTER TABLE podcast_episodes ADD COLUMN episode_title VARCHAR(4096);
-ALTER TABLE podcast_episodes ADD COLUMN episode_description VARCHAR(4096);


### PR DESCRIPTION
Basically I jumped the gun on using alpha.8 for the SQL before alpha.7 was out. So it would probably make sense to move the SQL from #659 back to alpha.7 before release.