### PR TITLE
Allow schedule times without microseconds in api_client

### DIFF
--- a/python_apps/api_clients/api_clients/utils.py
+++ b/python_apps/api_clients/api_clients/utils.py
@@ -198,5 +198,8 @@ def fromisoformat(time_string):
     only added in Python 3.7. Until LibreTime drops Python 3.6 support, this
     wrapper uses the old way of doing it.
     """
-    datetime_obj = datetime.datetime.strptime(time_string, "%H:%M:%S.%f")
+    try:
+        datetime_obj = datetime.datetime.strptime(time_string, "%H:%M:%S.%f")
+    except ValueError:
+        datetime_obj = datetime.datetime.strptime(time_string, "%H:%M:%S")
     return datetime_obj.time()

--- a/python_apps/api_clients/tests/utils_test.py
+++ b/python_apps/api_clients/tests/utils_test.py
@@ -51,6 +51,7 @@ def test_get_protocol_force_https(payload, use_config, values, expected):
     [
         ("00:00:00.500000", datetime.time(microsecond=500000)),
         ("00:04:30.092540", datetime.time(minute=4, second=30, microsecond=92540)),
+        ("00:04:30", datetime.time(minute=4, second=30)),
     ],
 )
 def test_fromisoformat(payload, expected):


### PR DESCRIPTION
Follow up fix to #1228