### PR TITLE
Config for lock bot

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,30 @@
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 365
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+  Please chat to us on [discourse](https://discourse.libretime.org/) or
+  ask for help on our [chat](https://chat.libretime.org/) if you have any
+  questions or need further assistance with this issue.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Limit to only `issues` or `pulls`
+# only: issues


### PR DESCRIPTION
I activated the [lock probot](https://probot.github.io/apps/lock/) after our discussion in #434.

Before the the bot every had any work to do it was refactored to mandate needing a config file in `.github/lock.yml`.

This PR finally adds such a configuration and configures it to post a comment that points people finding such issues our discourse and chat.