### PR TITLE
correctly determine protocol from port and configuration in PHP

### DIFF
--- a/airtime_mvc/application/common/HTTPHelper.php
+++ b/airtime_mvc/application/common/HTTPHelper.php
@@ -32,6 +32,7 @@ class Application_Common_HTTPHelper
         $baseDir = $CC_CONFIG['baseDir'];
         $basePort = $CC_CONFIG['basePort'];
         $forceSSL = $CC_CONFIG['forceSSL'];
+        $configProtocol = $CC_CONFIG['protocol'];
         if (empty($baseDir)) {
             $baseDir = "/";
         }
@@ -42,15 +43,22 @@ class Application_Common_HTTPHelper
             $baseDir = $baseDir . "/";
         }
 
+        # Set in reverse order of preference. ForceSSL configuration takes absolute preference, then
+        # the protocol set in config. If neither are set, the port is used to determine the scheme
         $scheme = "http";
-        if ($forceSSL || ($secured && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')) {
+        if ($secured && $basePort == "443") {
             $scheme = "https";
-            $basePort = "443"; //Airtime Pro compatibility hack
+        }
+        if (!empty($configProtocol)) {
+          $scheme = $configProtocol;
+        }
+        if ($forceSSL) {
+          $scheme = "https";
         }
 
         $portStr = "";
-        if (!(($scheme == "http" && $basePort == "80")
-            || ($scheme == "https" && $basePort == "443"))) {
+        if (($scheme == "http" && $basePort !== "80")
+            || ($scheme == "https" && $basePort !== "443")) {
             $portStr = ":${basePort}";
         }
         $stationUrl = "$scheme://${baseUrl}${portStr}${baseDir}";

--- a/airtime_mvc/application/configs/conf.php
+++ b/airtime_mvc/application/configs/conf.php
@@ -31,7 +31,7 @@ class Config {
         $CC_CONFIG['basePort'] = $values['general']['base_port'];
         $CC_CONFIG['stationId'] = $values['general']['station_id'];
         $CC_CONFIG['phpDir'] = $values['general']['airtime_dir'];
-        $CC_CONFIG['forceSSL'] = isset($values['general']['force_ssl']) ? $values['general']['force_ssl'] : FALSE;
+        $CC_CONFIG['forceSSL'] = isset($values['general']['force_ssl']) ? Config::isYesValue($values['general']['force_ssl']) : FALSE;
         $CC_CONFIG['protocol'] = isset($values['general']['protocol']) ? $values['general']['protocol'] : '';
         if (isset($values['general']['dev_env'])) {
             $CC_CONFIG['dev_env'] = $values['general']['dev_env'];
@@ -107,5 +107,16 @@ class Config {
             self::loadConfig();
         }
         return self::$CC_CONFIG;
+    }
+
+    /**
+     * Check if the string is one of 'yes' or 'true' (case insensitive).
+     */
+    public static function isYesValue($value)
+    {
+        if (is_bool($value))    return $value;
+        if (!is_string($value)) return false;
+
+        return in_array(strtolower($value), ['yes', 'true']);
     }
 }

--- a/airtime_mvc/application/configs/conf.php
+++ b/airtime_mvc/application/configs/conf.php
@@ -32,6 +32,7 @@ class Config {
         $CC_CONFIG['stationId'] = $values['general']['station_id'];
         $CC_CONFIG['phpDir'] = $values['general']['airtime_dir'];
         $CC_CONFIG['forceSSL'] = isset($values['general']['force_ssl']) ? $values['general']['force_ssl'] : FALSE;
+        $CC_CONFIG['protocol'] = isset($values['general']['protocol']) ? $values['general']['protocol'] : '';
         if (isset($values['general']['dev_env'])) {
             $CC_CONFIG['dev_env'] = $values['general']['dev_env'];
         } else {

--- a/airtime_mvc/build/airtime.example.conf
+++ b/airtime_mvc/build/airtime.example.conf
@@ -33,6 +33,17 @@
 #                    on your webserver, relative to the base_url.
 #                    The default is /.
 #
+# force_ssl:         Use HTTPS for all API calls and internal links,
+#                    even if the web server is not operating on port
+#                    443. This is useful for working behind a reverse
+#                    proxy.
+#                    The default is False.
+#
+# protocol:          Set the specific protocol if required. This is
+#                    useful when using http on port 443. Mutually
+#                    exclusive with force_ssl.
+#                    Default is empty.
+#
 # cache_ahead_hours: How many hours ahead of time the Airtime playout
 #                    engine (pypo) should cache scheduled media files.
 #                    The default is 1.
@@ -54,6 +65,7 @@ base_url = localhost
 base_port = 80
 base_dir = /
 force_ssl =
+protocol = 
 cache_ahead_hours = 1
 airtime_dir =
 station_id =

--- a/airtime_mvc/tests/application/configs/ConfigTest.php
+++ b/airtime_mvc/tests/application/configs/ConfigTest.php
@@ -1,0 +1,21 @@
+<?php
+require_once "../application/configs/conf.php";
+
+class ConfigTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testIsYesValue()
+    {
+        foreach (["yes", "Yes", "True", "true", true] as $value) {
+            $this->assertEquals(Config::isYesValue($value), true);
+        }
+
+        foreach (["no", "No", "False", "false", false] as $value) {
+            $this->assertEquals(Config::isYesValue($value), false);
+        }
+
+        foreach (["", "anything", "0", 0, "1", 1, null] as $value) {
+            $this->assertEquals(Config::isYesValue($value), false);
+        }
+    }
+}


### PR DESCRIPTION
The PHP logic now matches the Python. Fixes: #1283

@Robbt would appreciate your review here, PHP is not a strong point for me

Restores #1284 