### PR TITLE
Removed mkdocs build from TravisCI tests

### DIFF
--- a/travis/python.sh
+++ b/travis/python.sh
@@ -14,7 +14,3 @@ pushd python_apps/api_clients
 pip3 install -e .
 nosetests
 popd
-
-echo "Building docs..."
-mkdocs build --clean -q > /dev/null
-echo -n "done"


### PR DESCRIPTION
I'm not sure if this will disable updates of mkdocs but evidently our current mkdocs settings are not building any ways so it should fix the tests in the meantime.