### PR TITLE
if the screen is small enough to have a scrollbar always go to the top

### DIFF
--- a/airtime_mvc/public/js/setup/setup-config.js
+++ b/airtime_mvc/public/js/setup/setup-config.js
@@ -117,6 +117,7 @@ function submitForm(e, obj) {
     e.preventDefault();
     var d = $(e.target).serializeArray();
     addOverlay();
+    $(".viewport").scrollTop(0);
     // Append .promise().done() rather than using a
     // callback to avoid call duplication
     $("#overlay, #loadingImage").fadeIn(500).promise().done(function() {


### PR DESCRIPTION
This should fix #984 by moving the scrollbar to the top on any new page load. Thus preventing the top of the message from being cut-off as indicated in the bug report.