### PR TITLE
Exclude gitattributes from release tarball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ addons:
     - python-gst-1.0
     - python-magic
     - mp3gain
+    - dos2unix
 install:
 - >
     if [[ "$PYTHON" == false ]]; then

--- a/dev_tools/release/release.sh
+++ b/dev_tools/release/release.sh
@@ -68,6 +68,7 @@ tar -czf $target_file \
         --exclude-vcs \
         --exclude .zfproject.xml \
         --exclude .gitignore \
+        --exclude .gitattributes \
         --exclude .travis.yml \
         --exclude travis \
         --exclude dev_tools \


### PR DESCRIPTION
Hopefully this fixes the continued nightmare that is trying to release a deb using a git managed tarball with mixed line-endings. It also adds a dependency to travis on dos2unix, which is required in the release script