### PR TITLE
Require python-dateutil version 2.7 or higher

### DIFF
--- a/python_apps/api_clients/setup.py
+++ b/python_apps/api_clients/setup.py
@@ -21,7 +21,7 @@ setup(
     scripts=[],
     install_requires=[
         "configobj",
-        "python-dateutil",
+        "python-dateutil>=2.7.0",
     ],
     zip_safe=False,
     data_files=[],


### PR DESCRIPTION
isoparse was implemented in version 2.7