### PR TITLE
input streams on ports 8001 or 8002 break the MVC

### DIFF
--- a/airtime_mvc/application/controllers/ScheduleController.php
+++ b/airtime_mvc/application/controllers/ScheduleController.php
@@ -302,8 +302,10 @@ class ScheduleController extends Zend_Controller_Action
             $range["previous"]["ends"] = Application_Common_DateHelper::UTCStringToUserTimezoneString($range["previous"]["ends"]);
         }
         if (isset($range["current"])) {
-            $get_artwork = FileDataHelper::getArtworkData($range["current"]["metadata"]["artwork"], 256);
-            $range["current"]["metadata"]["artwork_data"] = $get_artwork;
+            if (isset($range["current"]["metadata"])) {
+                $get_artwork = FileDataHelper::getArtworkData($range["current"]["metadata"]["artwork"], 256);
+                $range["current"]["metadata"]["artwork_data"] = $get_artwork;
+            }
             $range["current"]["starts"] = Application_Common_DateHelper::UTCStringToUserTimezoneString($range["current"]["starts"]);
             $range["current"]["ends"] = Application_Common_DateHelper::UTCStringToUserTimezoneString($range["current"]["ends"]);
         }


### PR DESCRIPTION
I've found this is because of ScheduleController L305, introduced recently
https://github.com/LibreTime/libretime/commit/45dbf8475060e14a56dae4d9389ff8546a69bc09
A simple if clause allows us to workaround the issue, which must be that live streams don't have pictures nor metadata...

Fixes #919