### PR TITLE
change default icecast password automatically during install

### DIFF
--- a/airtime_mvc/public/setup/database-setup.php
+++ b/airtime_mvc/public/setup/database-setup.php
@@ -185,7 +185,6 @@ class DatabaseSetup extends Setup {
             throw new AirtimeDatabaseException("The Icecast Password file was not accessible", array());
        };
        $icecast_pass = file_get_contents(LIBRETIME_CONF_DIR . '/icecast_pass', true);
-       error_log($icecast_pass);
        $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's1_pass'");
        $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
        try {
@@ -193,7 +192,6 @@ class DatabaseSetup extends Setup {
            }
        catch (PDOException $ex) {
            print "Error!: " . $ex->getMessage() . "<br />";
-           die();
            }
        $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's1_admin_pass'");
        $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
@@ -202,7 +200,6 @@ class DatabaseSetup extends Setup {
            }
        catch (PDOException $ex) {
            print "Error!: " . $ex->getMessage() . "<br />";
-           die();
            }
        $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's2_pass'");
        $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
@@ -211,7 +208,6 @@ class DatabaseSetup extends Setup {
            }
        catch (PDOException $ex) {
            print "Error!: " . $ex->getMessage() . "<br />";
-           die();
            }
        $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's2_admin_pass'");
        $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
@@ -220,7 +216,6 @@ class DatabaseSetup extends Setup {
            }
        catch (PDOException $ex) {
            print "Error!: " . $ex->getMessage() . "<br />";
-           die();
            }
 
        $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's3_pass'");
@@ -230,7 +225,6 @@ class DatabaseSetup extends Setup {
            }
        catch (PDOException $ex) {
            print "Error!: " . $ex->getMessage() . "<br />";
-           die();
            }
        $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's3_admin_pass'");
        $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
@@ -239,7 +233,6 @@ class DatabaseSetup extends Setup {
            }
        catch (PDOException $ex) {
            print "Error!: " . $ex->getMessage() . "<br />";
-           die();
            }
        $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's1_admin_pass'");
        $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
@@ -248,7 +241,6 @@ class DatabaseSetup extends Setup {
            }
        catch (PDOException $ex) {
            print "Error!: " . $ex->getMessage() . "<br />";
-           die();
            }
        $statement =  self::$dbh->prepare("INSERT INTO cc_pref (keystr, valstr) VALUES ('default_icecast_password', :icecastpass )");
        $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
@@ -257,7 +249,6 @@ class DatabaseSetup extends Setup {
            }
        catch (PDOException $ex) {
            print "Error!: " . $ex->getMessage() . "<br />";
-           die();
            }
     }
 

