### PR TITLE
[wip] Track playback analytics

### DIFF
--- a/airtime_mvc/application/controllers/ListenerstatController.php
+++ b/airtime_mvc/application/controllers/ListenerstatController.php
@@ -127,4 +127,12 @@ class ListenerstatController extends Zend_Controller_Action
             $endsDT->format(DEFAULT_TIMESTAMP_FORMAT));
         $this->_helper->json->sendJson($data);
     }
+
+    public function getTrackDataAction(){
+        list($startsDT, $endsDT) = Application_Common_HTTPHelper::getStartEndFromRequest($this->getRequest());
+        $file_id = $this->getRequest()->getParam("file_id", null);
+        $data = Application_Model_ListenerStat::getTrackDataPointsWithinRange($startsDT->format(DEFAULT_TIMESTAMP_FORMAT),
+            $endsDT->format(DEFAULT_TIMESTAMP_FORMAT), $file_id);
+        $this->_helper->json->sendJson($data);
+    }
 }

--- a/airtime_mvc/application/models/ListenerStat.php
+++ b/airtime_mvc/application/models/ListenerStat.php
@@ -141,6 +141,54 @@ SQL;
         return $all_show_data;
     }
 
+
+// this will currently log the average number of listeners to a specific show during a certain range
+    public static function getTrackListenersWithinRange($p_start, $p_end, $file_id) {
+        $playData = [];
+        $ccFile = CcFilesQuery::create()->findPk($file_id);
+        $trackTitle = $ccFile->getDbName();
+        $trackArtist = $ccFile->getDbArtistName();
+        $trackISRC = $ccFile->getDbIsrcNumber();
+        $trackAlbum = $ccFile->getDbAlbumTitle();
+        $trackLabel = $ccFile->getDbLabel();
+
+
+
+        // this query selects all show instances that aired in this date range that match the show_id
+        $sql = <<<SQL
+SELECT id, starts, ends FROM cc_playout_history WHERE file_id =:p1 
+AND starts >=:p2 AND ends <=:p3
+SQL;
+        $data = Application_Common_Database::prepareAndExecute($sql,
+            array('p1'=>$file_id,'p2'=>$p_start, 'p3'=>$p_end));
+        foreach ($data as $d) {
+            $sql = <<<SQL
+SELECT timestamp, SUM(listener_count) AS listeners
+    FROM cc_listener_count AS lc
+    INNER JOIN cc_timestamp AS ts ON (lc.timestamp_id = ts.ID)
+    INNER JOIN cc_mount_name AS mn ON (lc.mount_name_id = mn.ID)
+WHERE (ts.timestamp >=:p1 AND ts.timestamp <=:p2)
+GROUP BY timestamp
+SQL;
+            $data = Application_Common_Database::prepareAndExecute($sql,
+                array('p1'=>$d['starts'], 'p2'=>$d['ends']));
+            $utcTimezone = new DateTimeZone("UTC");
+            $displayTimezone = new DateTimeZone(Application_Model_Preference::GetUserTimezone());
+            if (sizeof($data) > 0) {
+                $t = new DateTime($data[0]['timestamp'], $utcTimezone);
+                $t->setTimezone($displayTimezone);
+                // tricking javascript so it thinks the server timezone is in UTC
+                $average_listeners = array_sum(array_column($data, 'listeners')) / sizeof($data);
+                $max_num_listeners = max(array_column($data, 'listeners'));
+                $entry = array("trackTitle" => $trackTitle, "trackArtist" => $trackArtist, "trackISRC" => $trackISRC, "trackAlbum" => $trackAlbum, "trackLabel" => $trackLabel, "time" => $t->format( 'Y-m-d H:i:s')
+                , "average_number_of_listeners" => $average_listeners,
+                    "maximum_number_of_listeners" => $max_num_listeners);
+                array_push($playData, $entry);
+            }
+        }
+        return($playData);
+    }
+
     public static function insertDataPoints($p_dataPoints) {
 
 


### PR DESCRIPTION
This will enable the viewing of a playback report for specific files in the database including how many times they were played aka "spun" and how many people were tuned in when it was playing.

It currently just exists as a json returning endpoint and should probably be integrated into the playback history service in addition to being a standalone file.

The basic idea is to add another option to the Tracks Dashboard called "View Play History" - this will then bring up a page that allows you to select a date range defaulting to the last 2 weeks. And once you submit the query it will return a report with a number of entries.

Specifically it will include a list of the time the file played. A list of the number of listeners counted during the time it played (unfortunately for short bits like IDs or even underwriting announcements the system is currently configured to only query every 2 minutes so this will miss a listener count for the vast majority of plays). It will probably get a count for songs etc that are longer than 1 minute. To get more accurate results we would need to modify the frequency of queries to the icecast server or consult the icecast log itself.

If a track is played the play count is incremented and if a listener was recorded while it aired then it will increment the audience measurement.

These statistics along with ATH when fit into a file play history would help people who wanted to use their LibreTime analytics to submit their records.