### PR TITLE
Revert "changed pages to nav due to deprecation of pages in mkdocs"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ repo_url: https://github.com/LibreTime/libretime/
 extra_css:
   - '_css/term.css'
 
-nav:
+pages:
   - 'Home': index.md
   - 'What is LibreTime?': manual/index.md
   - 'Features': features.md
@@ -25,7 +25,7 @@ nav:
     - 'Preparing the Server': manual/preparing-the-server/index.md
     - 'Setting the Server Time': manual/setting-the-server-time/index.md
   - 'Using LibreTime':
-    - 'On Air in 60 seconds!': manual/on-air-in-60-seconds/index.md
+    - 'On Air in 60 seconds!': 'manual/on-air-in-60-seconds/index.md'
     - 'Getting Started': manual/getting-started/index.md
     - 'Tutorials': manual/tutorials/index.md
     - 'How-Tos': manual/howtos/index.md


### PR DESCRIPTION
Reverts LibreTime/libretime#1001
For some reason the current LibreTime.org site has a really goofy navigation, all pages are being built but each link has a Home under it.
Hopefully this fixes #986 