### PR TITLE
changed pages to nav due to deprecation of pages in mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ repo_url: https://github.com/LibreTime/libretime/
 extra_css:
   - '_css/term.css'
 
-pages:
+nav:
   - 'Home': index.md
   - 'What is LibreTime?': manual/index.md
   - 'Features': features.md
@@ -25,7 +25,7 @@ pages:
     - 'Preparing the Server': manual/preparing-the-server/index.md
     - 'Setting the Server Time': manual/setting-the-server-time/index.md
   - 'Using LibreTime':
-    - 'On Air in 60 seconds!': 'manual/on-air-in-60-seconds/index.md'
+    - 'On Air in 60 seconds!': manual/on-air-in-60-seconds/index.md
     - 'Getting Started': manual/getting-started/index.md
     - 'Tutorials': manual/tutorials/index.md
     - 'How-Tos': manual/howtos/index.md


### PR DESCRIPTION
This might work for #986 
Since pages was deprecated and navs is now preferred, I am wondering if switching to navs will somehow fix the broken links for tutorials.

It is a difficult thing to troubleshoot because it works on local mkdocs instances but so far the github deployed version is suddenly broken. Anyways, this shouldn't hurt and might the lack of inclusion.
