### PR TITLE
Fix Dashboard when current instance has no metadata

### DIFF
--- a/airtime_mvc/public/js/airtime/dashboard/dashboard.js
+++ b/airtime_mvc/public/js/airtime/dashboard/dashboard.js
@@ -130,8 +130,7 @@ function updatePlaybar(){
             $('#current').html("<span style='color:red; font-weight:bold'>"+$.i18n._("Recording:")+"</span>"+currentSong.name+",");
         } else {
             $('#current').text(currentSong.name+",");
-
-            if (currentSong.metadata.artwork_data) {
+            if (currentSong.metadata && currentSong.metadata.artwork_data) {
 
                   var check_current_song = Cookies.get('current_track');
                   var loaded = Cookies.get('loaded');


### PR DESCRIPTION
The issue in the dashboard was when scheduling elements which do not have metadata (for instance, a webstream, or a live input stream). 

This basic not null check was missing in javascript .

fixes #924

may be related to #919 and #921 