### PR TITLE
Remove airtime.pro servername check in setup

### DIFF
--- a/airtime_mvc/public/index.php
+++ b/airtime_mvc/public/index.php
@@ -69,12 +69,6 @@ if (file_exists($filename)) {
 }
 // Otherwise, we'll need to run our configuration setup
 else {
-    // Sometimes we can get into a weird NFS state where a station's airtime.conf has
-    // been neg-cached - redirect to a 404 instead until the NFS cache is updated
-    if (strpos($_SERVER['SERVER_NAME'], "airtime.pro") !== false) {
-        header($_SERVER['SERVER_PROTOCOL'] . ' 404 Page Not Found', true, 404);
-        exit;
-    }
     $airtimeSetup = true;
     require_once(SETUP_PATH . 'setup-config.php');
 }


### PR DESCRIPTION
This check used to ensure that SaaS users never got to see the setup page.

Should anyone want to ensure that the setup page is never displayed, the straightforward way is to ensure that the config file always exists (the setup routine only gets triggered if airtime.conf is missing).