### PR TITLE
Simplify test workflow triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,20 +1,12 @@
 name: Python and PHP Tests
+
 on:
   push:
-    paths-ignore:
-      - "docs/**"
+    branches:
+      - master
   pull_request:
-    types:
-      [
-        opened,
-        ready_for_review,
-        review_requested,
-        edited,
-        reopened,
-        synchronize,
-      ]
-    paths-ignore:
-      - "docs/**"
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- Pre-commit should run everytime, also for documentation changes.
- Only run Test workflow on master and pullrequest against master.

Also because dependabot uses local branches and we don't want to run CI twice for a branch and pull request.