### PR TITLE
Add check for deleted instance to AutoPlaylist

### DIFF
--- a/airtime_mvc/application/common/AutoPlaylistManager.php
+++ b/airtime_mvc/application/common/AutoPlaylistManager.php
@@ -97,6 +97,7 @@ class AutoPlaylistManager {
 	    $future->add(new DateInterval('PT1H'));
 	    
         return CcShowInstancesQuery::create()
+            ->filterByDbModifiedInstance(false)
             ->filterByDbStarts($now,Criteria::GREATER_THAN) 
           ->filterByDbStarts($future,Criteria::LESS_THAN)
             ->useCcShowQuery('a', 'left join')


### PR DESCRIPTION
When building list of instances with autoplaylists, filter out those where modified_instance is true.

This should resolve issue #1126.