### PR TITLE
changed track type id to serial for auto increment

### DIFF
--- a/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.9.2/upgrade.sql
+++ b/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.9.2/upgrade.sql
@@ -2,7 +2,7 @@ ALTER TABLE cc_files ADD COLUMN track_type VARCHAR(16);
 
 CREATE TABLE IF NOT EXISTS "cc_track_types"
 (
-    "id" integer DEFAULT nextval('cc_track_types_id_seq'::regclass) NOT NULL,
+    "id" serial NOT NULL,
     "code" VARCHAR(16) NOT NULL,
     "type_name" VARCHAR(64),
     "description" VARCHAR(255),
@@ -24,4 +24,3 @@ INSERT INTO cc_track_types VALUES (10, 'COM', 'Commercial', 'This is used for co
 INSERT INTO cc_track_types VALUES (11, 'ITV', 'Interview', 'This is used for radio interviews', true);
 INSERT INTO cc_track_types VALUES (12, 'VTR', 'Voice Tracking', 'Also referred as robojock or taped. Make announcements without actually being in the station.', true);
 
-ALTER SEQUENCE cc_track_types_id_seq RESTART WITH 13;


### PR DESCRIPTION
This should fix the issue with auto upgrades. I tested it on Ubuntu Xenial vagrant box and the use of serial worked whereas the previous code was failing to create the DB.