--- a/airtime_mvc/public/setup/database-setup.php
+++ b/airtime_mvc/public/setup/database-setup.php
@@ -184,17 +184,81 @@ class DatabaseSetup extends Setup {
        if (!file_exists(LIBRETIME_CONF_DIR . '/icecast_pass')) {
             throw new AirtimeDatabaseException("The Icecast Password file was not accessible", array());
        };
-       $icecastPass = file_get_contents(LIBRETIME_CONF_DIR . '/icecast_pass', true);
-       error_log($icecastPass);
-       $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's1_pass' AND SET value = :icecastpass WHERE keyname = 's1_admin_pass'; "
-                                         . "UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's2_pass'; "
-                                         . "UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's2_admin_pass'; "
-                                         . "UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's3_pass'; "
-                                         . "UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's3_admin_pass'; "
-                                         . "INSERT INTO cc_pref (keystr, valstr) VALUES ('default_icecast_password', :icecastpass )");
-       if (!$statement->execute(array(":icecastpass" => $icecastPass))) {
-          throw new AirtimeDatabaseException("Could not update the database with icecast password!", array());
-       }
+       $icecast_pass = file_get_contents(LIBRETIME_CONF_DIR . '/icecast_pass', true);
+       error_log($icecast_pass);
+       $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's1_pass'");
+       $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
+       try {
+           $statement->execute(); 
+           }
+       catch (PDOException $ex) {
+           print "Error!: " . $ex->getMessage() . "<br />";
+           die();
+           }
+       $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's1_admin_pass'");
+       $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
+       try {
+           $statement->execute(); 
+           }
+       catch (PDOException $ex) {
+           print "Error!: " . $ex->getMessage() . "<br />";
+           die();
+           }
+       $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's2_pass'");
+       $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
+       try {
+           $statement->execute(); 
+           }
+       catch (PDOException $ex) {
+           print "Error!: " . $ex->getMessage() . "<br />";
+           die();
+           }
+       $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's2_admin_pass'");
+       $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
+       try {
+           $statement->execute(); 
+           }
+       catch (PDOException $ex) {
+           print "Error!: " . $ex->getMessage() . "<br />";
+           die();
+           }
+
+       $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's3_pass'");
+       $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
+       try {
+           $statement->execute(); 
+           }
+       catch (PDOException $ex) {
+           print "Error!: " . $ex->getMessage() . "<br />";
+           die();
+           }
+       $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's3_admin_pass'");
+       $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
+       try {
+           $statement->execute(); 
+           }
+       catch (PDOException $ex) {
+           print "Error!: " . $ex->getMessage() . "<br />";
+           die();
+           }
+       $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's1_admin_pass'");
+       $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
+       try {
+           $statement->execute(); 
+           }
+       catch (PDOException $ex) {
+           print "Error!: " . $ex->getMessage() . "<br />";
+           die();
+           }
+       $statement =  self::$dbh->prepare("INSERT INTO cc_pref (keystr, valstr) VALUES ('default_icecast_password', :icecastpass )");
+       $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
+       try {
+           $statement->execute(); 
+           }
+       catch (PDOException $ex) {
+           print "Error!: " . $ex->getMessage() . "<br />";
+           die();
+           }
     }
 
 }

--- a/airtime_mvc/public/setup/database-setup.php
+++ b/airtime_mvc/public/setup/database-setup.php
@@ -184,7 +184,10 @@ class DatabaseSetup extends Setup {
        if (!file_exists(LIBRETIME_CONF_DIR . '/icecast_pass')) {
             throw new AirtimeDatabaseException("The Icecast Password file was not accessible", array());
        };
-       $icecast_pass = file_get_contents(LIBRETIME_CONF_DIR . '/icecast_pass', true);
+       $icecast_pass_txt = file(LIBRETIME_CONF_DIR . '/icecast_pass');
+       $icecast_pass = $icecast_pass_txt[0];
+       $icecast_pass = str_replace(PHP_EOL, '', $icecast_pass);
+       error_log($icecast_pass);
        $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's1_pass'");
        $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
        try {

--- a/airtime_mvc/public/setup/database-setup.php
+++ b/airtime_mvc/public/setup/database-setup.php
@@ -79,6 +79,7 @@ class DatabaseSetup extends Setup {
         $this->setNewDatabaseConnection(self::$_properties["dbname"]);
         $this->checkSchemaExists();
         $this->createDatabaseTables();
+        $this->updateIcecastPassword();
     }
 
     /**
@@ -174,6 +175,26 @@ class DatabaseSetup extends Setup {
             throw new AirtimeDatabaseException("The database was installed with an incorrect encoding type!",
                                                array(self::DB_NAME,));
         }
+    }
+    /**
+    * Updates the icecast password in the database based upon the temp file created during install
+    * @throws AirtimeDatabaseException
+    */
+    private function updateIcecastPassword() {
+       if (!file_exists(LIBRETIME_CONF_DIR . '/icecast_pass')) {
+            throw new AirtimeDatabaseException("The Icecast Password file was not accessible", array());
+       };
+       $icecastPass = file_get_contents(LIBRETIME_CONF_DIR . '/icecast_pass', true);
+       error_log($icecastPass);
+       $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's1_pass' AND SET value = :icecastpass WHERE keyname = 's1_admin_pass'; "
+                                         . "UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's2_pass'; "
+                                         . "UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's2_admin_pass'; "
+                                         . "UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's3_pass'; "
+                                         . "UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's3_admin_pass'; "
+                                         . "INSERT INTO cc_pref (keystr, valstr) VALUES ('default_icecast_password', :icecastpass )");
+       if (!$statement->execute(array(":icecastpass" => $icecastPass))) {
+          throw new AirtimeDatabaseException("Could not update the database with icecast password!", array());
+       }
     }
 
 }

