### PR TITLE
Simplified status page check to work under Debian

### DIFF
--- a/airtime_mvc/build/airtime-setup/load.php
+++ b/airtime_mvc/build/airtime-setup/load.php
@@ -113,7 +113,7 @@ function checkRMQConnection() {
  * @return boolean true if airtime-analyzer is running
  */
 function checkAnalyzerService() {
-    exec("pgrep -f -u www-data airtime_analyzer", $out, $status);
+    exec("pgrep -f airtime_analyzer", $out, $status);
     if (($out > 0) && $status == 0) {
         return posix_kill(rtrim($out[0]), 0);
     }
@@ -126,7 +126,7 @@ function checkAnalyzerService() {
  * @return boolean true if airtime-playout is running
  */
 function checkPlayoutService() {
-    exec("pgrep -f -u www-data airtime-playout", $out, $status);
+    exec("pgrep -f airtime-playout", $out, $status);
     if ($out > 0) {
         return posix_kill(rtrim($out[0]), 0);
     }
@@ -139,7 +139,7 @@ function checkPlayoutService() {
  * @return boolean true if airtime-liquidsoap is running
  */
 function checkLiquidsoapService() {
-    exec("pgrep -f -u www-data airtime-liquidsoap", $out, $status);
+    exec("pgrep -f airtime-liquidsoap", $out, $status);
     if ($out > 0) {
         return posix_kill(rtrim($out[0]), 0);
     }

--- a/airtime_mvc/build/airtime-setup/load.php
+++ b/airtime_mvc/build/airtime-setup/load.php
@@ -114,7 +114,7 @@ function checkRMQConnection() {
  */
 function checkAnalyzerService() {
     exec("pgrep -f -u www-data airtime_analyzer", $out, $status);
-    if (array_key_exists(0, $out) && $status == 0) {
+    if (($out > 0) && $status == 0) {
         return posix_kill(rtrim($out[0]), 0);
     }
     return $status == 0;
@@ -127,7 +127,7 @@ function checkAnalyzerService() {
  */
 function checkPlayoutService() {
     exec("pgrep -f -u www-data airtime-playout", $out, $status);
-    if (array_key_exists(0, $out) && $status == 0) {
+    if ($out > 0) {
         return posix_kill(rtrim($out[0]), 0);
     }
     return $status == 0;
@@ -140,7 +140,7 @@ function checkPlayoutService() {
  */
 function checkLiquidsoapService() {
     exec("pgrep -f -u www-data airtime-liquidsoap", $out, $status);
-    if (array_key_exists(0, $out) && $status == 0) {
+    if ($out > 0) {
         return posix_kill(rtrim($out[0]), 0);
     }
     return $status == 0;


### PR DESCRIPTION
This fixes #662 - as far as I can tell the issue in the code wasn't related to Systemd but some change I don't fully understand because I'm not sure why it was coded like this in the first place.

Basically I removed the && status == 0 and simplified the check to simply check if $out which is the command result from pgrep was greater than 0. This made it work under Debian Buster. It should work on the other systems as well but needs testing.

I wasn't sure the purpose of $status == 0 was and for some reason the array_exists check that was there previously was providing a false positive when I removed the status check.

I think that this is a simpler way of doing things and it seems to work. 

I also removed the -u www-data from the pgrep because that seemed like an unnecessary check that would make the software only work in debian based systems.