### PR TITLE
Fix count warning in schedule

### DIFF
--- a/airtime_mvc/application/models/Schedule.php
+++ b/airtime_mvc/application/models/Schedule.php
@@ -104,7 +104,7 @@ SQL;
         $utcNow = new DateTime("now", new DateTimeZone("UTC"));
 
         $shows = Application_Model_Show::getPrevCurrentNext($utcNow, $utcTimeEnd, $showsToRetrieve);
-        $currentShowID = count($shows['currentShow'])>0?$shows['currentShow']['instance_id']:null;
+        $currentShowID = (is_array($shows['currentShow'] && count($shows['currentShow'])>0))?$shows['currentShow']['instance_id']:null;
         $source = self::_getSource();
         $results = Application_Model_Schedule::getPreviousCurrentNextMedia($utcNow, $currentShowID, self::_getSource());
 


### PR DESCRIPTION
This just gets rid of a php 7.2 null count warning error that is breaking an API call.