### PR TITLE
Do not run release on every push to master

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -2,10 +2,10 @@ name: Create Release .tar.gz
 
 on:
   push:
-    branches: [ master ]
     # Sequence of patterns matched against refs/tags
     tags:
-    - '\d+.\d+.\d+(~\s+\.\d+)*' # Originally '*', changes by @paddatrapper
+      # MAJ.MIN.BUG version with an optional -TYPE.VER (for example 3.0.0-alpha.8)
+      - '\d+.\d+.\d+(-\w+\.\d+)*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Fixes the tag regexp and removes running on pushes to master