### PR TITLE
Replace support link with discourse

### DIFF
--- a/airtime_mvc/application/configs/constants.php
+++ b/airtime_mvc/application/configs/constants.php
@@ -22,7 +22,7 @@ define('PRIVACY_POLICY_URL'         , 'https://github.com/LibreTime/code-of-cond
 define('USER_MANUAL_URL'            , 'http://libretime.org/manual/');
 define('ABOUT_AIRTIME_URL'          , 'http://libretime.org');
 define('AIRTIME_TRANSIFEX_URL'      , 'http://libretime.org/translating/');
-define('SUPPORT_TICKET_URL'         , 'https://github.com/LibreTime/libretime/issues');
+define('LIBRETIME_DISCOURSE_URL'    , 'https://discourse.libretime.org');
 define('UI_REVAMP_EMBED_URL'        , 'https://www.youtube.com/embed/nqpNnCKGluY');
 define('LIBRETIME_WHATS_NEW_URL'    , 'https://github.com/LibreTime/libretime/releases');
 define('LIBRETIME_UPDATE_FEED'      , 'https://github.com/LibreTime/libretime/releases.atom');

--- a/airtime_mvc/application/configs/navigation.php
+++ b/airtime_mvc/application/configs/navigation.php
@@ -206,8 +206,8 @@ $pages[] = array(
             'target'     => "_blank"
         ),
         array(
-            'label'     => _('File a Support Ticket'),
-            'uri'       => SUPPORT_TICKET_URL,
+            'label'     => _('Get Help Online'),
+            'uri'       => LIBRETIME_DISCOURSE_URL,
             'target'    => "_blank"
         ),
         array(

--- a/airtime_mvc/locale/ast/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ast/LC_MESSAGES/airtime.po
@@ -743,7 +743,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/az/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/az/LC_MESSAGES/airtime.po
@@ -743,7 +743,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/cs_CZ/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/cs_CZ/LC_MESSAGES/airtime.po
@@ -745,7 +745,7 @@ msgid "User Manual"
 msgstr "Návod k obsluze"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/da_DK/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/da_DK/LC_MESSAGES/airtime.po
@@ -743,7 +743,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/de_AT/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/de_AT/LC_MESSAGES/airtime.po
@@ -745,7 +745,7 @@ msgid "User Manual"
 msgstr "Benutzerhandbuch"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/de_DE/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/de_DE/LC_MESSAGES/airtime.po
@@ -749,8 +749,8 @@ msgid "User Manual"
 msgstr "Benutzerhandbuch"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
-msgstr "Support Anfrage erstellen"
+msgid "Get Help Online"
+msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210
 msgid "What's New?"

--- a/airtime_mvc/locale/el_GR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/el_GR/LC_MESSAGES/airtime.po
@@ -745,7 +745,7 @@ msgid "User Manual"
 msgstr "Εγχειρίδιο Χρήστη"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/en_CA/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_CA/LC_MESSAGES/airtime.po
@@ -745,7 +745,7 @@ msgid "User Manual"
 msgstr "User Manual"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/en_GB/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_GB/LC_MESSAGES/airtime.po
@@ -746,8 +746,8 @@ msgid "User Manual"
 msgstr "User Manual"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
-msgstr "File a Support Ticket"
+msgid "Get Help Online"
+msgstr "Get Help Online"
 
 #: airtime_mvc/application/configs/navigation.php:210
 msgid "What's New?"

--- a/airtime_mvc/locale/en_US/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_US/LC_MESSAGES/airtime.po
@@ -745,7 +745,7 @@ msgid "User Manual"
 msgstr "User Manual"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/es_ES/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/es_ES/LC_MESSAGES/airtime.po
@@ -748,8 +748,8 @@ msgid "User Manual"
 msgstr "Manual para el usuario"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
-msgstr "Presentar un Ticket de Soporte"
+msgid "Get Help Online"
+msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210
 msgid "What's New?"

--- a/airtime_mvc/locale/fr_FR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/fr_FR/LC_MESSAGES/airtime.po
@@ -745,7 +745,7 @@ msgid "User Manual"
 msgstr "Manuel Utilisateur"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/hr_HR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hr_HR/LC_MESSAGES/airtime.po
@@ -744,7 +744,7 @@ msgid "User Manual"
 msgstr "Priručnik"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/hu_HU/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hu_HU/LC_MESSAGES/airtime.po
@@ -769,8 +769,8 @@ msgid "User Manual"
 msgstr "Felhasználói kézikönyv"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
-msgstr "Támogatási jegy készítése"
+msgid "Get Help Online"
+msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210
 msgid "What's New?"

--- a/airtime_mvc/locale/hy/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hy/LC_MESSAGES/airtime.po
@@ -740,7 +740,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/hy_AM/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hy_AM/LC_MESSAGES/airtime.po
@@ -743,7 +743,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/id_ID/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/id_ID/LC_MESSAGES/airtime.po
@@ -743,7 +743,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/it_IT/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/it_IT/LC_MESSAGES/airtime.po
@@ -746,7 +746,7 @@ msgid "User Manual"
 msgstr "Manuale utente"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/ja/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ja/LC_MESSAGES/airtime.po
@@ -746,7 +746,7 @@ msgid "User Manual"
 msgstr "ユーザーマニュアル"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/ja_JP/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ja_JP/LC_MESSAGES/airtime.po
@@ -741,7 +741,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/ka/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ka/LC_MESSAGES/airtime.po
@@ -743,7 +743,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/ko_KR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ko_KR/LC_MESSAGES/airtime.po
@@ -744,7 +744,7 @@ msgid "User Manual"
 msgstr "사용자 메뉴얼"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/lt/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/lt/LC_MESSAGES/airtime.po
@@ -744,7 +744,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/nl_NL/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/nl_NL/LC_MESSAGES/airtime.po
@@ -748,7 +748,7 @@ msgid "User Manual"
 msgstr "Gebruikershandleiding"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/pl_PL/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/pl_PL/LC_MESSAGES/airtime.po
@@ -745,7 +745,7 @@ msgid "User Manual"
 msgstr "Instrukcja użytkowania"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/pt_BR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/pt_BR/LC_MESSAGES/airtime.po
@@ -746,7 +746,7 @@ msgid "User Manual"
 msgstr "Manual do Usuário"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/ro_RO/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ro_RO/LC_MESSAGES/airtime.po
@@ -743,7 +743,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/ru_RU/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ru_RU/LC_MESSAGES/airtime.po
@@ -753,8 +753,8 @@ msgid "User Manual"
 msgstr "Руководство пользователя"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
-msgstr "Добавить запрос в поддержку"
+msgid "Get Help Online"
+msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210
 msgid "What's New?"

--- a/airtime_mvc/locale/si/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/si/LC_MESSAGES/airtime.po
@@ -743,7 +743,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/sr_RS/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/sr_RS/LC_MESSAGES/airtime.po
@@ -744,7 +744,7 @@ msgid "User Manual"
 msgstr "Упутство"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/sr_RS@latin/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/sr_RS@latin/LC_MESSAGES/airtime.po
@@ -744,7 +744,7 @@ msgid "User Manual"
 msgstr "Uputstvo"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/template/airtime.po
+++ b/airtime_mvc/locale/template/airtime.po
@@ -743,7 +743,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/tr/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/tr/LC_MESSAGES/airtime.po
@@ -744,7 +744,7 @@ msgid "User Manual"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210

--- a/airtime_mvc/locale/zh_CN/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/zh_CN/LC_MESSAGES/airtime.po
@@ -744,7 +744,7 @@ msgid "User Manual"
 msgstr "用户手册"
 
 #: airtime_mvc/application/configs/navigation.php:200
-msgid "File a Support Ticket"
+msgid "Get Help Online"
 msgstr ""
 
 #: airtime_mvc/application/configs/navigation.php:210


### PR DESCRIPTION
I'm replacing the "File a Support Ticket" link with a "Get Help Online" link that points to our Discourse with the hopes that this change reduces the amount of support issues we get through GitHub.