### PR TITLE
Add a warning to avoid special characters in rabbitmq password

### DIFF
--- a/airtime_mvc/build/airtime-setup/forms/rabbitmq-settings.php
+++ b/airtime_mvc/build/airtime-setup/forms/rabbitmq-settings.php
@@ -16,7 +16,9 @@
     <p>
         In either case, we recommend that you change at least the default password provided -
         you can do this by running the following line from the command line:<br/>
-        <code>sudo rabbitmqctl change_password &lt;username&gt; &lt;newpassword&gt;</code>
+        <code>sudo rabbitmqctl change_password &lt;username&gt; &lt;newpassword&gt;</code><br/>
+        <strong>Notice:</strong> using special characters such as ! in your rabbitmq password will cause LibreTime to fail
+            to load properly after setup. Please use alphanumerical characters only.
     </p>
     <div id="rmqSlideToggle">
         <span><strong>Advanced </strong></span><span id="advCaret" class="caret"></span><hr/>


### PR DESCRIPTION
This kind of fixes #1026 - I tried wrapping the rabbitmq password in the conf file as a solution which allowed it to work but then the python services such as airtime_analyzer failed to read it correctly. I also considered doing jquery validation etc but didn't make much progress.

So I figured just adding a text warning in the description on the rabbitmq setup screen is a good stop-gap that should hopefully mitigate this issue some.