### PR TITLE
Artwork fix in track API

### DIFF
--- a/airtime_mvc/application/controllers/ApiController.php
+++ b/airtime_mvc/application/controllers/ApiController.php
@@ -590,7 +590,7 @@ class ApiController extends Zend_Controller_Action
                 //default
                 foreach ($md as $key => $value) {
                     if ($key == 'MDATA_KEY_ARTWORK' && !is_null($value)) {
-                        FileDataHelper::renderImage($fp . $md['MDATA_KEY_ARTWORK'].'-1024.jpg');
+                        FileDataHelper::renderImage($fp . $md['MDATA_KEY_ARTWORK'].'-512.jpg');
                     }
                 }
             } elseif ($return === "artwork-32") {
@@ -615,12 +615,6 @@ class ApiController extends Zend_Controller_Action
                 foreach ($md as $key => $value) {
                     if ($key == 'MDATA_KEY_ARTWORK' && !is_null($value)) {
                         FileDataHelper::renderImage($fp . $md['MDATA_KEY_ARTWORK'].'-512.jpg');
-                    }
-                }
-            } elseif ($return === "artwork-1024") {
-                foreach ($md as $key => $value) {
-                    if ($key == 'MDATA_KEY_ARTWORK' && !is_null($value)) {
-                        FileDataHelper::renderImage($fp . $md['MDATA_KEY_ARTWORK'].'-1024.jpg');
                     }
                 }
             } elseif ($return === "json") {


### PR DESCRIPTION
Removed 1024px for artwork in API. This was old code from before the merge and forgot to remove them on the API. Most artwork available for these audio files (from Apple Music, Amazon, ect...) are around 500px - 600px, so it doesn't make sense to enlarge a thumbnail at that size... it also made uploading take a little longer.

The default value is now 512px if using just "artwork" in api to get track info by ID. (eg. http://192.168.10.100:8080/api/track?id=1&return=artwork)

The default url for artwork, like the example above is also available in the API for live-info. Whenever you guys have a chance you can merge so nobody runs into any issues if using the API.

I will try to work on the artwork upload from the edit tab soon.