### PR TITLE
do not take focus away from advanced search fields

### DIFF
--- a/airtime_mvc/public/js/airtime/library/library.js
+++ b/airtime_mvc/public/js/airtime/library/library.js
@@ -745,8 +745,10 @@ var AIRTIME = (function(AIRTIME) {
                         filterMessage.text("");
                     }
                     $libContent.find('.dataTables_filter input[type="text"]')
-                        .css('padding-right', $('#advanced-options').find('button').outerWidth())
-                        .focus();
+                        .css('padding-right', $('#advanced-options').find('button').outerWidth());
+                    if (! ($('#advanced_search input[type="text"]').is(":focus")) ) {
+                        $libContent.find('.dataTables_filter input[type="text"]').focus();
+                    }
                 });
             },
             "fnRowCallback": AIRTIME.library.fnRowCallback,


### PR DESCRIPTION
This fixes #819 and focus still goes back to the library search otherwise.