### PR TITLE
Expose source status via live-info-v2 endpoint.

### DIFF
--- a/airtime_mvc/application/controllers/ApiController.php
+++ b/airtime_mvc/application/controllers/ApiController.php
@@ -384,6 +384,15 @@ class ApiController extends Zend_Controller_Action
             // convert image paths to point to api endpoints
             WidgetHelper::findAndConvertPaths($result);
 
+            // Expose the live source status
+            $live_dj        = Application_Model_Preference::GetSourceSwitchStatus('live_dj')        ;
+            $master_dj      = Application_Model_Preference::GetSourceSwitchStatus('master_dj')      ;
+            $scheduled_play = Application_Model_Preference::GetSourceSwitchStatus('scheduled_play') ;
+            $result["sources"] = array();
+            $result["sources"]["livedj"] = $live_dj;
+            $result["sources"]["masterdj"] = $master_dj;
+            $result["sources"]["scheduledplay"] = $scheduled_play;
+
             // used by caller to determine if the airtime they are running or widgets in use is out of date.
             $result["station"]["AIRTIME_API_VERSION"] = AIRTIME_API_VERSION;
 


### PR DESCRIPTION
As per feature request: [#799](https://github.com/LibreTime/libretime/issues/799)
I'd like to see the show source status exposed via the live-info-v2 API to allow 3rd party scripts to make show-type-based decisions.  e.g., posting to social media, or triggering recording, etc.
