### PR TITLE
Make travis CI use 1.0 explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ jobs:
   - env: PYTHON=true
   include:
   # having the latest run as php 7.3 to do the python tests
-    php: 7.3
   - env: PYTHON=true
+    php: 7.3
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,14 @@ jobs:
   # there are some issues with phpunit as well as some deep in zf1 on 7.3
   - env: PYTHON=false
     php: 7.3
-  exclude:
-  # by excluding all of python we make way to just run python tests in one seperate instance
-  - env: PYTHON=true
   include:
   # having the latest run as php 7.3 to do the python tests
   - env: PYTHON=true
     php: 7.3
+  exclude:
+  # by excluding all of python we make way to just run python tests in one seperate instance
+  - env: PYTHON=true
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
   # there are some issues with phpunit as well as some deep in zf1 on 7.3
   - env: PYTHON=false
     php: 7.3
+jobs:
   exclude:
   # by excluding all of python we make way to just run python tests in one seperate instance
   - env: PYTHON=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,12 @@ jobs:
   exclude:
   # by excluding all of python we make way to just run python tests in one seperate instance
   - env: PYTHON=true
+    php: 5.6
+    php: 5.4
+    php: 7.0
+    php: 7.1
+    php: 7.2
+  
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: trusty
+version: ~> 1.0
 language: php
 php:
 # the latest and greatest, has some issues that are excluded below in matrix.allow_failures

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,14 @@ matrix:
   - env: PYTHON=false
     php: 7.2
   # there are some issues with phpunit as well as some deep in zf1 on 7.3
-  #- env: PYTHON=false
+  - env: PYTHON=false
     php: 7.3
   exclude:
   # by excluding all of python we make way to just run python tests in one seperate instance
   - env: PYTHON=true
   include:
-  # using latest to run python on since it will last the longest
-  - php: 7.3
+  # having php 7.0 run python tests because travisCI quit running a independent job with 7.3 and 7.0 can still run phpunit tests
+  - php: 7.0
     env: PYTHON=true
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ jobs:
     php: 7.3
   include:
   # having the latest run as php 7.3 to do the python tests
-  - env: PYTHON=true
+  - name: "python test and doc push"
+    env: PYTHON=true
     php: 7.3
   exclude:
   # by excluding all of python we make way to just run python tests in one seperate instance

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
   global:
   - ENVIRONMENT=testing
   - LIBRETIME_LOG_DIR=/tmp/log/libretime
-  matrix:
+  jobs:
   - PYTHON=false
   - PYTHON=true
-matrix:
+jobs:
   allow_failures:
   # there are currently some testing issues with DateTime precision on 7.1
   - env: PYTHON=false
@@ -33,14 +33,13 @@ matrix:
   # there are some issues with phpunit as well as some deep in zf1 on 7.3
   - env: PYTHON=false
     php: 7.3
-jobs:
   exclude:
   # by excluding all of python we make way to just run python tests in one seperate instance
   - env: PYTHON=true
   include:
-  # having php 7.0 run python tests because travisCI quit running a independent job with 7.3 and 7.0 can still run phpunit tests
-  - php: 7.0
-    env: PYTHON=true
+  # having the latest run as php 7.3 to do the python tests
+    php: 7.3
+  - env: PYTHON=true
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,21 +33,18 @@ jobs:
   # there are some issues with phpunit as well as some deep in zf1 on 7.3
   - env: PYTHON=false
     php: 7.3
-  include:
-  # having the latest run as php 7.3 to do the python tests
-  - name: "python test and doc push"
-    env: PYTHON=true
-    php: 7.3
   exclude:
-  # by excluding all of python we make way to just run python tests in one seperate instance
+  # we need to explicitly exclude python for every version of php other than 7.3 to  make way to just run python tests in one seperate instance
+  - env: PYTHON=true
+    php: 7.2
+  - env: PYTHON=true
+    php: 7.1
+  - env: PYTHON=true
+    php: 7.0
   - env: PYTHON=true
     php: 5.6
+  - env: PYTHON=true
     php: 5.4
-    php: 7.0
-    php: 7.1
-    php: 7.2
-  
-
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   - env: PYTHON=false
     php: 7.2
   # there are some issues with phpunit as well as some deep in zf1 on 7.3
-  - env: PYTHON=false
+  #- env: PYTHON=false
     php: 7.3
   exclude:
   # by excluding all of python we make way to just run python tests in one seperate instance


### PR DESCRIPTION
This is an attempt to fix #986 - as the build logs are showing warnings related to the beta travis CI 2.0 or dpl v2 command line

For instance 
```
 Build config validation
deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)
deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)
deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)
deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)
deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)
deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)
root: key matrix is an alias for jobs, using jobs
deploy: key api_key is an alias for token, using token
deploy: key github_token is an alias for token, using token
env: key matrix is an alias for jobs, using jobs
root: key matrix is an alias for jobs, using jobs
deploy: missing strategy, using the default git
root: missing os, using the default linux
deploy: key api_key is an alias for token, using token
deploy: key github_token is an alias for token, using token
env: key matrix is an alias for jobs, using jobs 
```

I don't know how to test this PR without merging it and I'm not sure it will fix the docs issue, but it might and should be easy to revert if it breaks anything.