### PR TITLE
Fix postrotate command of airtime-liquidsoap

### DIFF
--- a/python_apps/pypo/liquidsoap/airtime-liquidsoap.logrotate
+++ b/python_apps/pypo/liquidsoap/airtime-liquidsoap.logrotate
@@ -6,6 +6,6 @@
   notifempty
   sharedscripts
   postrotate
-    start-stop-daemon --stop --signal USR1 --quiet --pidfile /var/run/airtime/airtime-liquidsoap.pid
+    systemctl kill --signal=SIGUSR1 airtime-liquidsoap >/dev/null 2>&1 || true
   endscript
 }


### PR DESCRIPTION
Running at least Debian Buster, the current logrotate configuration for airtime-liquidsoap put the logrotate service in failure since the postrotate command fails. As the airtime-liquidsoap script is managed by systemd, this command is replaced to use systemd to send the `SIGUSR1` signal and prevent any failure with ` || true`.