### PR TITLE
Better error handling in api_client and airtime_mvc

### DIFF
--- a/airtime_mvc/application/controllers/ApiController.php
+++ b/airtime_mvc/application/controllers/ApiController.php
@@ -1427,7 +1427,16 @@ class ApiController extends Zend_Controller_Action
 
     public function pushStreamStatsAction() {
         $request = $this->getRequest();
-        $data = json_decode($request->getParam("data"), true);
+
+        $data_blob = $request->getParam("data");
+        $data = json_decode($data_blob, true);
+
+        if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+            $message = "An error occured while decoding the 'data' JSON blob: '$data_blob'";
+            Logging::error($message);
+            $this->jsonError(400, $message);
+            return;
+        }
 
         Application_Model_ListenerStat::insertDataPoints($data);
         $this->view->data = $data;
@@ -1435,7 +1444,16 @@ class ApiController extends Zend_Controller_Action
 
     public function updateStreamSettingTableAction() {
         $request = $this->getRequest();
-        $data = json_decode($request->getParam("data"), true);
+
+        $data_blob = $request->getParam("data");
+        $data = json_decode($data_blob, true);
+
+        if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+            $message = "An error occured while decoding the 'data' JSON blob: '$data_blob'";
+            Logging::error($message);
+            $this->jsonError(400, $message);
+            return;
+        }
 
         foreach ($data as $k=>$v) {
             Application_Model_StreamSetting::SetListenerStatError($k, $v);
@@ -1710,5 +1728,19 @@ class ApiController extends Zend_Controller_Action
 
         // enable cors access from configured URLs
         CORSHelper::enableCrossOriginRequests($request, $response);
+    }
+
+    /**
+     * Respond with a JSON error message with a custom HTTP status code.
+     * 
+     * This logic should be handled by Zend, but I lack understanding of this
+     * framework, and prefer not break it or spend too much time on it.
+     */
+    private final function jsonError($status, $message)
+    {
+        $this->getResponse()
+            ->setHttpResponseCode($status)
+            ->setHeader('Content-Type', 'application/json')
+            ->setBody(json_encode(['error' => $message]));
     }
 }

--- a/python_apps/api_clients/api_clients/utils.py
+++ b/python_apps/api_clients/api_clients/utils.py
@@ -95,7 +95,7 @@ class ApiRequest:
         final_url = self.url.params(**kwargs).url()
         self.logger.debug(final_url)
         try:
-            if _post_data:
+            if _post_data is not None:
                 res = requests.post(
                     final_url,
                     data=_post_data,

--- a/python_apps/api_clients/api_clients/utils.py
+++ b/python_apps/api_clients/api_clients/utils.py
@@ -121,8 +121,9 @@ class ApiRequest:
             raise
         except requests.exceptions.HTTPError:
             self.logger.error(
-                f"HTTP request to '{res.request.url}' failed"
-                f" with status '{res.status_code}':\n{res.text}"
+                f"{res.request.method} {res.request.url} request failed '{res.status_code}':"
+                f"\nPayload: {res.request.body}"
+                f"\nResponse: {res.text}"
             )
             raise
 


### PR DESCRIPTION
Add request method and payload to api_client http error handling, as we have some obscure behavior in this area.

Let the requests library encode the JSON payload if present.

Handle bad payload in some airtime_mvc api calls: Added a basic JSON decode error safe guard for the following actions:
- pushStreamStatsAction
- updateStreamSettingTableAction