--- a/airtime_mvc/public/setup/database-setup.php
+++ b/airtime_mvc/public/setup/database-setup.php
@@ -187,7 +187,6 @@ class DatabaseSetup extends Setup {
        $icecast_pass_txt = file(LIBRETIME_CONF_DIR . '/icecast_pass');
        $icecast_pass = $icecast_pass_txt[0];
        $icecast_pass = str_replace(PHP_EOL, '', $icecast_pass);
-       error_log($icecast_pass);
        $statement =  self::$dbh->prepare("UPDATE cc_stream_setting SET value = :icecastpass WHERE keyname = 's1_pass'");
        $statement->bindValue(':icecastpass', $icecast_pass, PDO::PARAM_STR);
        try {

--- a/install
+++ b/install
@@ -891,15 +891,20 @@ if [ "$icecast" = "t" ]; then
     icecast_unit_name="icecast2"
     if [ "$dist" != "centos" ]; then
         sed -i 's/ENABLE=false/ENABLE=true/g' /etc/default/icecast2
+        icecast_config="/etc/icecast2/icecast.xml"
     else
         icecast_unit_name="icecast"
+	icecast_config="/etc/icecast.xml"
     fi
-    icecast_pass=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-12};)
-    echo $icecast_pass > /tmp/icecast_pass
-    xmlstarlet ed --inplace -u /icecast/authentication/source-password -v $icecast_pass /etc/icecast2/icecast.xml
-    xmlstarlet ed --inplace -u /icecast/authentication/relay-password -v $icecast_pass /etc/icecast2/icecast.xml
-    xmlstarlet ed --inplace -u /icecast/authentication/admin-password -v $icecast_pass /etc/icecast2/icecast.xml
-
+    # only update icecast password if 
+    if [ ! -f "/etc/airtime/airtime.conf" ]; then
+        icecast_pass=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-12};)
+        echo $icecast_pass > /tmp/icecast_pass
+        loud "\n New install detected setting icecast password to random value."
+        xmlstarlet ed --inplace -u /icecast/authentication/source-password -v $icecast_pass $icecast_config
+        xmlstarlet ed --inplace -u /icecast/authentication/relay-password -v $icecast_pass $icecast_config
+        xmlstarlet ed --inplace -u /icecast/authentication/admin-password -v $icecast_pass $icecast_config
+    fi
     # restart in case icecast was already started (like is the case on debian)
     systemInitCommand restart ${icecast_unit_name}
     verbose "...Done"
@@ -1104,10 +1109,10 @@ if [ ! -d "/etc/airtime" ]; then
 
     verbose "\n * Creating /etc/airtime/ directory..."
     mkdir /etc/airtime
+    # need to copy the icecast_pass from temp to /etc/airtime so installer can read it
+    cp /tmp/icecast_pass /etc/airtime/icecast_pass
 fi
 
-# need to copy the icecast_pass from temp to /etc/airtime so installer can read it
-    cp /tmp/icecast_pass /etc/airtime/icecast_pass
 
 
 chown -R ${web_user}:${web_user} /etc/airtime

--- a/install
+++ b/install
@@ -894,7 +894,7 @@ if [ "$icecast" = "t" ]; then
     else
         icecast_unit_name="icecast"
     fi
-    icecast_pass=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-12};echo;)
+    icecast_pass=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-12};)
     echo $icecast_pass > /tmp/icecast_pass
     xmlstarlet ed --inplace -u /icecast/authentication/source-password -v $icecast_pass /etc/icecast2/icecast.xml
     xmlstarlet ed --inplace -u /icecast/authentication/relay-password -v $icecast_pass /etc/icecast2/icecast.xml

--- a/install
+++ b/install
@@ -894,6 +894,12 @@ if [ "$icecast" = "t" ]; then
     else
         icecast_unit_name="icecast"
     fi
