### PR TITLE
Fix replaygain_analyzer in Python 3.5

### DIFF
--- a/python_apps/airtime_analyzer/airtime_analyzer/replaygain_analyzer.py
+++ b/python_apps/airtime_analyzer/airtime_analyzer/replaygain_analyzer.py
@@ -21,7 +21,7 @@ class ReplayGainAnalyzer(Analyzer):
         command = [ReplayGainAnalyzer.REPLAYGAIN_EXECUTABLE, '-d', filename]
         try:
             results = subprocess.check_output(command, stderr=subprocess.STDOUT,
-                                              close_fds=True, text=True)
+                                              close_fds=True, universal_newlines=True)
             gain_match = r'Calculating Replay Gain information \.\.\.(?:\n|.)*?:([\d.-]*) dB'
             replaygain = re.search(gain_match, results).group(1)
             metadata['replay_gain'] = float(replaygain)


### PR DESCRIPTION
'text' argument was added in Python 3.7 as an alias of 'universal_newlines'. Using 'universal_newlines' works on Python 3.5/3.6 and should be forward-compatible.