### PR TITLE
Removed HTTPS condition from source of player

### DIFF
--- a/airtime_mvc/application/views/scripts/embed/player.phtml
+++ b/airtime_mvc/application/views/scripts/embed/player.phtml
@@ -21,7 +21,7 @@
             this.settings = {
                 'elementId': id_element,    // leave alone
                 'autoplay': false,          // or true (only works on some browsers)
-                'forceHTTPS': true,         // or true if the stream is in SSL (beware of the listening port, usually 8000)
+                'forceHTTPS': false,         // or true if the stream is in SSL (beware of the listening port, usually 8000)
                 'replacePort':false,        // false for disabled or '8000' as the usual start port, forces to specify replacePortTo.
                 'replacePortTo':''          // either '' to use the default port of the browser (80/http, 443/https) or '8443' to force the port of the stream.
             };


### PR DESCRIPTION
ForceHTTPS = false ; It was causing issues on fresh install where the player would not play from the mountpoint because of https conditon.