+    icecast_pass=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-12};echo;)
+    echo $icecast_pass > /tmp/icecast_pass
+    xmlstarlet ed --inplace -u /icecast/authentication/source-password -v $icecast_pass /etc/icecast2/icecast.xml
+    xmlstarlet ed --inplace -u /icecast/authentication/relay-password -v $icecast_pass /etc/icecast2/icecast.xml
+    xmlstarlet ed --inplace -u /icecast/authentication/admin-password -v $icecast_pass /etc/icecast2/icecast.xml
+
     # restart in case icecast was already started (like is the case on debian)
     systemInitCommand restart ${icecast_unit_name}
     verbose "...Done"
@@ -1099,6 +1105,9 @@ if [ ! -d "/etc/airtime" ]; then
     verbose "\n * Creating /etc/airtime/ directory..."
     mkdir /etc/airtime
 fi
+
+# need to copy the icecast_pass from temp to /etc/airtime so installer can read it
+    cp /tmp/icecast_pass /etc/airtime/icecast_pass
 
 
 chown -R ${web_user}:${web_user} /etc/airtime

--- a/installer/lib/requirements-debian-buster.apt
+++ b/installer/lib/requirements-debian-buster.apt
@@ -67,3 +67,5 @@ liquidsoap
 libopus0
 
 systemd-sysv
+
+xmlstarlet

--- a/installer/lib/requirements-debian-jessie.apt
+++ b/installer/lib/requirements-debian-jessie.apt
@@ -63,3 +63,5 @@ libopus0
 
 sysvinit
 sysvinit-utils
+
+xmlstarlet

--- a/installer/lib/requirements-debian-stretch.apt
+++ b/installer/lib/requirements-debian-stretch.apt
@@ -67,3 +67,5 @@ liquidsoap
 libopus0
 
 systemd-sysv
+
+xmlstarlet

--- a/installer/lib/requirements-ubuntu-bionic.apt
+++ b/installer/lib/requirements-ubuntu-bionic.apt
@@ -81,3 +81,5 @@ build-essential
 libssl-dev
 libffi-dev
 python-dev
+
+xmlstarlet

--- a/installer/lib/requirements-ubuntu-precise.apt
+++ b/installer/lib/requirements-ubuntu-precise.apt
@@ -70,3 +70,5 @@ liquidsoap-plugin-pulseaudio
 liquidsoap-plugin-taglib
 liquidsoap-plugin-voaacenc
 liquidsoap-plugin-vorbis
+
+xmlstarlet

--- a/installer/lib/requirements-ubuntu-xenial.apt
+++ b/installer/lib/requirements-ubuntu-xenial.apt
@@ -81,3 +81,5 @@ build-essential
 libssl-dev
 libffi-dev
 python-dev
+
+xmlstarlet

--- a/installer/lib/requirements-ubuntu-xenial_docker_minimal.apt
+++ b/installer/lib/requirements-ubuntu-xenial_docker_minimal.apt
@@ -76,3 +76,5 @@ build-essential
 libssl-dev
 libffi-dev
 python-dev
+
+xmlstarlet

--- a/installer/vagrant/centos.sh
+++ b/installer/vagrant/centos.sh
@@ -86,7 +86,7 @@ yum install -y \
   policycoreutils-python \
   python-celery \
   python2-pika \
-  lsof \ 
+  lsof \
   xmlstarlet
 
 # for pip ssl install

--- a/installer/vagrant/centos.sh
+++ b/installer/vagrant/centos.sh
@@ -86,7 +86,8 @@ yum install -y \
   policycoreutils-python \
   python-celery \
   python2-pika \
-  lsof
+  lsof \ 
+  xmlstarlet
 
 # for pip ssl install
 yum install -y \


### PR DESCRIPTION
This is my almost working attempt to update the default icecast password.
It fixes #86 by automagically generating a password for icecast.

I am running into an issue where the prepared PDO SQL statement to insert the password into the database doesn't appear to actually run and so there is a bug somewhere in there. 

Once I can figure that out it just needs more testing but should be ready to rock. I'm pushing it right now in case anyone wants to review it and point out what I'm doing wrong, otherwise I'll come back to it later and figure it out.