### PR TITLE
Add podcast import date column to podcast page

### DIFF
--- a/airtime_mvc/application/modules/rest/controllers/PodcastController.php
+++ b/airtime_mvc/application/modules/rest/controllers/PodcastController.php
@@ -36,7 +36,10 @@ class Rest_PodcastController extends Zend_Rest_Controller
         $stationPodcastId = Application_Model_Preference::getStationPodcastId();
         $result = PodcastQuery::create()
             // Don't return the Station podcast - we fetch it separately
-            ->filterByDbId($stationPodcastId, Criteria::NOT_EQUAL);
+            ->filterByDbId($stationPodcastId, Criteria::NOT_EQUAL)
+            ->leftJoinImportedPodcast()
+            ->withColumn('auto_ingest_timestamp');
+
         if ($limit > 0) { $result->setLimit($limit); }
         $result->setOffset($offset)
             ->orderBy($sortColumn, $sortDir);

--- a/airtime_mvc/public/js/airtime/library/library.js
+++ b/airtime_mvc/public/js/airtime/library/library.js
@@ -1365,7 +1365,8 @@ var AIRTIME = (function(AIRTIME) {
             /* Creator */        { "sTitle" : $.i18n._("Creator")            , "mDataProp" : "creator"      , "sClass"      : "library_creator"     , "sWidth"  : "160px" },
             /* Website */        { "sTitle" : $.i18n._("Description")        , "mDataProp" : "description"  , "bVisible"    : false                 , "sWidth"  : "150px" },
             /* Year */           { "sTitle" : $.i18n._("Owner")              , "mDataProp" : "owner"        , "bVisible"    : false                 , "sWidth"  : "60px"  },
-            /* URL */            { "sTitle" : $.i18n._("Feed URL")           , "mDataProp" : "url"          , "bVisible"    : false                 , "sWidth"  : "60px"  }
+            /* URL */            { "sTitle" : $.i18n._("Feed URL")           , "mDataProp" : "url"          , "bVisible"    : false                 , "sWidth"  : "60px"  },
+            /* Import Date */    { "sTitle" : $.i18n._("Import Date")        ,"mDataProp" : "auto_ingest_timestamp", "bVisible"    : true           , "sWidth"  : "60px"  },
             ],
             ajaxSourceURL = baseUrl+"rest/podcast",
             podcastToolbarButtons = AIRTIME.widgets.Table.getStandardToolbarButtons();


### PR DESCRIPTION
This adds a new field to the podcast datatable called Import Date which is basically the last time an episode was automatically downloaded by the system. This can be helpful in tracking podcasts that aren't being updated. 

This only updates when the system ingests the podcast and it also doesn't catch failed attempts where there is an issue with the RSS feed. They'll still have the date updated if there are new items even if it fails to download them.

I made it visible by default.