### PR TITLE
Fixing a permission bug in the install script.

### DIFF
--- a/install
+++ b/install
@@ -777,7 +777,7 @@ if [[ ! ${commandFound} -eq 0 ]]; then
 fi
 
 # Run composer (install PHP dependencies) and create a VERSION file
-loudCmd "./build.sh"
+loudCmd "bash ./build.sh"
 if [ -f /etc/airtime/airtime.conf ]; then
   # TODO use VERSION or some other way to check for updates and handle
   # media-monitor case on it's own


### PR DESCRIPTION
### Description

On a new Ubuntu 18.04 installation, the script stops when trying to execute `build.sh`. Calling `bash` to launch the script fixes the issue.

### Testing Notes

**What I did:**

I'm using my fix in order to install LibreTime on a new Ubuntu 18.04 installation.

**How you can replicate my testing:**

Install LibreTime on a new Ubuntu 18.04 installation.

### **Links**

No links.