### PR TITLE
Fix api client v2 get schedule

### DIFF
--- a/python_apps/api_clients/api_clients/version2.py
+++ b/python_apps/api_clients/api_clients/version2.py
@@ -47,7 +47,7 @@ class AirtimeApiClient:
 
     def get_schedule(self):
         current_time = datetime.datetime.utcnow()
-        end_time = current_time + datetime.timedelta(hours=1)
+        end_time = current_time + datetime.timedelta(days=1)
 
         str_current = current_time.isoformat(timespec="seconds")
         str_end = end_time.isoformat(timespec="seconds")

--- a/python_apps/api_clients/api_clients/version2.py
+++ b/python_apps/api_clients/api_clients/version2.py
@@ -6,9 +6,9 @@
 # probably want to create a script on your server side to automatically
 # schedule a playlist one minute from the current time.
 ###############################################################################
-import datetime
 import logging
 import sys
+from datetime import datetime, timedelta
 
 from configobj import ConfigObj
 from dateutil.parser import isoparse
@@ -46,8 +46,8 @@ class AirtimeApiClient:
             sys.exit(1)
 
     def get_schedule(self):
-        current_time = datetime.datetime.utcnow()
-        end_time = current_time + datetime.timedelta(days=1)
+        current_time = datetime.utcnow()
+        end_time = current_time + timedelta(days=1)
 
         str_current = current_time.isoformat(timespec="seconds")
         str_end = end_time.isoformat(timespec="seconds")


### PR DESCRIPTION
Scheduler should prepare 1 day ahead, not 1 hour.

The old API client v1 used to call the following action, and underlying schedule model:
https://github.com/LibreTime/libretime/blob/d6093f7356d262838e866deb80439dadf3220e78/airtime_mvc/application/controllers/ApiController.php#L720-L730
https://github.com/LibreTime/libretime/blob/d6093f7356d262838e866deb80439dadf3220e78/airtime_mvc/application/models/Schedule.php#L1118-L1140

The new API v2 prepared 1 hour of scheduled track instead
of 1 day in the old  API.

Fixes #1275 