### PR TITLE
Fix source disconnection with recent Liquidsoap

### DIFF
--- a/python_apps/pypo/pypo/telnetliquidsoap.py
+++ b/python_apps/pypo/pypo/telnetliquidsoap.py
@@ -234,9 +234,9 @@ class TelnetLiquidsoap:
         self.logger.debug('Disconnecting source: %s', sourcename)
         command = ""
         if(sourcename == "master_dj"):
-            command += "master_harbor.kick\n"
+            command += "master_harbor.stop\n"
         elif(sourcename == "live_dj"):
-            command += "live_dj_harbor.kick\n"
+            command += "live_dj_harbor.stop\n"
 
         try:
             self.telnet_lock.acquire()


### PR DESCRIPTION
The `kick` command has been removed since Liquidsoap [1.3.2](https://github.com/savonet/liquidsoap/blob/master/CHANGES.md#132-02-09-2017) as it was a duplicate of `stop`. Thus, source disconnection is broken and especially the DJ one - which is quite problematic for scheduled shows.