### PR TITLE
Replace mock with stdlib unittest.mock

### DIFF
--- a/python_apps/airtime_analyzer/requirements-dev.txt
+++ b/python_apps/airtime_analyzer/requirements-dev.txt
@@ -1,5 +1,4 @@
 distro
-mock
 pylint
 pytest
 pytest-cov

--- a/python_apps/airtime_analyzer/tests/filemover_analyzer_test.py
+++ b/python_apps/airtime_analyzer/tests/filemover_analyzer_test.py
@@ -2,8 +2,8 @@ import os
 import shutil
 import tempfile
 import time
+from unittest import mock
 
-import mock
 import pytest
 from airtime_analyzer.filemover_analyzer import FileMoverAnalyzer
 

--- a/python_apps/airtime_analyzer/tests/metadata_analyzer_test.py
+++ b/python_apps/airtime_analyzer/tests/metadata_analyzer_test.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
+from unittest import mock
 
-import mock
 import mutagen
 import pytest
 from airtime_analyzer.metadata_analyzer import MetadataAnalyzer

--- a/python_apps/api_clients/requirements-dev.txt
+++ b/python_apps/api_clients/requirements-dev.txt
@@ -1,4 +1,3 @@
-mock
 pylint
 pytest
 pytest-cov

--- a/python_apps/api_clients/tests/apirequest_test.py
+++ b/python_apps/api_clients/tests/apirequest_test.py
@@ -1,5 +1,6 @@
+from unittest.mock import MagicMock, patch
+
 from api_clients.utils import ApcUrl, ApiRequest
-from mock import MagicMock, patch
 
 
 def test_api_request_init():


### PR DESCRIPTION
mock was merged into stdlib, we should use the stdlib instead of the mock package.