### PR TITLE
Add link to mattermost in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ we have a forum at [discourse.libretime.org](http://discourse.libretime.org).
 We are moving towards using the forum to provide community support and reserving
 the github issue queue for confirmed bugs and well-formed feature requests.
 
+You can also contact us through our [Mattermost instance](https://chat.libretime.org)
+where you can talk with other users and developers.
+
 ## Contributors
 
 ### Code Contributors


### PR DESCRIPTION
Realised we probably should link to mattermost in the README too