### PR TITLE
[WIP] Add back file checking for pypo cache file using md5

### DIFF
--- a/python_apps/pypo/pypo/pypofile.py
+++ b/python_apps/pypo/pypo/pypofile.py
@@ -40,8 +40,15 @@ class PypoFile(Thread):
         dst = media_item['dst']
         src_md5 = media_item['md5']
 
+        dst_exists = False
+        try:
+            dst_exists = os.path.exists(dst)
+        except Exception as e:
+            self.logger.warning(e)
+            dst_exists = False
+
         do_copy = False
-        if os.path.exists(dst):
+        if dst_exists:
             # TODO: Check if the locally cached variant of the file is sane.
             # This used to be a filesize check that didn't end up working.
             # Once we have watched folders updated files from them might

--- a/python_apps/pypo/pypo/pypofile.py
+++ b/python_apps/pypo/pypo/pypofile.py
@@ -38,18 +38,10 @@ class PypoFile(Thread):
         """
         src = media_item['uri']
         dst = media_item['dst']
-
         src_md5 = media_item['md5']
 
-        dst_exists = False
-        try:
-            dst_exists = os.path.exists(dst)
-        except Exception, e:
-            self.logger.debug(e)
-            dst_exists = False
-
         do_copy = False
-        if dst_exists:
+        if os.path.exists(dst):
             # TODO: Check if the locally cached variant of the file is sane.
             # This used to be a filesize check that didn't end up working.
             # Once we have watched folders updated files from them might

--- a/python_apps/pypo/pypo/pypofile.py
+++ b/python_apps/pypo/pypo/pypofile.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from threading import Thread
-from Queue import Empty
-from ConfigParser import NoOptionError
+from queue import Empty
+from configparser import NoOptionError
 
 import logging
 import shutil
@@ -12,7 +12,7 @@ import os
 import sys
 import stat
 import requests
-import ConfigParser
+import configparser
 import json
 import hashlib
 from requests.exceptions import ConnectionError, HTTPError, Timeout
@@ -76,11 +76,11 @@ class PypoFile(Thread):
             baseurl = self._config.get(CONFIG_SECTION, 'base_url')
             try:
                 port = self._config.get(CONFIG_SECTION, 'base_port')
-            except NoOptionError, e:
+            except NoOptionError as e:
                 port = 80
             try:
                 protocol = self._config.get(CONFIG_SECTION, 'protocol')
-            except NoOptionError, e:
+            except NoOptionError as e:
                 protocol = str(("http", "https")[int(port) == 443])
 
             try:
@@ -110,7 +110,7 @@ class PypoFile(Thread):
                     media_item["filesize"] = file_size
 
                 media_item['file_ready'] = True
-            except Exception, e:
+            except Exception as e:
                 self.logger.error("Could not copy from %s to %s" % (src, dst))
                 self.logger.error(e)
 
@@ -179,7 +179,7 @@ class PypoFile(Thread):
 
     def read_config_file(self, config_path):
         """Parse the application's config file located at config_path."""
-        config = ConfigParser.SafeConfigParser(allow_no_value=True)
+        config = configparser.SafeConfigParser(allow_no_value=True)
         try:
             config.readfp(open(config_path))
         except IOError as e:
@@ -209,14 +209,14 @@ class PypoFile(Thread):
                     """
                     try:
                         self.media = self.media_queue.get_nowait()
-                    except Empty, e:
+                    except Empty as e:
                         pass
 
 
                 media_item = self.get_highest_priority_media_item(self.media)
                 if media_item is not None:
                     self.copy_file(media_item)
-            except Exception, e:
+            except Exception as e:
                 import traceback
                 top = traceback.format_exc()
                 self.logger.error(str(e))
@@ -228,7 +228,7 @@ class PypoFile(Thread):
         Entry point of the thread
         """
         try: self.main()
-        except Exception, e:
+        except Exception as e:
             top = traceback.format_exc()
             self.logger.error('PypoFile Exception: %s', top)
             time.sleep(5)

--- a/python_apps/pypo/pypo/pypofile.py
+++ b/python_apps/pypo/pypo/pypofile.py
@@ -39,12 +39,13 @@ class PypoFile(Thread):
         src = media_item['uri']
         dst = media_item['dst']
 
-        src_size = media_item['filesize']
+        src_md5 = media_item['md5']
 
-        dst_exists = True
+        dst_exists = False
         try:
-            dst_size = os.path.getsize(dst)
+            dst_exists = os.path.exists(dst)
         except Exception, e:
+            self.logger.debug(e)
             dst_exists = False
 
         do_copy = False
@@ -55,7 +56,14 @@ class PypoFile(Thread):
             # become an issue here... This needs proper cache management.
             # https://github.com/LibreTime/libretime/issues/756#issuecomment-477853018
             # https://github.com/LibreTime/libretime/pull/845
-            self.logger.debug("file %s already exists in local cache as %s, skipping copying..." % (src, dst))
+            with open(dst, 'rb') as file:
+                data = file.read()
+                dst_md5 = hashlib.md5(data).hexdigest()
+
+            if dst_md5 != src_md5:
+                do_copy = True
+            else:
+                self.logger.debug("file %s already exists in local cache as %s, skipping copying..." % (src, dst))
         else:
             do_copy = True
 

--- a/python_apps/pypo/pypo/pypofile.py
+++ b/python_apps/pypo/pypo/pypofile.py
@@ -38,17 +38,10 @@ class PypoFile(Thread):
         """
         src = media_item['uri']
         dst = media_item['dst']
-        src_md5 = media_item['md5']
-
-        dst_exists = False
-        try:
-            dst_exists = os.path.exists(dst)
-        except Exception as e:
-            self.logger.warning(e)
-            dst_exists = False
+        src_md5 = media_item['metadata']['md5']
 
         do_copy = False
-        if dst_exists:
+        if os.path.exists(dst):
             # TODO: Check if the locally cached variant of the file is sane.
             # This used to be a filesize check that didn't end up working.
             # Once we have watched folders updated files from them might
@@ -58,7 +51,6 @@ class PypoFile(Thread):
             with open(dst, 'rb') as file:
                 data = file.read()
                 dst_md5 = hashlib.md5(data).hexdigest()
-
             if dst_md5 != src_md5:
                 do_copy = True
             else:


### PR DESCRIPTION
The pypo scheduler used to check file size before it decided to copy a file to the pypo schedule cache folder. This appeared to cause issues mentioned in #756. PR #845 removed this check as an intermediate solution. Now that the watch folder feature is actively in development #908, we need to add file checking back to ensure that if a file is updated after it was copied to the cache, then the scheduler will copy the new file. 

As suggested in #70, I'm using the md5 of the audio file to determine whether we need to copy over the new file.

This PR is labeled WIP because I think we'll need to do some testing to ensure that #756 doesn't come back. I noticed there's a `file_ready` field and I wonder if we set that value to `False` when the file is being played by liquidsoap. If so, checking that field could be a simple way to prevent us from overwriting a file being played by liquidsoap.

