### PR TITLE
Schedule: Display warning icon and tooltip on overbooked show

### DIFF
--- a/airtime_mvc/public/css/styles.css
+++ b/airtime_mvc/public/css/styles.css
@@ -2307,6 +2307,9 @@ span.errors.sp-errors{
 .small-icon.show-partial-filled, .small-icon.media-item-in-use {
     background:url(images/icon_alert_cal_alt2.png) no-repeat 0 0;
 }
+.small-icon.show-overbooked {
+    background:url(images/icon_alert_cal.png) no-repeat 0 0;
+}
 .small-icon.is_scheduled {
     background:url(images/is_scheduled.png) no-repeat 0 0;
     height: 16px !important;

--- a/airtime_mvc/public/js/airtime/schedule/full-calendar-functions.js
+++ b/airtime_mvc/public/js/airtime/schedule/full-calendar-functions.js
@@ -239,6 +239,21 @@ function eventRender(event, element, view) {
                         .find(".fc-event-time")
                         .before('<span class="small-icon show-partial-filled"></span>');
                 }
+            } else if (event.percent > 100) {
+                if (event.linked) {
+                    $(element)
+                        .find(".fc-event-time")
+                        .before('<span class="small-icon linked"></span><span class="small-icon show-overbooked"></span>');
+                } else if (event.show_has_auto_playlist === true) {
+                    $(element)
+                        .find(".fc-event-time")
+                        .before('<span class="small-icon autoplaylist"></span>');
+                } else {
+                    $(element)
+                        .find(".fc-event-time")
+                        .before('<span class="small-icon show-overbooked"></span>');
+                }
+
             } else {
                 if (event.linked) {
                     $(element)
@@ -278,6 +293,20 @@ function eventRender(event, element, view) {
                     $(element)
                         .find(".fc-event-title")
                         .after('<span title="' + $.i18n._("Show is partially filled") + '" class="small-icon show-partial-filled"></span>');
+                }
+            } else if (event.percent > 100) {
+                if (event.linked) {
+                    $(element)
+                        .find(".fc-event-title")
+                        .after('<span class="small-icon linked"></span><span title="' + $.i18n._("Shows longer than their scheduled time will be cut off by a following show.") + '" class="small-icon show-overbooked"></span>');
+                } else if (event.show_has_auto_playlist === true) {
+                    $(element)
+                        .find(".fc-event-title")
+                        .after('<span title="' + $.i18n._("Show has an automatic playlist") + '"class="small-icon autoplaylist"></span>');
+                } else {
+                    $(element)
+                        .find(".fc-event-title")
+                        .after('<span title="' + $.i18n._("Shows longer than their scheduled time will be cut off by a following show.") + '" class="small-icon show-overbooked"></span>');
                 }
             } else {
                 if (event.linked) {
@@ -566,6 +595,27 @@ function addQtipsToIcons(ele, id) {
         $(ele).qtip({
             content: {
                 text: $.i18n._("This show is not completely filled with content.")
+            },
+            position: {
+                adjust: {
+                    resize: true,
+                    method: "flip flip"
+                },
+                at: "right center",
+                my: "left top",
+                viewport: $(window)
+            },
+            style: {
+                classes: "ui-tooltip-dark file-md-long"
+            },
+            show: {
+                ready: true // Needed to make it show on first mouseover event
+            }
+        });
+    } else if ($(ele).hasClass("show-overbooked")) {
+        $(ele).qtip({
+            content: {
+                text: $.i18n._("Shows longer than their scheduled time will be cut off by a following show.")
             },
             position: {
                 adjust: {

--- a/airtime_mvc/public/js/airtime/schedule/schedule.js
+++ b/airtime_mvc/public/js/airtime/schedule/schedule.js
@@ -22,21 +22,6 @@ function closeDialogCalendar(event, ui) {
     $("#schedule_calendar").fullCalendar( 'refetchEvents' );
 }
 
-function checkShowLength(json) {
-    var percent = json.percentFilled;
-
-    if (percent > 100){
-        $("#show_time_warning")
-            .text($.i18n._("Shows longer than their scheduled time will be cut off by a following show."))
-            .show();
-    }
-    else {
-        $("#show_time_warning")
-            .empty()
-            .hide();
-    }
-}
-
 function confirmCancelShow(show_instance_id){
     if (confirm($.i18n._('Cancel Current Show?'))) {
         var url = baseUrl+"Schedule/cancel-current-show";


### PR DESCRIPTION
This displays a warning icon with corresponding tooltip on the schedule page if a show is overbooked. The following screenshots show how it looks while hovering over the icon.

**month overview**
<img width="480" alt="Screen Shot 2019-08-17 at 17 27 48" src="https://user-images.githubusercontent.com/116588/63214168-13130b80-c115-11e9-8f7a-f14af3f2fdc9.png">
**week view**
<img width="773" alt="Screen Shot 2019-08-17 at 17 33 45" src="https://user-images.githubusercontent.com/116588/63214179-363dbb00-c115-11e9-89f1-99aff31661cc.png">

It does not display this warning on autoplaylist based shows since it is expected that they usually are slightly overbooked. The icon i'm using isn't used anywhere else as far as I can tell. I'm also removing a dead js function that used to do something similar.