### PR TITLE
Change Airtime modal to simple LibreTime intro

### DIFF
--- a/airtime_mvc/application/layouts/scripts/layout.phtml
+++ b/airtime_mvc/application/layouts/scripts/layout.phtml
@@ -179,18 +179,10 @@
                 <div id="whatsnew_video">
                     <iframe width="560" height="315" src="<?php echo UI_REVAMP_EMBED_URL ?>" frameborder="0" allowfullscreen></iframe>
                 </div>
-                <h2><?php echo _("Airtime Pro has a new look!"); ?></h2>
-                <p><?php echo _("Your favorite features are now even easier to use - and we've even
-                    added a few new ones! Check out the video above or read on to find out more."); ?></p>
-                <ul>
-                    <li><?php echo _("Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists
-                        is easier than ever."); ?></li>
-                    <li><?php echo _("We've streamlined the Airtime interface to make navigation easier. With the most important tools
-                        just a click away, you'll be on air and hands-free in no time."); ?></li>
-                    <li><?php echo _("Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."); ?></li>
-                    <li><?php echo _("The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime
-                        experience, no matter how you're connected."); ?></li>
-                </ul>
+                <h2><?php echo _("Welcome to LibreTime"); ?></h2>
+                <p><?php echo _("LibreTime is free software for radio stations built by a community.
+                You can find out more information at LibreTime.org. We are built as a fork of Airtime.
+                If you have any questions you can also go to https://discourse.libretime.org and ask them."); ?></p>
             </div>
             <button id="whatsnew_close" class="btn btn-new">OK, got it!</button>
         </div>


### PR DESCRIPTION
This fixes #783 - which only shows up currently when a new user logs in to a system that was updated from Airtime 2.5.x - we might want to put more information in here at some point but this just removes the reference to Airtime.pro