### PR TITLE
List install first in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,10 @@ pages:
   - 'Features': features.md
   - 'F.A.Q.': faq.md
   - 'Rights and Royalties': manual/rights-and-royalties/index.md
+  - 'Installation':
+    - 'Install': install.md
+    - 'Preparing the Server': manual/preparing-the-server/index.md
+    - 'Setting the Server Time': manual/setting-the-server-time/index.md
   - 'Using LibreTime':
     - 'On Air in 60 seconds!': 'manual/on-air-in-60-seconds/index.md'
     - 'Getting Started': manual/getting-started/index.md
@@ -55,10 +59,6 @@ pages:
     - 'Smartphone Journalism': manual/smartphone-journalism/index.md
     - 'Icecast and SHOUTcast': manual/icecast-and-shoutcast/index.md
     - 'Recording Shows': manual/recording-shows/index.md
-  - 'Installation':
-    - 'Install': install.md
-    - 'Preparing the Server': manual/preparing-the-server/index.md
-    - 'Setting the Server Time': manual/setting-the-server-time/index.md
   - 'Administration':
     - 'Backing Up the Server': manual/backing-up-the-server/index.md
     - 'Media Folders': manual/media-folders/index.md


### PR DESCRIPTION
The install processes is the first thing users need to do, thus list it
first