### PR TITLE
add audio/flac to mimetype in filedatahelper

### DIFF
--- a/airtime_mvc/application/common/FileDataHelper.php
+++ b/airtime_mvc/application/common/FileDataHelper.php
@@ -16,6 +16,7 @@ class FileDataHelper {
             "audio/mp4"         => "m4a",
             "video/mp4"         => "mp4",
             "audio/x-flac"      => "flac",
+            "audio/flac"        => "flac",
             "audio/wav"         => "wav",
             "audio/x-wav"       => "wav",
             "audio/mp2"         => "mp2",


### PR DESCRIPTION
This solves an issue posted in #509 that was unrelated to the preview but was indeed causing some flac files to fail to play.
Basically for some reason the getAudioMimeTypeArray had audio/flac-x  but not audio/flac and so files that showed up as audio/flac would give a 400 error when the airtime-playout tried to download them.
This fixes it but still doesn't fix the preview.