### PR TITLE
Fix Ubuntu condition checking for add-apt-repository

### DIFF
--- a/install
+++ b/install
@@ -712,7 +712,7 @@ if [ "$ignore_dependencies" = "f" ]; then
     loud "         * Installing External Dependencies *        "
     loud "-----------------------------------------------------"
     
-    if [ $is_ubuntu_dist ]; then
+    if $is_ubuntu_dist; then
     	loudCmd "add-apt-repository -y ppa:libretime/libretime"
     	fi
 


### PR DESCRIPTION
The way those variables are formatted, the `[` and `]` surrounding the condition make them evaluate incorrectly