### PR TITLE
Configure stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,57 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale (5 months)
+daysUntilStale: 150
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed. (1 month)
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 30
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+  - "[Status] Maybe Later"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  activity in the last 5 months. It will be closed if no activity occurs in
+  the next month.
+
+  Please chat to us on [discourse](https://discourse.libretime.org/) or
+  ask for help on our [chat](https://chat.libretime.org/) if you have any
+  questions or need further support with getting this issue resolved.
+
+  You may also label an issue as *pinned* if you would like to make sure
+  that it does not get closed by this bot.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  This issue has been autmatically closed after is was marked as stale and
+  did not receive any further inputs.
+
+  Feel free to let us know on [discourse](https://discourse.libretime.org/) or
+  ask for help on our [chat](https://chat.libretime.org/) if you feel this
+  issue should not have been closed.
+
+  Thank you for your contributions.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30


### PR DESCRIPTION
This issue prepares the configuration for the [stale probot](https://github.com/probot/stale). If we decide to merge it I will activate the bot after the merge.

The issues closed by the but will get tagged as *wontfix* and a comment will be added. These comments will look similar to the image below.

![stale bot example](https://cloud.githubusercontent.com/assets/173/23858697/4885f0d6-07cf-11e7-96ed-716948027bbc.png)

For our case I replaced the stock test with the following.

> This issue has been automatically marked as stale because it has not had activity in the last 5 months. It will be closed if no activity occurs in the next month.
>  
> Please chat us up on [discourse](https://discourse.libretime.org/) or ask for help on our [chat](https://chat.libretime.org/) if you have any questions or need further support with getting this issue resolved.
>
>  You may also label an issue as *pinned* if you would like to make sure that it does not get closed by this bot.

After closing an issue as stale the bot will also post the following comment.

> This issue has been autmatically closed after is was marked as stale and did not receive any further inputs.
>
> Feel free to let us know on [discourse](https://discourse.libretime.org/) or ask for help on our [chat](https://chat.libretime.org/) if you feel this issue should not have been closed.
>
>  Thank you for your contributions.

Tagging issues as *wontfix* isn't done to indicate that we do not want to fix an issue, it's more a case of us being honest. If an issue hasn't been pinned or worked on for half a year, chances are slim that it will get fixed anytime soon.

Please take a look at the bots [README](https://github.com/probot/stale/blob/master/README.md) for more details on the reasoning behind the feature this bot implements. The README also has more details on how to configure the bot.

Feel free to let me know if you would like some changes to the bots config and I'll adapt the config and rebase this PR.

I tried to set up the timeouts used by the bots in a rather conservative manner. We can opt-out of having the bot close individual issues by tagging them as *pinned*.

I'm assuming that the bot will have quite a bit of work to do once it is activated. In the long run it should remove some of the burden of tracking issues that didn't receive any love.