### PR TITLE
Force fixed strings on grep for media-monitor

### DIFF
--- a/install
+++ b/install
@@ -768,7 +768,7 @@ loudCmd "./build.sh"
 if [ -f /etc/airtime/airtime.conf ]; then
     # TODO use VERSION or some other way to check for updates and handle
     # media-monitor case on it's own
-    OLD_CONF=$(grep "[media-monitor]" /etc/airtime/airtime.conf)
+    OLD_CONF=$(grep -F "[media-monitor]" /etc/airtime/airtime.conf || true)
     
     if [ -n "${OLD_CONF}" ]; then
         upgrade="t"


### PR DESCRIPTION
Fixes removing the config file on re-running install. This somewhat addresses LT handling upgrades badly when using `./install`. The issue was that it was grepping for `[media-monitor]`, which was being interpreted as a regular expression, and so matching lines with any of those digits in them. Thus, it always thought it needed to migrate from media-monitor and scrap the old config file