### PR TITLE
Fix missing 'fallback' kwarg for base_port in pypofile

### DIFF
--- a/python_apps/pypo/pypo/pypofile.py
+++ b/python_apps/pypo/pypo/pypofile.py
@@ -67,7 +67,7 @@ class PypoFile(Thread):
             CONFIG_SECTION = "general"
             username = self._config.get(CONFIG_SECTION, 'api_key')
             baseurl = self._config.get(CONFIG_SECTION, 'base_url')
-            port = self._config.get(CONFIG_SECTION, 'base_port', 80)
+            port = self._config.get(CONFIG_SECTION, 'base_port', fallback=80)
             if self._config.getboolean(CONFIG_SECTION, 'force_ssl', fallback=False):
                 protocol = 'https'
             else:


### PR DESCRIPTION
This was introduced by #1165, `fallback` is a keyword only argument - see [the doc](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.get). I didn't provided any test as it seems not covered for the moment, and regarding the - amazing and uplifting - coming changes, it is maybe not needed as of now…