### PR TITLE
Update styles.css

### DIFF
--- a/airtime_mvc/public/css/styles.css
+++ b/airtime_mvc/public/css/styles.css
@@ -2063,7 +2063,7 @@ span.errors.sp-errors{
 }
 .collapsible-header .arrow-icon, .collapsible-header-disabled  .arrow-icon {
     display:block;
-    background:url(images/arrows_collapse.png) no-repeat 0 0;
+    background:url(images/arrows_collapse.png) no-repeat 0 -11px;
     height:11px;
     width:11px;
     position:absolute;
@@ -2072,7 +2072,7 @@ span.errors.sp-errors{
 
 }
 .collapsible-header.closed .arrow-icon, .collapsible-header-disabled.close  .arrow-icon {
-    background-position: 0 -11px !important;
+    background-position: 0 0 !important;
 }
 #schedule-add-show .button-bar {
     height: 28px;


### PR DESCRIPTION
Fixed arrow-icon position. In the master branch, the icon arrow looks open when it'd be closed and viceversa.

### Description

This PR fixes the display of the arrow buttons on collapsible widgets

### Testing Notes

**What I did:**

Just css styling to display the arrow open and closed correctly

### **Images**
Before:
![arrow-icon-fix-before](https://user-images.githubusercontent.com/1733884/130930061-e1e9ae1a-f9b9-43f3-b69c-e63a44d333bd.png)
After:
![arrow-icon-fix-after](https://user-images.githubusercontent.com/1733884/130930112-3ae19359-0dab-4d08-a2a7-7860bf1e8b5c.png)
