### PR TITLE
Fix text overflow in tooltip

### DIFF
--- a/airtime_mvc/public/css/styles.css
+++ b/airtime_mvc/public/css/styles.css
@@ -575,6 +575,7 @@ table.library-track-md{
 
 .ui-tooltip-dark.file-md-long{ 
     max-width: 415px !important;
+    overflow-y: unset;
 }
 
 .library-get-file-md tr td, .library-track-md tr td{


### PR DESCRIPTION
Fixes that the scrollbar was getting displayed in tooltips on the schedule page.

**Current behaviour**
<img width="479" alt="Screen Shot 2019-08-17 at 20 27 18" src="https://user-images.githubusercontent.com/116588/63215940-0d75ef80-c12e-11e9-9a98-fb1fd3ee539a.png">

**With change**
<img width="490" alt="Screen Shot 2019-08-17 at 20 27 29" src="https://user-images.githubusercontent.com/116588/63215941-136bd080-c12e-11e9-9111-f4968d27276f.png">
