### PR TITLE
fix podcast non audio enclosure problem

### DIFF
--- a/airtime_mvc/application/services/PodcastEpisodeService.php
+++ b/airtime_mvc/application/services/PodcastEpisodeService.php
@@ -416,12 +416,18 @@ class Application_Service_PodcastEpisodeService extends Application_Service_Thir
                 // we need to check if this is an array otherwise sizeof will fail and stop this whole script
                 if (is_array($testenclosures)) {
                     $numenclosures = sizeof($testenclosures);
-                    for ($i = 0; $i < $numenclosures; $i++) {
+                    // now we loop through and look for a audio file and then stop the loop at the first one we find
+                    for ($i = 0; $i < $numenclosures + 1; $i++) {
                         $enclosure_attribs = array_values($testenclosures[$i]['attribs'])[0];
                         if (stripos($enclosure_attribs['type'], 'audio') !== false) {
                             $url = $enclosure_attribs['url'];
                             $enclosure = new SimplePie_Enclosure($enclosure_attribs['url'], $enclosure_attribs['type'], $length = $enclosure_attribs['length']);
                             break;
+                        }
+                        // if we didn't find an audio file we need to continue because there were no audio item enclosures
+                        // so this should keep it from showing items without audio items on the episodes list
+                        if ($i = $numenclosures) {
+                            continue;
                         }
                     }
                 }

--- a/airtime_mvc/application/services/PodcastEpisodeService.php
+++ b/airtime_mvc/application/services/PodcastEpisodeService.php
@@ -410,15 +410,23 @@ class Application_Service_PodcastEpisodeService extends Application_Service_Thir
                 // this is a rather hackish way of accessing the enclosures but get_enclosures() didnt detect multiple
                 // enclosures at certain points so we search through them and then manually create an enclosure object
                 // if we find an audio file in an enclosure and send it off
+                Logging::info('found a non audio');
                 $testenclosures = $enclosures = $item->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'enclosure');
-                $numenclosures = sizeof($testenclosures);
-                for ($i = 0; $i < $numenclosures; $i++) {
-                    $enclosure_attribs = array_values($testenclosures[$i]['attribs'])[0];
-                    if (stripos($enclosure_attribs['type'], 'audio') !== false) {
-                        $url = $enclosure_attribs['url'];
-                        $enclosure = new SimplePie_Enclosure($enclosure_attribs['url'], $enclosure_attribs['type'], $length = $enclosure_attribs['length']);
-                        break;
+                Logging::info($testenclosures);
+                // we need to check if this is an array otherwise sizeof will fail and stop this whole script
+                if (is_array($testenclosures)) {
+                    $numenclosures = sizeof($testenclosures);
+                    for ($i = 0; $i < $numenclosures; $i++) {
+                        $enclosure_attribs = array_values($testenclosures[$i]['attribs'])[0];
+                        if (stripos($enclosure_attribs['type'], 'audio') !== false) {
+                            $url = $enclosure_attribs['url'];
+                            $enclosure = new SimplePie_Enclosure($enclosure_attribs['url'], $enclosure_attribs['type'], $length = $enclosure_attribs['length']);
+                            break;
+                        }
                     }
+                }
+                else {
+                    continue;
                 }
             } else {
                 $enclosure = $item->get_enclosure();

--- a/airtime_mvc/application/services/PodcastEpisodeService.php
+++ b/airtime_mvc/application/services/PodcastEpisodeService.php
@@ -132,7 +132,6 @@ class Application_Service_PodcastEpisodeService extends Application_Service_Thir
         /** @var PodcastEpisodes $episode */
         foreach($episodes as $episode) {
             $podcast = $episode->getPodcast();
-            Logging::info($episode);
             $this->_download($episode->getDbId(), $episode->getDbDownloadUrl(), $podcast->getDbTitle(), $this->_getAlbumOverride($podcast), $episode->getDbEpisodeTitle());
         }
     }
@@ -398,9 +397,33 @@ class Application_Service_PodcastEpisodeService extends Application_Service_Thir
         foreach ($rss->get_items() as $item) {
             /** @var SimplePie_Item $item */
             // If the enclosure is empty or has not URL, this isn't a podcast episode (there's no audio data)
+            // technically podcasts shouldn't have multiple enclosures but often CMS add non-audio files
             $enclosure = $item->get_enclosure();
             $url = $enclosure instanceof SimplePie_Enclosure ? $enclosure->get_link() : $enclosure["link"];
-            if (empty($url)) { continue; }
+            if (empty($url)) {
+                continue;
+            }
+            // next we check and see if the enclosure is not an audio file - this can happen from improperly
+            // formatted podcasts and we instead will search through the enclosures and see if there is an audio item
+            // then we pass that on, otherwise we just pass the first item since it is probably an audio file
+            elseif (!(substr($enclosure->get_type(), 0, 5) === 'audio')) {
+                // this is a rather hackish way of accessing the enclosures but get_enclosures() didnt detect multiple
+                // enclosures at certain points so we search through them and then manually create an enclosure object
+                // if we find an audio file in an enclosure and send it off
+                $testenclosures = $enclosures = $item->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'enclosure');
+                $numenclosures = sizeof($testenclosures);
+                for ($i = 0; $i < $numenclosures; $i++) {
+                    $enclosure_attribs = array_values($testenclosures[$i]['attribs'])[0];
+                    if (stripos($enclosure_attribs['type'], 'audio') !== false) {
+                        $url = $enclosure_attribs['url'];
+                        $enclosure = new SimplePie_Enclosure($enclosure_attribs['url'], $enclosure_attribs['type'], $length = $enclosure_attribs['length']);
+                        break;
+                    }
+                }
+            } else {
+                $enclosure = $item->get_enclosure();
+            }
+            //Logging::info($enclosure);
             $itemId = $item->get_id();
             $ingested = in_array($itemId, $episodeIds) ? (empty($episodeFiles[$itemId]) ? -1 : 1) : 0;
             $file = $ingested > 0 && !empty($episodeFiles[$itemId]) ?
@@ -420,12 +443,11 @@ class Application_Service_PodcastEpisodeService extends Application_Service_Thir
                 "author" => $this->_buildAuthorString($item),
                 "description" => htmlspecialchars($item->get_description()),
                 "pub_date" => $item->get_gmdate(),
-                "link" => $item->get_link(),
-                "enclosure" => $item->get_enclosure(),
+                "link" => $url,
+                "enclosure" => $enclosure,
                 "file" => $file
             ));
         }
-
         return $episodesArray;
     }
 


### PR DESCRIPTION
So this was inspired by #464 
 and fixes #675

The problem is that SimplePie appears to not support multiple enclosures of different types. At least with my test URL. From the [SimplePie docs](http://simplepie.org/api/class-SimplePie_Item.html#_get_enclosures)
```get_enclosures( )

Get all available enclosures (podcasts, etc.)

Supports the <enclosure> RSS tag, as well as Media RSS and iTunes RSS.

At this point, we're pretty much assuming that all enclosures for an item are the same content. Anything else is too complicated to properly support.```

So we had to manually search through the tags find enclosures and then look for audio ones and create a new enclosure object based upon these attributes.

This worked for my test URL but it would be handy to test it on others as well.
It only does the search if the first enclosure isn't an audio type and then it stops once it finds an audio enclosure and assumes that is the right one.

This should be a good workaround for poorly formatted CMS that add images as enclosures in RSS feeds.
