### PR TITLE
[WIP] Move CORS URLs configuration into the config file

### DIFF
--- a/airtime_mvc/application/common/CORSHelper.php
+++ b/airtime_mvc/application/common/CORSHelper.php
@@ -29,7 +29,7 @@ class CORSHelper
     {
         $allowedCorsUrls = array_map(
             function($v) { return trim($v); },
-            explode(PHP_EOL, Application_Model_Preference::GetAllowedCorsUrls())
+            explode(',', Config::getConfig()['allowed_cors_urls']))
         );
 
         // always allow the configured server in (as reported by the server and not what is i baseUrl)

--- a/airtime_mvc/application/controllers/PreferenceController.php
+++ b/airtime_mvc/application/controllers/PreferenceController.php
@@ -50,7 +50,6 @@ class PreferenceController extends Zend_Controller_Action
                 Application_Model_Preference::SetIntroPlaylist($values["introPlaylistSelect"]);
                 Application_Model_Preference::SetOutroPlaylist($values["outroPlaylistSelect"]);
                 Application_Model_Preference::SetAllow3rdPartyApi($values["thirdPartyApi"]);
-                Application_Model_Preference::SetAllowedCorsUrls($values["allowedCorsUrls"]);
                 Application_Model_Preference::SetDefaultLocale($values["locale"]);
                 Application_Model_Preference::SetDefaultTimezone($values["timezone"]);
                 Application_Model_Preference::SetWeekStartDay($values["weekStartDay"]);

--- a/airtime_mvc/application/forms/GeneralPreferences.php
+++ b/airtime_mvc/application/forms/GeneralPreferences.php
@@ -166,11 +166,13 @@ class Application_Form_GeneralPreferences extends Zend_Form_SubForm
                                         ));
         $this->addElement($third_party_api);
 
-        $allowedCorsUrlsValue = Application_Model_Preference::GetAllowedCorsUrls();
+        $config = Config::getConfig();
+        $allowedCorsUrlsValue = $config['allowed_cors_urls'];
         $allowedCorsUrls = new Zend_Form_Element_Textarea('allowedCorsUrls');
         $allowedCorsUrls->setLabel(_('Allowed CORS URLs'));
         $allowedCorsUrls->setDescription(_('Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line.'));
         $allowedCorsUrls->setValue($allowedCorsUrlsValue);
+        $allowedCorsUrls->setAttrib("readonly", true);
         $this->addElement($allowedCorsUrls);
 
         $locale = new Zend_Form_Element_Select("locale");

--- a/airtime_mvc/application/models/Preference.php
+++ b/airtime_mvc/application/models/Preference.php
@@ -1628,19 +1628,15 @@ class Application_Model_Preference
     /**
      * Getter for CORS URLs
      *
+     * DEPRECATED - CORS URLs configuration has been moved to the config file as it is required
+     * to access the instance from behind a proxy. When using a proxy, the Database setting is
+     * inaccessible. It is used in Config::loadConfig() to migrate users from the database
+     * version to the configuration file
+     *
+     * @deprecated
      * @return string
      */
     public static function GetAllowedCorsUrls() {
         return self::getValue('allowed_cors_urls');
-    }
-
-    /**
-     * Setter for CORS URLs
-     *
-     * @param string $value
-     * @return void
-     */
-    public static function SetAllowedCorsUrls($value) {
-        self::setValue('allowed_cors_urls', $value);
     }
 }


### PR DESCRIPTION
From #917, it turns out that you need the CORS URLs settings to access the CORS URLs settings. So this needs to be set before the user is able to log into LibreTime. This PR moves the configuration into the config file which means the system administrator can set it properly before running through the install guide

To do:

- [x] Move references to DB to config file
- [x] Write existing values to config file
- [ ] Fix bugs
- [ ] Document new way of setting CORS URLs