### PR TITLE
Corrupt Cover Art prohibits mp3 upload

### DIFF
--- a/airtime_mvc/application/common/FileDataHelper.php
+++ b/airtime_mvc/application/common/FileDataHelper.php
@@ -394,16 +394,18 @@ class FileDataHelper {
               $im = @imagecreatefromjpeg($get_cont);
           }
 
-          if ($size){
-            $im = imagescale($im , $size);
-          }
-
-          if(!$im) {
+          // if one of those bombs, create an error image instead
+          if (!$im) {
               $im  = imagecreatetruecolor(150, 30);
               $bgc = imagecolorallocate($im, 255, 255, 255);
               $tc  = imagecolorallocate($im, 0, 0, 0);
               imagefilledrectangle($im, 0, 0, 150, 30, $bgc);
-              imagestring($im, 1, 5, 5, 'Error loading ' . $imgname, $tc);
+              imagestring($im, 1, 5, 5, 'Error loading ' . $converted_filename, $tc);
+          }
+        
+          // scale if appropriate
+          if ($size){
+            $im = imagescale($im , $size);
           }
 
           $img = $im;


### PR DESCRIPTION
Don't throw an exception on corrupted cover art image data in upload. The order of processing needs to be the other way around.