### PR TITLE
Smartblock sort tracks by last play date

### DIFF
--- a/airtime_mvc/application/forms/SmartBlockCriteria.php
+++ b/airtime_mvc/application/forms/SmartBlockCriteria.php
@@ -171,7 +171,9 @@ class Application_Form_SmartBlockCriteria extends Zend_Form_SubForm
             $this->sortOptions = array(
                 "random"   => _("Randomly"),
                 "newest" => _("Newest"),
-                "oldest"   => _("Oldest")
+                "oldest"   => _("Oldest"),
+                "mostrecentplay" => ("Most recently played"),
+                "leastrecentplay" => ("Least recently played")
             );
         }
         return $this->sortOptions;

--- a/airtime_mvc/application/models/Block.php
+++ b/airtime_mvc/application/models/Block.php
@@ -1762,10 +1762,10 @@ SQL;
             $qry->addAscendingOrderByColumn('utime');
         }
         else if ($sortTracks == 'mostrecentplay') {
-            $qry->addDescendingOrderByColumn('lptime');
+            $qry->addDescendingOrderByColumn('(lptime IS NULL), lptime');
         }
         else if ($sortTracks == 'leastrecentplay') {
-            $qry->addAscendingOrderByColumn('lptime');
+            $qry->addAscendingOrderByColumn('(lptime IS NOT NULL), lptime');
         }
         else if ($sortTracks == 'random') {
             $qry->addAscendingOrderByColumn('random()');

--- a/airtime_mvc/application/models/Block.php
+++ b/airtime_mvc/application/models/Block.php
@@ -1202,7 +1202,6 @@ SQL;
                 // that might contradict itself we group them based upon their original position on the form
                 $criteriaGroup = $i;
                 foreach ($p_criteriaData['criteria'][$critKeys[$i]] as $d) {
-                    Logging::info($d);
                 	$field = $d['sp_criteria_field'];
                 	$value = $d['sp_criteria_value'];
                 	$modifier = $d['sp_criteria_modifier'];
@@ -1586,7 +1585,6 @@ SQL;
         $storedCrit = array();
 
         foreach ($out as $crit) {
-            Logging::info($crit);
             $criteria = $crit->getDbCriteria();
             $modifier = $crit->getDbModifier();
             $value = $crit->getDbValue();
@@ -1614,8 +1612,6 @@ SQL;
                     "display_modifier"=>$modifierOptions[$modifier]);
             }
         }
-
-        Logging::info($storedCrit);
         return $storedCrit;
 
     }
@@ -1730,14 +1726,9 @@ SQL;
                         if ($spCriteria == "owner_id") {
                             $spCriteria = "subj.login";
                         }
-                        Logging::info($i);
-                        Logging::info($group);
-                        Logging::info($prevgroup);
                         if ($i > 0 && $prevgroup == $group) {
-                            Logging::info('adding or');
                             $qry->addOr($spCriteria, $spCriteriaValue, $spCriteriaModifier);
                         } else {
-                            Logging::info('adding and');
                             $qry->addAnd($spCriteria, $spCriteriaValue, $spCriteriaModifier);
                         }
                         // only add this NOT LIKE null if you aren't also matching on another criteria
@@ -1758,6 +1749,8 @@ SQL;
         // check if file exists
         $qry->add("file_exists", "true", Criteria::EQUAL);
         $qry->add("hidden", "false", Criteria::EQUAL);
+
+        //$qry->addAsColumn('lptime','COALESCE("lptime",\'1970-01-01\')');
         $sortTracks = 'random';
         if (isset($storedCrit['sort'])) {
             $sortTracks = $storedCrit['sort']['value'];
@@ -1767,6 +1760,12 @@ SQL;
         }
         else if ($sortTracks == 'oldest') {
             $qry->addAscendingOrderByColumn('utime');
+        }
+        else if ($sortTracks == 'mostrecentplay') {
+            $qry->addDescendingOrderByColumn('lptime');
+        }
+        else if ($sortTracks == 'leastrecentplay') {
+            $qry->addAscendingOrderByColumn('lptime');
         }
         else if ($sortTracks == 'random') {
             $qry->addAscendingOrderByColumn('random()');
@@ -1812,7 +1811,6 @@ SQL;
 
         try {
             $out = $qry->setFormatter(ModelCriteria::FORMAT_ON_DEMAND)->find();
-
             return array("files"=>$out, "limit"=>$limits, "repeat_tracks"=> $repeatTracks, "overflow_tracks"=> $overflowTracks, "count"=>$out->count());
         } catch (Exception $e) {
             Logging::info($e);

--- a/airtime_mvc/application/models/Block.php
+++ b/airtime_mvc/application/models/Block.php
@@ -1750,7 +1750,6 @@ SQL;
         $qry->add("file_exists", "true", Criteria::EQUAL);
         $qry->add("hidden", "false", Criteria::EQUAL);
 
-        //$qry->addAsColumn('lptime','COALESCE("lptime",\'1970-01-01\')');
         $sortTracks = 'random';
         if (isset($storedCrit['sort'])) {
             $sortTracks = $storedCrit['sort']['value'];
@@ -1761,6 +1760,7 @@ SQL;
         else if ($sortTracks == 'oldest') {
             $qry->addAscendingOrderByColumn('utime');
         }
+        // these sort additions are needed to override the default postgres NULL sort behavior
         else if ($sortTracks == 'mostrecentplay') {
             $qry->addDescendingOrderByColumn('(lptime IS NULL), lptime');
         }


### PR DESCRIPTION
This fixes #775 by adding the ability for smartblocks to be sorted by the most recently played tracks (tracks that were played recently come to the top) or least recently played (tracks that were never played come to the top of the list and it is basically randomly selecting between tracks that match the criteria that have never been played and then if all tracks have been played once based upon the 'lptime' track it'll play the track that was played furthest in the past.

This will allow smartblocks to choose unplayed tracks by setting the sort order to be least recently played.

The docs should also be fixed include this new option but we still need to rewrite the existing smartblock docs page.