### PR TITLE
Docs Kramdown dependency bump to 2.3.0

### DIFF
--- a/docs/gemfile
+++ b/docs/gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'kramdown', '~> 2.2', '>= 2.2.1'
+gem 'kramdown', '>= 2.3.0'
 
 gem 'jekyll', '~> 4.1'


### PR DESCRIPTION
Bump kramdown dependency to 2.3.0 to address https://github.com/advisories/GHSA-mqm2-cgpr-p4m6

~Do not prompt for confirmation in install of packages required for docs as this breaks Vagrant~