### PR TITLE
macOS Catalina support for Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,12 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 8888, host:8888
 
   # make sure we are using nfs (doesn't work out of the box with debian)
-  config.vm.synced_folder ".", "/vagrant", type: "nfs"
+  nfsPath = "."
+  # macOS Catalina support
+  if Dir.exist?("/System/Volumes/Data")
+      nfsPath = "/System/Volumes/Data" + Dir.pwd
+  end
+  config.vm.synced_folder nfsPath, "/vagrant", type: "nfs"
   # private network for nfs
   config.vm.network "private_network", ip: "192.168.10.100"
 


### PR DESCRIPTION
NFS sync fix for Mac users updating to the new OS. Due to the changes in Catalina with their dedicated system volume we have to change the Vagrantfile in order to point to the install file, else it won't work.