### PR TITLE
added check to prevent unnecessary conversion to seconds

### DIFF
--- a/airtime_mvc/application/models/Scheduler.php
+++ b/airtime_mvc/application/models/Scheduler.php
@@ -858,8 +858,14 @@ final class Application_Model_Scheduler
 
                         // default fades are in seconds
                         // we need to convert to '00:00:00' format
-                        $file['fadein'] = Application_Common_DateHelper::secondsToPlaylistTime($file['fadein']);
-                        $file['fadeout'] = Application_Common_DateHelper::secondsToPlaylistTime($file['fadeout']);
+                        // added a check to only run the conversion if they are in seconds format 
+                        // otherwise php > 7.1 throws errors
+                        if (is_numeric($file['fadein'])) {
+                            $file['fadein'] = Application_Common_DateHelper::secondsToPlaylistTime($file['fadein']);
+                        }
+                        if (is_numeric($file['fadeout'])) {
+                            $file['fadeout'] = Application_Common_DateHelper::secondsToPlaylistTime($file['fadeout']);
+                        }
 
                         switch ($file["type"]) {
                             case 0:


### PR DESCRIPTION
This fixes #759 by preventing an unnecessary attempt to convert a timestamp formatted variable to a time stamp variable which causes errors due to attempting arithmetic improperly. If the comments are to believed this should fix the problem and it does remove the error and allow people to move items in the schedule. 