### PR TITLE
Remove facebook widget link

### DIFF
--- a/airtime_mvc/application/configs/navigation.php
+++ b/airtime_mvc/application/configs/navigation.php
@@ -57,12 +57,6 @@ $pages[] = array(
             'module'     => 'default',
             'controller' => 'embeddablewidgets',
             'action'     => 'schedule',
-        ),
-        array(
-            'label'      => _('Facebook'),
-            'module'     => 'default',
-            'controller' => 'embeddablewidgets',
-            'action'     => 'facebook',
         )
     )
 );

--- a/airtime_mvc/application/controllers/EmbeddablewidgetsController.php
+++ b/airtime_mvc/application/controllers/EmbeddablewidgetsController.php
@@ -43,6 +43,7 @@ class EmbeddableWidgetsController extends Zend_Controller_Action
         }
     }
 
+    // The Facebook widget is untested & unsupported, the widget has been removed from the navigation in navigation.php
     public function facebookAction()
     {
         Zend_Layout::getMvcInstance()->assign('parent_page', 'Widgets');


### PR DESCRIPTION
This fixes #452 in the simplest way possible, by removing the widget from the navigation. The widget would require various updates to conform with the current Facebook API and we don't have anyone who has volunteered to work on it. The other option would be to delete the code but this seems like a good first step.