### PR TITLE
Set mutagen~=1.43.0 until LibreTime moves to python3

### DIFF
--- a/python_apps/airtime_analyzer/setup.py
+++ b/python_apps/airtime_analyzer/setup.py
@@ -28,7 +28,7 @@ setup(name='airtime_analyzer',
       packages=['airtime_analyzer'],
       scripts=['bin/airtime_analyzer'],
       install_requires=[
-          'mutagen>=1.41.1', # got rid of specific version requirement 
+          'mutagen~=1.43.0', # got rid of specific version requirement 
           'pika',
           'daemon',
           'file-magic',


### PR DESCRIPTION
This PR closes #959.

I'm not sure how to do a full blown test to ensure this works but considering the change from >=1.41. to ~=1.43.0 there's a high confidence this is safe to merge.
