### PR TITLE
fix: update to CentOS 8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,7 @@ Vagrant.configure("2") do |config|
     provision_libretime(os, "debian.sh", installer_args)
   end
   config.vm.define "centos" do |os|
-    os.vm.box = 'centos/7'
+    os.vm.box = 'centos/8'
     provision_libretime(os, "centos.sh", installer_args + "--selinux")
   end
 

--- a/airtime_mvc/application/upgrade/Upgrades.php
+++ b/airtime_mvc/application/upgrade/Upgrades.php
@@ -239,12 +239,12 @@ abstract class AirtimeUpgrader
     }
 
     protected function _runUpgrade() {
-        passthru("export PGPASSWORD=".$this->password." && psql -h ".$this->host." -U ".$this->username." -q -f ".$this->_dir."/upgrade_sql/airtime_"
+        passthru("export PGPASSWORD=".$this->password." && /usr/bin/psql -h ".$this->host." -U ".$this->username." -q -f ".$this->_dir."/upgrade_sql/airtime_"
                  .$this->getNewVersion()."/upgrade.sql ".$this->database." 2>&1 | grep -v -E \"will create implicit sequence|will create implicit index\"");
     }
 
     protected function _runDowngrade() {
-        passthru("export PGPASSWORD=".$this->password." && psql -h ".$this->host." -U ".$this->username." -q -f ".$this->_dir."/downgrade_sql/airtime_"
+        passthru("export PGPASSWORD=".$this->password." && /usr/bin/psql -h ".$this->host." -U ".$this->username." -q -f ".$this->_dir."/downgrade_sql/airtime_"
                  .$this->getNewVersion()."/downgrade.sql ".$this->database." 2>&1 | grep -v -E \"will create implicit sequence|will create implicit index\"");
     }
 

--- a/airtime_mvc/public/setup/database-setup.php
+++ b/airtime_mvc/public/setup/database-setup.php
@@ -152,7 +152,7 @@ class DatabaseSetup extends Setup {
                  * have multiple issues; they similarly die on any SQL errors, fail to read in multi-line
                  * commands, and fail on any unescaped ? or $ characters.
                  */
-                exec("export PGPASSWORD=" . self::$_properties["dbpass"] . " && psql -U " . self::$_properties["dbuser"]
+                exec("export PGPASSWORD=" . self::$_properties["dbpass"] . " && /usr/bin/psql -U " . self::$_properties["dbuser"]
                      . " --dbname " . self::$_properties["dbname"] . " -h " . self::$_properties["host"]
                      . " -f $sqlDir$f 2>/dev/null", $out, $status);
             } catch (Exception $e) {

--- a/airtime_mvc/tests/application/helpers/AirtimeInstall.php
+++ b/airtime_mvc/tests/application/helpers/AirtimeInstall.php
@@ -166,7 +166,7 @@ class AirtimeInstall
         echo " * Creating Airtime database user".PHP_EOL;
         $username = $CC_CONFIG['dsn']['username'];
         $password = $CC_CONFIG['dsn']['password'];
-        $command = "echo \"CREATE USER $username ENCRYPTED PASSWORD '$password' LOGIN CREATEDB NOCREATEUSER;\" | su postgres -c psql 2>/dev/null";
+        $command = "echo \"CREATE USER $username ENCRYPTED PASSWORD '$password' LOGIN CREATEDB NOCREATEUSER;\" | su postgres -c /usr/bin/psql 2>/dev/null";
         @exec($command, $output, $results);
         if ($results == 0) {
             echo "  * Database user '{$CC_CONFIG['dsn']['username']}' created.".PHP_EOL;
@@ -230,7 +230,7 @@ class AirtimeInstall
         $dir = self::GetAirtimeSrcDir()."/build/sql/";
         $files = array("schema.sql", "sequences.sql", "views.sql", "triggers.sql", "defaultdata.sql");
         foreach ($files as $f){
-            $command = "export PGPASSWORD=$p_dbpasswd && psql --username $p_dbuser --dbname $p_dbname --host $p_dbhost --file $dir$f 2>&1";
+            $command = "export PGPASSWORD=$p_dbpasswd && /usr/bin/psql --username $p_dbuser --dbname $p_dbname --host $p_dbhost --file $dir$f 2>&1";
             @exec($command, $output, $results);
         }
         AirtimeInstall::$databaseTablesCreated = true;

--- a/docs/_docs/vagrant.md
+++ b/docs/_docs/vagrant.md
@@ -94,10 +94,10 @@ offers the option to choose a different operation system according to you needs.
 | OS     | Command             | Comment |
 | ------ | ------------------- | ------- |
 | Debian 10   | `vagrant up debian-buster`  | Install on Debian Buster. |
-| Debian 9   | `vagrant up debian-stretch` | Install on current Debian Stretch. Needs manual intervention due to Liquidsoap 1.3.3. |
+| Debian 9   | `vagrant up debian-stretch` | Install on current Debian Stretch. |
 | Ubuntu 18.04 | `vagrant up ubuntu-bionic`  | Install on current Ubuntu Bionic Beaver. |
 | Ubuntu 16.04 | `vagrant up ubuntu-xenial`  | Install on Ubuntu Xenial Xerus. |
-| CentOS | `vagrant up centos` | Extremely experimental install on 7.3 with native systemd support and activated SELinux. Needs manual intervention due to Liquidsoap 1.3.3. |
+| CentOS | `vagrant up centos` | CentOS 8 with native systemd support and activated SELinux. |
 
 ## Troubleshooting
 

--- a/install
+++ b/install
@@ -698,12 +698,12 @@ verbose "Using distribution id \"$dist\", release code \"$code\""
 systemInitDetect
 
 if $is_centos_dist; then
-    python_bin="python3"
+    python_bin="python3.8"
     apache_bin="httpd"
     apache_service="httpd"
     web_user="${web_user:-apache}"
 else
-    python_bin="python"
+    python_bin="python3"
     apache_bin="apache2ctl"
     apache_service="apache2"
     web_user="${web_user:-www-data}"

--- a/install
+++ b/install
@@ -624,6 +624,7 @@ is_ubuntu_bionic=false
 is_ubuntu_xenial=false
 is_centos_dist=false
 is_centos_7=false
+is_centos_8=false
 # Use specified distribution and release or detected otherwise.
 dist="${dist:-$ID}"
 code="${code:-$VERSION_ID}"
@@ -682,9 +683,9 @@ case "${dist}-${code}" in
         echo -e "The LibreTime installer dropped support for installing LibreTime on Wheezy in 3.0.0-alpha.6." >&2
         exit 1
         ;;
-    centos-7)
+    centos-8)
         is_centos_dist=true
-        is_centos_7=true
+        is_centos_8=true
         ;;
     *)
         echo -e "ERROR: Distribution \"$PRETTY_NAME\" is not supported with \"${dist}-${code}\"!" >&2
@@ -697,10 +698,12 @@ verbose "Using distribution id \"$dist\", release code \"$code\""
 systemInitDetect
 
 if $is_centos_dist; then
+    python_bin="python3"
     apache_bin="httpd"
     apache_service="httpd"
     web_user="${web_user:-apache}"
 else
+    python_bin="python"
     apache_bin="apache2ctl"
     apache_service="apache2"
     web_user="${web_user:-www-data}"
@@ -957,11 +960,11 @@ loud "\n-----------------------------------------------------"
 loud "          * Installing Airtime Services *            "
 loud "-----------------------------------------------------"
 
-python_version=$(python3 --version 2>&1 | awk '{ print $2 }')
+python_version=$($python_bin --version 2>&1 | awk '{ print $2 }')
 verbose "Detected Python version: $python_version"
 
 verbose "\n * Installing necessary python services..."
-loudCmd "pip3 install setuptools --upgrade"
+loudCmd "$python_bin -mpip install setuptools --upgrade"
 verbose "...Done"
 
 verbose "\n * Creating /run/airtime..."
@@ -984,11 +987,11 @@ if [ ! -d /var/log/airtime ]; then
 fi
 
 verbose "\n * Installing API client..."
-loudCmd "python3 ${AIRTIMEROOT}/python_apps/api_clients/setup.py install --install-scripts=/usr/bin"
+loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/api_clients/setup.py install --install-scripts=/usr/bin"
 verbose "...Done"
 
 verbose "\n * Installing pypo and liquidsoap..."
-loudCmd "python3 ${AIRTIMEROOT}/python_apps/pypo/setup.py install --install-scripts=/usr/bin --no-init-script"
+loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/pypo/setup.py install --install-scripts=/usr/bin --no-init-script"
 loudCmd "mkdir -p /var/log/airtime/{pypo,pypo-liquidsoap} /var/tmp/airtime/pypo/{cache,files,tmp} /var/tmp/airtime/show-recorder/"
 loudCmd "chown -R ${web_user}:${web_user} /var/log/airtime/{pypo,pypo-liquidsoap} /var/tmp/airtime/pypo/{cache,files,tmp} /var/tmp/airtime/show-recorder/"
 systemInitInstall libretime-liquidsoap $web_user
@@ -996,7 +999,7 @@ systemInitInstall libretime-playout $web_user
 verbose "...Done"
 
 verbose "\n * Installing airtime-celery..."
-loudCmd "python3 ${AIRTIMEROOT}/python_apps/airtime-celery/setup.py install --no-init-script"
+loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/airtime-celery/setup.py install --no-init-script"
 # Create the Celery user
 if $is_centos_dist; then
     loudCmd "id celery 2>/dev/null || adduser --no-create-home -c 'LibreTime Celery' -r celery || true"
@@ -1012,7 +1015,7 @@ systemInitInstall libretime-celery
 verbose "...Done"
 
 verbose "\n * Installing airtime_analyzer..."
-loudCmd "python3 ${AIRTIMEROOT}/python_apps/airtime_analyzer/setup.py install --install-scripts=/usr/bin --no-init-script"
+loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/airtime_analyzer/setup.py install --install-scripts=/usr/bin --no-init-script"
 systemInitInstall libretime-analyzer $web_user
 verbose "...Done"
 

--- a/installer/vagrant/centos.sh
+++ b/installer/vagrant/centos.sh
@@ -3,16 +3,21 @@
 # Additional Repos
 yum install -y epel-release
 
-# Nux Dextop
-yum install -y http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+# RPMfusion (for ffmpeg) - needs PowerTools
+dnf install -y https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
+dnf config-manager --enable powertools
+
+# xiph multimedia (for icecast)
+curl -o /etc/yum.repos.d/multimedia:xiph.repo \
+    https://download.opensuse.org/repositories/multimedia:/xiph/CentOS_8/multimedia:xiph.repo
 
 # RaBe Liquidsoap Distribution (RaBe LSD)
 curl -o /etc/yum.repos.d/home:radiorabe:liquidsoap.repo \
-    http://download.opensuse.org/repositories/home:/radiorabe:/liquidsoap/CentOS_7/home:radiorabe:liquidsoap.repo
+    https://download.opensuse.org/repositories/home:/radiorabe:/liquidsoap/CentOS_8/home:radiorabe:liquidsoap.repo
 
 # RaBe Audio Packages for Enterprise Linux (RaBe APEL)
 curl -o /etc/yum.repos.d/home:radiorabe:audio.repo \
-    http://download.opensuse.org/repositories/home:/radiorabe:/audio/CentOS_7/home:radiorabe:audio.repo
+    https://download.opensuse.org/repositories/home:/radiorabe:/audio/CentOS_8/home:radiorabe:audio.repo
 
 # Update all the things (just to be sure we are on latest)
 yum update -y
@@ -20,13 +25,13 @@ yum update -y
 # Database
 yum install -y postgresql-server patch
 
-postgresql-setup initdb
+postgresql-setup --initdb
 
 patch -f /var/lib/pgsql/data/pg_hba.conf << EOD
---- /var/lib/pgsql/data/pg_hba.conf.orig2016-09-01 20:45:11.364000000 -0400
-+++ /var/lib/pgsql/data/pg_hba.conf2016-09-01 20:46:17.939000000 -0400
+--- pg_hba.conf.orig	2020-12-19 13:10:46.828960307 +0000
++++ pg_hba.conf	2020-12-19 13:11:37.356290128 +0000
 @@ -78,10 +78,11 @@
-
+ 
  # "local" is for Unix domain socket connections only
  local   all             all                                     peer
 +local   all             all                                     md5
@@ -38,7 +43,7 @@ patch -f /var/lib/pgsql/data/pg_hba.conf << EOD
 +host    all             all             ::1/128                 md5
  # Allow replication connections from localhost, by a user with the
  # replication privilege.
- #local   replication     postgres                                peer
+ local   replication     all                                     peer
 EOD
 
 systemctl enable postgresql
@@ -55,6 +60,7 @@ echo "GRANT ALL PRIVILEGES ON DATABASE airtime TO airtime;" | su -l postgres bas
 
 
 # RabbitMQ
+curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh | sudo bash
 yum install -y rabbitmq-server
 
 systemctl enable rabbitmq-server
@@ -65,44 +71,56 @@ rabbitmqctl add_vhost /airtime
 rabbitmqctl set_permissions -p /airtime airtime ".*" ".*" ".*"
 
 # LibreTime deps
-# TODO: move me to requirements-file ala debian e.a.
+# some of these are needed to build pip deps and as such should no be installed
+# on production grade systems (mostly the -devel packages)
 yum install -y \
+  cairo-gobject-devel \
+  gcc \
   git \
+  glib2-devel \
+  gobject-introspection-devel \
+  openssl-devel \
   php \
   php-xml \
   php-pdo \
   php-pgsql \
   php-bcmath \
   php-mbstring \
+  php-json \
+  php-process \
+  python36-devel \
   httpd \
-  fdk-aac \
-  liquidsoap \
-  silan \
-  ecasound \
-  alsa-utils \
   icecast \
-  python-pip \
+  liquidsoap \
+  alsa-utils \
   selinux-policy \
-  policycoreutils-python \
-  python-celery \
-  python2-pika \
+  policycoreutils-python-utils \
   lsof \
   xmlstarlet
 
-# for pip ssl install
-yum install -y \
-  gcc \
-  python-devel \
-  python-lxml \
-  openssl-devel
+# replace icecast init system with proper systemd unit ("ported" from CentOS 7)
+cat > /etc/systemd/system/icecast.service << 'EOD'
+[Unit]
+Description=Icecast Network Audio Streeaming Server
+After=network.target
 
+[Service]
+ExecStart=/usr/bin/icecast -c /etc/icecast.xml
+ExecReload=/bin/kill -HUP $MAINPID
 
+[Install]
+WantedBy=multi-user.target
+EOD
+
+# install manually since it isn't required somewhere later
+python3 -mpip install pycairo
 
 # SELinux Setup
 setsebool -P httpd_can_network_connect 1
 setsebool -P httpd_can_network_connect_db 1
 setsebool -P httpd_execmem on # needed by liquidsoap to do stuff when called by php
 setsebool -P httpd_use_nfs 1 # to get nfs mounted /vagrant
+setsebool -P httpd_graceful_shutdown 1 # to allow prefork to shutdown gracefully
 setsebool -P git_system_use_nfs 1 # same for git
 
 semanage port -a -t http_port_t -p tcp 9080 # default vagrant web port
@@ -117,10 +135,17 @@ restorecon -Rv /vagrant /etc/airtime /srv/airtime
 # Disable default apache page
 sed -i -e 's/^/#/' /etc/httpd/conf.d/welcome.conf
 
+# Switch to prefork since CentOS will disable mod_php if we use mpm_event
+sed -i \
+  -e 's/#LoadModule mpm_prefork_module/LoadModule mpm_prefork_module/' \
+  -e 's/LoadModule mpm_event_module/#LoadModule mpm_event_module/' \
+  /etc/httpd/conf.modules.d/00-mpm.conf
+
+
 # celery will not run unless we install a specific version (https://github.com/pypa/setuptools/issues/942)
 # this will need to be figured out later on and will get overriden by the docs installer anyhow :(
-pip install setuptools==33.1.1
-pip freeze setuptools==33.1.1
+pip3 install setuptools==33.1.1
+pip3 freeze setuptools==33.1.1
 
 # the web will fail badly if this is not set, using my personal default just because
 echo 'date.timezone=Europe/Zurich' >> /etc/php.d/timezone.ini


### PR DESCRIPTION
Update CentOS Vagrant environment to CentOS 8. The changes to the database routines work on `.deb` based platforms as well, everything else is specific only to the `centos.sh` Vagrant init script.

Fix #1113 