### PR TITLE
Fix installation failure on install -fap

### DIFF
--- a/install
+++ b/install
@@ -1152,9 +1152,11 @@ if [ ! -d "/etc/airtime" ]; then
     mkdir /etc/airtime
 fi
 
-if [ ! -e "/etc/airtime/airtime.conf" ] && [ ! -e "/etc/airtime/airtime.conf.tmp" ]; then
+if [ "$icecast" = "t" ]; then
+  if [ ! -e "/etc/airtime/airtime.conf" ] && [ ! -e "/etc/airtime/airtime.conf.tmp" ]; then
     # need to copy the icecast_pass from temp to /etc/airtime so web-based installer can read it
     cp /tmp/icecast_pass /etc/airtime/icecast_pass
+  fi
 fi
 
 chown -R ${web_user}:${web_user} /etc/airtime


### PR DESCRIPTION
When installing Icecast manually, we don't want the installer to interfere with the icecast.xml config file by changing the passwords.

The script fails trying to copy the Icecast password file it didn't create.


