### PR TITLE
fix(centos): update to python 3.8 and install psycopg

### DIFF
--- a/installer/vagrant/centos.sh
+++ b/installer/vagrant/centos.sh
@@ -88,7 +88,8 @@ yum install -y \
   php-mbstring \
   php-json \
   php-process \
-  python36-devel \
+  python38-devel \
+  python38-psycopg2 \
   httpd \
   icecast \
   liquidsoap \


### PR DESCRIPTION
This was missing from #1139. We need to use 3.8 since it's easier to use pycairo than with 3.6 and we also install psycopg in preparation for using the CentOS vm with the Django api from #958.