### PR TITLE
Apistatus

### DIFF
--- a/airtime_mvc/application/controllers/ApiController.php
+++ b/airtime_mvc/application/controllers/ApiController.php
@@ -185,6 +185,10 @@ class ApiController extends Zend_Controller_Action
         $result["on_air_light"] = false;
         $result["on_air_light_expected_status"] = false;
         $result["station_down"] = false;
+        $result["master_stream"] = false;
+        $result["live_stream"] = false;
+        $result["master_stream_on_air"] = false;
+        $result["live_stream_on_air"] = false;
 
         $range = Application_Model_Schedule::GetPlayOrderRange();
 
@@ -208,6 +212,25 @@ class ApiController extends Zend_Controller_Action
 
         if ($result["on_air_light_expected_status"] != $result["on_air_light"]) {
             $result["station_down"] = true;
+        }
+
+        $live_dj_stream = Application_Model_Preference::GetSourceStatus("live_dj");
+        $master_dj_stream = Application_Model_Preference::GetSourceStatus("master_dj");
+        $live_dj_on_air = Application_Model_Preference::GetSourceSwitchStatus("live_dj");
+        $master_dj_on_air = Application_Model_Preference::GetSourceSwitchStatus("master_dj");
+
+        if($live_dj_stream == true){
+            $result["live_stream"] = true;
+            if ($live_dj_on_air == "on") {
+                $result["live_stream_on_air"] = true;
+            }
+        }
+
+        if($master_dj_stream == true){
+            $result["master_stream"] = true;
+            if ($master_dj_on_air == "on") {
+                $result["master_stream_on_air"] = true;
+            }
         }
 
         $this->returnJsonOrJsonp($request, $result);

--- a/airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml
+++ b/airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml
@@ -13,12 +13,12 @@
         <div id="weekly-schedule-widget-preview" <?php if (isset($this->weekly_schedule_error_msg)) echo "style=display:none"; ?>>
             <label><?php echo _("Preview:") ?></label>
             <div class="schedule_iframe_wrapper">
-                <iframe id="schedule_iframe" height="400px" width="550px" scrolling="no" frameborder="0" src=<?php echo Application_Common_HTTPHelper::getStationUrl()."embed/weekly-program"?>></iframe>
+                <iframe id="schedule_iframe" height="400px" width="550px" scrolling="no" frameborder="0" src="<?php echo Application_Common_HTTPHelper::getStationUrl()."embed/weekly-program"?>"></iframe>
             </div>
 
             <div style="clear:both"></div>
             <label>Embeddable Code:</label>
-            <textarea style="width:98%" rows="3" readonly="readonly"><iframe height="400px" width="550px" scrolling="no" frameborder="0" src=<?php echo Application_Common_HTTPHelper::getStationUrl()."embed/weekly-program"?>></iframe>
+            <textarea style="width:98%" rows="3" readonly="readonly"><iframe height="400px" width="550px" scrolling="no" frameborder="0" src="<?php echo Application_Common_HTTPHelper::getStationUrl()."embed/weekly-program"?>"></iframe>
             </textarea>
             <div><p>
                     Copy this code and paste it into your website's HTML to embed the weekly schedule in your site.

--- a/airtime_mvc/application/views/scripts/index/index.phtml
+++ b/airtime_mvc/application/views/scripts/index/index.phtml
@@ -34,7 +34,7 @@
     <?php endif; ?>
 
     <div id="tab-1" class="schedule tab_content current">
-        <iframe onLoad="autoResize('schedule_iframe');" id="schedule_iframe" height="300px" scrolling="yes" frameborder="0" src=<?php echo $this->stationUrl."embed/weekly-program?style=premium"?>></iframe>
+        <iframe onLoad="autoResize('schedule_iframe');" id="schedule_iframe" height="300px" scrolling="yes" frameborder="0" src="<?php echo $this->stationUrl."embed/weekly-program?style=premium"?>"></iframe>
     </div>
 
 


### PR DESCRIPTION
Added some new data to the JSON output on the API call "onAirLightAction". This shows the status of the two main streams and also whether they are connected to the on air feed.
I use this to show on my wall clock whether we are actually streaming data and whether our stream is online as opposed to just trusting that my connection is OK at my end because BUTT says I am connected.
I have also fixed a couple of missing quotes on a couple of pages which were showing up in red in my code but I'm just being picky!