### PR TITLE
PypoMessageHandler reliable RabbitMQ consumption

### DIFF
--- a/python_apps/pypo/pypo/pypomessagehandler.py
+++ b/python_apps/pypo/pypo/pypomessagehandler.py
@@ -7,14 +7,31 @@ import sys
 from threading import Thread
 import time
 # For RabbitMQ
-from kombu.connection import BrokerConnection
+from kombu.connection import Connection
 from kombu.messaging import Exchange, Queue
 from kombu.simple import SimpleQueue
 from amqp.exceptions import AMQPError
 import json
 
+from kombu.mixins import ConsumerMixin
+
 logging.captureWarnings(True)
 
+
+class RabbitConsumer(ConsumerMixin):
+    def __init__(self, connection, queues, handler):
+        self.connection = connection
+        self.queues = queues
+        self.handler = handler
+
+    def get_consumers(self, Consumer, channel):
+        return [
+            Consumer(self.queues, callbacks=[self.on_message], accept=['text/plain']),
+        ]
+
+    def on_message(self, body, message):
+        self.handler.handle_message(message.payload)
+        message.ack()
 
 class PypoMessageHandler(Thread):
     def __init__(self, pq, rq, config):
@@ -26,21 +43,17 @@ class PypoMessageHandler(Thread):
 
     def init_rabbit_mq(self):
         self.logger.info("Initializing RabbitMQ stuff")
-        simple_queue = None
         try:
             schedule_exchange = Exchange("airtime-pypo", "direct", durable=True, auto_delete=True)
             schedule_queue = Queue("pypo-fetch", exchange=schedule_exchange, key="foo")
-            connection = BrokerConnection(self.config["host"],
-                                          self.config["user"],
-                                          self.config["password"],
-                                          self.config["vhost"])
-
-            channel = connection.channel()
-            simple_queue = SimpleQueue(channel, schedule_queue)
+            with Connection(self.config["host"], \
+                            self.config["user"], \
+                            self.config["password"],\
+                            self.config["vhost"]) as connection:
+                rabbit = RabbitConsumer(connection, [schedule_queue], self)
+                rabbit.run()
         except Exception, e:
             self.logger.error(e)
-
-        return simple_queue
 
     """
     Handle a message from RabbitMQ, put it into our yucky global var.
@@ -89,12 +102,7 @@ class PypoMessageHandler(Thread):
 
     def main(self):
         try:
-            with self.init_rabbit_mq() as queue:
-                while True:
-                    message = queue.get(block=True)
-                    self.handle_message(message.payload)
-                    # ACK the message to take it off the queue
-                    message.ack()
+            self.init_rabbit_mq()
         except Exception, e:
             self.logger.error('Exception: %s', e)
             self.logger.error("traceback: %s", traceback.format_exc())

--- a/python_apps/pypo/pypo/pypomessagehandler.py
+++ b/python_apps/pypo/pypo/pypomessagehandler.py
@@ -48,8 +48,9 @@ class PypoMessageHandler(Thread):
             schedule_queue = Queue("pypo-fetch", exchange=schedule_exchange, key="foo")
             with Connection(self.config["host"], \
                             self.config["user"], \
-                            self.config["password"],\
-                            self.config["vhost"]) as connection:
+                            self.config["password"], \
+                            self.config["vhost"], \
+                            hearbeat = 4) as connection:
                 rabbit = RabbitConsumer(connection, [schedule_queue], self)
                 rabbit.run()
         except Exception, e:

--- a/python_apps/pypo/pypo/pypomessagehandler.py
+++ b/python_apps/pypo/pypo/pypomessagehandler.py
@@ -50,7 +50,7 @@ class PypoMessageHandler(Thread):
                             self.config["user"], \
                             self.config["password"], \
                             self.config["vhost"], \
-                            hearbeat = 4) as connection:
+                            heartbeat = 5) as connection:
                 rabbit = RabbitConsumer(connection, [schedule_queue], self)
                 rabbit.run()
         except Exception, e:

--- a/python_apps/pypo/pypo/pypopush.py
+++ b/python_apps/pypo/pypo/pypopush.py
@@ -69,7 +69,6 @@ class PypoPush(Thread):
                 media_schedule = self.queue.get(block=True)
             except Exception, e:
                 self.logger.error(str(e))
-                raise
             else:
                 self.logger.debug(media_schedule)
                 #separate media_schedule list into currently_playing and

--- a/python_apps/pypo/pypo/pypopush.py
+++ b/python_apps/pypo/pypo/pypopush.py
@@ -69,6 +69,7 @@ class PypoPush(Thread):
                 media_schedule = self.queue.get(block=True)
             except Exception, e:
                 self.logger.error(str(e))
+                raise
             else:
                 self.logger.debug(media_schedule)
                 #separate media_schedule list into currently_playing and


### PR DESCRIPTION
This fixes #906 

Finally I found out the main issue causing desynchronization between the MVC and Liquidosap was that the RabbitMQ got stale after a while (less than an hour), then schedules were only updated on PypoFetch time out.

The gotcha here is we were using a SimpleQueue, which's 'python-like' *get*  method apparently doesn't handle recovery well. Kombu Consumers are the way to go instead.