### PR TITLE
ci: use test matrix for php and python tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,16 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.3
 
-  test-bionic:
-    runs-on: ubuntu-18.04
+  test:
+    strategy:
+      matrix:
+        include:
+          - runs-on: ubuntu-18.04
+            python-version: "3.6"
+            php-version: "7.2"
+            prerequisites-script: install-bionic.sh
+
+    runs-on: ${{ matrix.runs-on }}
     env:
       ENVIRONMENT: testing
       LIBRETIME_LOG_DIR: /tmp/log/libretime
@@ -34,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.6"
+          python-version: ${{ matrix.python-version }}
       - name: Setup PostgreSQL
         run: |
           sudo systemctl start postgresql.service
@@ -46,9 +54,9 @@ jobs:
       - name: Setup PHP with specific version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "7.2"
+          php-version: ${{ matrix.php-version }}
       - name: Install prerequisites
-        run: sudo -E ./.github/scripts/install-bionic.sh
+        run: sudo -E ./.github/scripts/${{ matrix.prerequisites-script }}
       - name: Run Python tests
         run: |
           sudo ./.github/scripts/python-pkg-install.sh


### PR DESCRIPTION
In order to simplify any CI platforms and versions addition, we should use a test matrix and add our details in it, instead of copy pasting the entire test job.

Related-To: #1168 