### PR TITLE
Limit pygobject version to 3.36.1 for pycairo

### DIFF
--- a/python_apps/airtime_analyzer/setup.py
+++ b/python_apps/airtime_analyzer/setup.py
@@ -24,6 +24,8 @@ setup(
         "file-magic",
         "requests>=2.7.0",
         "rgain3==1.1.0",
+        # 3.36.1 is the latest version that does not fail to find py3cairo package
+        "PyGObject>=3.34.0,<=3.36.1",
         "pycairo==1.19.1",
     ],
     zip_safe=False,


### PR DESCRIPTION
### Description

Set max version for PyGObject so that it does fail install looking for `py3cairo`.

### Testing Notes

**What I did:**

Install tested in vagrant

**How you can replicate my testing:**

Vagrant up debian-buster
