### PR TITLE
CentOS 7/Python 2.7.5 compat fix

### DIFF
--- a/python_apps/pypo/pypo/__main__.py
+++ b/python_apps/pypo/pypo/__main__.py
@@ -16,7 +16,10 @@ from api_clients import api_client
 from configobj import ConfigObj
 from datetime import datetime
 from optparse import OptionParser
-from queue import Queue
+try:
+    from queue import Queue
+except ImportError:  # Python 2.7.5 (CentOS 7)
+    from Queue import Queue
 from threading import Lock
 
 from .listenerstat import ListenerStat


### PR DESCRIPTION
This gets rid of [a patch](https://build.opensuse.org/package/view_file/home:radiorabe:airtime/libretime/python-275-compat.patch?expand=1) that I have been applying to my CentOS 7 packages after having been a bit overzealous when I refactored pypo in #654.