### PR TITLE
Docs: Add live-broadcast to interface category

### DIFF
--- a/docs/_docs/live-broadcast.md
+++ b/docs/_docs/live-broadcast.md
@@ -2,7 +2,7 @@
 layout: article
 title: Broadcasting live with MIXXX or B.U.T.T.
 git: live-broadcast.md
-category: dj
+category: interface
 ---
 
 ## Live shows with MIXXX {#mixxx}


### PR DESCRIPTION
It wasn't being shown in the links on the website