### PR TITLE
Disable version notification

### DIFF
--- a/airtime_mvc/application/layouts/scripts/layout.phtml
+++ b/airtime_mvc/application/layouts/scripts/layout.phtml
@@ -9,7 +9,12 @@
 </head>
 <body>
     <div id="Panel" class="sticky">
-    <?php echo $this->versionNotify();
+    <?php
+						/*
+						NOTE: Temporarily disabled version notification to avoid confusion,
+						Users can check current version in Settings > Status.
+						*/
+						//echo $this->versionNotify();
             $sss = $this->SourceSwitchStatus();
             $scs = $this->SourceConnectionStatus();
     ?>
@@ -70,7 +75,7 @@
     <div id="nav">
         <?php echo $this->navigation()->menu(); ?>
     </div>
-        
+
     <div class="btn-group">
         <a href="<?php echo $this->baseUrl . '/login/logout'; ?>">
             <button id="add_media_btn" class="btn btn-small dashboard-btn btn-danger">


### PR DESCRIPTION
Disabled version notification to avoid confusion (plus it was getting a bit annoying), and left note. 

I wasn't getting any result for latest. Will look into it later on. For now, maybe it's best if we keep it disabled for new users. We might have to change it so this notification is visible to admins only, or perhaps remove completely since we can already see latest in Settings > Status. But that can be discussed later.