### PR TITLE
Rename isAlive method to is_alive

### DIFF
--- a/python_apps/pypo/pypo/timeout.py
+++ b/python_apps/pypo/pypo/timeout.py
@@ -21,7 +21,7 @@ def __timeout(func, timeout_duration, default, args, kwargs):
             timeout_duration = timeout_duration * 2
         it.join(timeout_duration)
 
-        if it.isAlive():
+        if it.is_alive():
             """Restart Liquidsoap and try the command one more time. If it
             fails again then there is something critically wrong..."""
             if first_attempt:


### PR DESCRIPTION
Python 3.9 compatibility fix.

From the following stack trace on Debian bullseye and python 3.9:
```
Aug 15 18:41:07 debian11 airtime-playout[11261]: Traceback (most recent call last):
Aug 15 18:41:07 debian11 airtime-playout[11261]:   File "/usr/bin/airtime-playout", line 4, in <module>
Aug 15 18:41:07 debian11 airtime-playout[11261]:     __import__('pkg_resources').run_script('airtime-playout==1.0', 'airtime-playout')
Aug 15 18:41:07 debian11 airtime-playout[11261]:   File "/usr/local/lib/python3.9/dist-packages/pkg_resources/__init__.py", line 651, in run_script
Aug 15 18:41:07 debian11 airtime-playout[11261]:     self.require(requires)[0].run_script(script_name, ns)
Aug 15 18:41:07 debian11 airtime-playout[11261]:   File "/usr/local/lib/python3.9/dist-packages/pkg_resources/__init__.py", line 1448, in run_script
Aug 15 18:41:07 debian11 airtime-playout[11261]:     exec(code, namespace, namespace)
Aug 15 18:41:07 debian11 airtime-playout[11261]:   File "/usr/local/lib/python3.9/dist-packages/airtime_playout-1.0-py3.9.egg/EGG-INFO/scripts/airtime-playout", line 4, in <module>
Aug 15 18:41:07 debian11 airtime-playout[11261]:     runpy.run_module("pypo", run_name="__main__")
Aug 15 18:41:07 debian11 airtime-playout[11261]:   File "/usr/lib/python3.9/runpy.py", line 213, in run_module
Aug 15 18:41:07 debian11 airtime-playout[11261]:     return _run_code(code, {}, init_globals, run_name, mod_spec)
Aug 15 18:41:07 debian11 airtime-playout[11261]:   File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
Aug 15 18:41:07 debian11 airtime-playout[11261]:     exec(code, run_globals)
Aug 15 18:41:07 debian11 airtime-playout[11261]:   File "/usr/local/lib/python3.9/dist-packages/airtime_playout-1.0-py3.9.egg/pypo/__main__.py", line 247, in <module>
Aug 15 18:41:07 debian11 airtime-playout[11261]:     liquidsoap_startup_test()
Aug 15 18:41:07 debian11 airtime-playout[11261]:   File "/usr/local/lib/python3.9/dist-packages/airtime_playout-1.0-py3.9.egg/pypo/__main__.py", line 187, in liquidsoap_startup_test
Aug 15 18:41:07 debian11 airtime-playout[11261]:     liquidsoap_version_string = liquidsoap_get_info(
Aug 15 18:41:07 debian11 airtime-playout[11261]:   File "/usr/local/lib/python3.9/dist-packages/airtime_playout-1.0-py3.9.egg/pypo/timeout.py", line 40, in new_f
Aug 15 18:41:07 debian11 airtime-playout[11261]:     return __timeout(f, timeout, default, args, kwargs)
Aug 15 18:41:07 debian11 airtime-playout[11261]:   File "/usr/local/lib/python3.9/dist-packages/airtime_playout-1.0-py3.9.egg/pypo/timeout.py", line 24, in __timeout
Aug 15 18:41:07 debian11 airtime-playout[11261]:     if it.isAlive():
Aug 15 18:41:07 debian11 airtime-playout[11261]: AttributeError: 'InterruptableThread' object has no attribute 'isAlive'
```