### PR TITLE
Start linting :tada: !

### DIFF
--- a/.github/annotations/pylint.json
+++ b/.github/annotations/pylint.json
@@ -1,0 +1,32 @@
+{
+  "problemMatcher": [
+    {
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^([^:]+):(\\d+):(\\d+): (E\\d+): \\033\\[[\\d;]+m([^\\033]+).*$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "code": 4,
+          "message": 5
+        }
+      ],
+      "owner": "pylint-error"
+    },
+    {
+      "severity": "warning",
+      "pattern": [
+        {
+          "regexp": "^([^:]+):(\\d+):(\\d+): ([A-DF-Z]\\d+): \\033\\[[\\d;]+m([^\\033]+).*$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "code": 4,
+          "message": 5
+        }
+      ],
+      "owner": "pylint-warning"
+    }
+  ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,31 @@ jobs:
           cd airtime_mvc/tests
           php ../../vendor/bin/phpunit
 
+  # Start lint the code without failing the entire workflow, should be merged
+  # into 'test' when the entire matrix succeeds.
+  lint:
+    runs-on: ubuntu-latest
+    container: ghcr.io/libretime/libretime-dev:buster
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Lint
+        run: |
+          make -C api lint
+          make -C python_apps/airtime_analyzer lint
+          make -C python_apps/airtime-celery lint
+          make -C python_apps/api_clients lint
+          make -C python_apps/pypo lint
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,8 +126,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [bionic, buster]
         context: [python_apps/airtime_analyzer, python_apps/api_clients]
+        release: [bionic, buster]
 
     container: ghcr.io/libretime/libretime-dev:${{ matrix.release }}
     defaults:
@@ -140,20 +140,10 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.context }}-${{ hashFiles('**/setup.py', '**/requirements-dev.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.context }}-${{ hashFiles('**/setup.py') }}
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.context }}
 
-      - name: Install dependencies
-        run: |
-          python3 -m venv venv && source venv/bin/activate
-          pip install --upgrade pip setuptools wheel
-          pip install -r requirements-dev.txt
-          pip install -e .
-        working-directory: ${{ matrix.context }}
-
       - name: Test
-        run: |
-          source venv/bin/activate
-          make test
+        run: make test
         working-directory: ${{ matrix.context }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Add annotations matchers
+        run: |
+          echo "::add-matcher::.github/annotations/pylint.json"
+
       - name: Lint
         run: |
           make -C api lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,11 +46,6 @@ repos:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
 
-  # - repo: https://github.com/pre-commit/mirrors-pylint
-  #   rev: v3.0.0a3
-  #   hooks:
-  #     - id: pylint
-
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,0 +1,9 @@
+all: lint
+
+include ../tools/python.mk
+
+PIP_INSTALL := --editable .[dev]
+PYLINT_ARG := libretimeapi
+
+lint: .pylint
+clean: .clean

--- a/api/Makefile
+++ b/api/Makefile
@@ -4,6 +4,7 @@ include ../tools/python.mk
 
 PIP_INSTALL := --editable .[dev]
 PYLINT_ARG := libretimeapi
+MYPY_ARG := libretimeapi
 
-lint: .pylint
+lint: .pylint .mypy
 clean: .clean

--- a/api/setup.py
+++ b/api/setup.py
@@ -20,6 +20,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     scripts=["bin/libretime-api"],
+    python_requires=">=3.6",
     install_requires=[
         "coreapi",
         "django~=3.0",

--- a/api/setup.py
+++ b/api/setup.py
@@ -34,6 +34,7 @@ setup(
         ],
         "dev": [
             "psycopg2-binary",
+            "mypy",
             "pylint",
         ],
     },

--- a/api/setup.py
+++ b/api/setup.py
@@ -22,11 +22,19 @@ setup(
     scripts=["bin/libretime-api"],
     install_requires=[
         "coreapi",
-        "Django~=3.0",
+        "django~=3.0",
         "djangorestframework",
         "django-url-filter",
         "markdown",
         "model_bakery",
-        "psycopg2",
     ],
+    extras_require={
+        "prod": [
+            "psycopg2",
+        ],
+        "dev": [
+            "psycopg2-binary",
+            "pylint",
+        ],
+    },
 )

--- a/python_apps/airtime-celery/Makefile
+++ b/python_apps/airtime-celery/Makefile
@@ -4,6 +4,7 @@ include ../../tools/python.mk
 
 PIP_INSTALL := --editable .[dev]
 PYLINT_ARG := airtime-celery
+MYPY_ARG := airtime-celery
 
-lint: .pylint
+lint: .pylint .mypy
 clean: .clean

--- a/python_apps/airtime-celery/Makefile
+++ b/python_apps/airtime-celery/Makefile
@@ -1,0 +1,9 @@
+all: lint
+
+include ../../tools/python.mk
+
+PIP_INSTALL := --editable .[dev]
+PYLINT_ARG := airtime-celery
+
+lint: .pylint
+clean: .clean

--- a/python_apps/airtime-celery/setup.py
+++ b/python_apps/airtime-celery/setup.py
@@ -18,6 +18,7 @@ setup(
     },
     license="MIT",
     packages=["airtime-celery"],
+    python_requires=">=3.6",
     install_requires=[
         "celery==4.4.7",
         "kombu==4.6.10",

--- a/python_apps/airtime-celery/setup.py
+++ b/python_apps/airtime-celery/setup.py
@@ -23,5 +23,11 @@ setup(
         "kombu==4.6.10",
         "configobj",
     ],
+    extras_require={
+        "prod": [],
+        "dev": [
+            "pylint",
+        ],
+    },
     zip_safe=False,
 )

--- a/python_apps/airtime-celery/setup.py
+++ b/python_apps/airtime-celery/setup.py
@@ -26,6 +26,7 @@ setup(
     extras_require={
         "prod": [],
         "dev": [
+            "mypy",
             "pylint",
         ],
     },

--- a/python_apps/airtime_analyzer/Makefile
+++ b/python_apps/airtime_analyzer/Makefile
@@ -1,19 +1,15 @@
-.PHONY: lint test
+all: lint test
 
-SHELL := bash
-CPU_CORES := $(shell nproc)
+include ../../tools/python.mk
 
-MODULE_APP := airtime_analyzer
-MODULE_TESTS := tests
+PIP_INSTALL := --editable .[dev]
+PYLINT_ARG := airtime_analyzer tests
+PYTEST_ARG := --cov=airtime_analyzer tests
 
-lint:
-	pylint ${MODULE_APP}
-	pylint ${MODULE_TESTS}
+lint: .pylint
 
 fixtures:
 	bash tests/fixtures/generate.sh
 
-test: fixtures
-	pytest -n ${CPU_CORES} --color=yes -v --cov=${MODULE_APP} ${MODULE_TESTS}
-
-all: lint test
+test: fixtures .pytest
+clean: .clean

--- a/python_apps/airtime_analyzer/Makefile
+++ b/python_apps/airtime_analyzer/Makefile
@@ -4,9 +4,10 @@ include ../../tools/python.mk
 
 PIP_INSTALL := --editable .[dev]
 PYLINT_ARG := airtime_analyzer tests
+MYPY_ARG := airtime_analyzer tests
 PYTEST_ARG := --cov=airtime_analyzer tests
 
-lint: .pylint
+lint: .pylint .mypy
 
 fixtures:
 	bash tests/fixtures/generate.sh

--- a/python_apps/airtime_analyzer/requirements-dev.txt
+++ b/python_apps/airtime_analyzer/requirements-dev.txt
@@ -1,5 +1,0 @@
-distro
-pylint
-pytest
-pytest-cov
-pytest-xdist

--- a/python_apps/airtime_analyzer/setup.py
+++ b/python_apps/airtime_analyzer/setup.py
@@ -23,6 +23,7 @@ setup(
             "libretime-analyzer=airtime_analyzer.cli:main",
         ]
     },
+    python_requires=">=3.6",
     install_requires=[
         "mutagen>=1.31.0",
         "pika>=1.0.0",

--- a/python_apps/airtime_analyzer/setup.py
+++ b/python_apps/airtime_analyzer/setup.py
@@ -37,6 +37,7 @@ setup(
         "prod": [],
         "dev": [
             "distro",
+            "mypy",
             "pylint",
             "pytest",
             "pytest-cov",

--- a/python_apps/airtime_analyzer/setup.py
+++ b/python_apps/airtime_analyzer/setup.py
@@ -33,5 +33,15 @@ setup(
         # If this version is changed, it needs changing in the install script too
         "pycairo==1.19.1",
     ],
+    extras_require={
+        "prod": [],
+        "dev": [
+            "distro",
+            "pylint",
+            "pytest",
+            "pytest-cov",
+            "pytest-xdist",
+        ],
+    },
     zip_safe=False,
 )

--- a/python_apps/api_clients/Makefile
+++ b/python_apps/api_clients/Makefile
@@ -1,16 +1,11 @@
-.PHONY: lint test
-
-SHELL := bash
-CPU_CORES := $(shell nproc)
-
-MODULE_APP := api_clients
-MODULE_TESTS := tests
-
-lint:
-	pylint ${MODULE_APP}
-	pylint ${MODULE_TESTS}
-
-test:
-	pytest -n ${CPU_CORES} --color=yes -v --cov=${MODULE_APP} ${MODULE_TESTS}
-
 all: lint test
+
+include ../../tools/python.mk
+
+PIP_INSTALL := --editable .[dev]
+PYLINT_ARG := api_clients tests
+PYTEST_ARG := --cov=api_clients tests
+
+lint: .pylint
+test: .pytest
+clean: .clean

--- a/python_apps/api_clients/Makefile
+++ b/python_apps/api_clients/Makefile
@@ -4,8 +4,9 @@ include ../../tools/python.mk
 
 PIP_INSTALL := --editable .[dev]
 PYLINT_ARG := api_clients tests
+MYPY_ARG := api_clients tests
 PYTEST_ARG := --cov=api_clients tests
 
-lint: .pylint
+lint: .pylint .mypy
 test: .pytest
 clean: .clean

--- a/python_apps/api_clients/requirements-dev.txt
+++ b/python_apps/api_clients/requirements-dev.txt
@@ -1,4 +1,0 @@
-pylint
-pytest
-pytest-cov
-pytest-xdist

--- a/python_apps/api_clients/setup.py
+++ b/python_apps/api_clients/setup.py
@@ -18,6 +18,7 @@ setup(
     },
     license="AGPLv3",
     packages=["api_clients"],
+    python_requires=">=3.6",
     install_requires=[
         "configobj",
         "python-dateutil>=2.7.0",

--- a/python_apps/api_clients/setup.py
+++ b/python_apps/api_clients/setup.py
@@ -26,6 +26,7 @@ setup(
     extras_require={
         "prod": [],
         "dev": [
+            "mypy",
             "pylint",
             "pytest",
             "pytest-cov",

--- a/python_apps/api_clients/setup.py
+++ b/python_apps/api_clients/setup.py
@@ -23,5 +23,14 @@ setup(
         "python-dateutil>=2.7.0",
         "requests",
     ],
+    extras_require={
+        "prod": [],
+        "dev": [
+            "pylint",
+            "pytest",
+            "pytest-cov",
+            "pytest-xdist",
+        ],
+    },
     zip_safe=False,
 )

--- a/python_apps/pypo/Makefile
+++ b/python_apps/pypo/Makefile
@@ -4,6 +4,7 @@ include ../../tools/python.mk
 
 PIP_INSTALL := --editable .[dev]
 PYLINT_ARG := liquidsoap pypo
+MYPY_ARG := liquidsoap pypo
 
-lint: .pylint
+lint: .pylint .mypy
 clean: .clean

--- a/python_apps/pypo/Makefile
+++ b/python_apps/pypo/Makefile
@@ -1,0 +1,9 @@
+all: lint
+
+include ../../tools/python.mk
+
+PIP_INSTALL := --editable .[dev]
+PYLINT_ARG := liquidsoap pypo
+
+lint: .pylint
+clean: .clean

--- a/python_apps/pypo/setup.py
+++ b/python_apps/pypo/setup.py
@@ -40,6 +40,7 @@ setup(
     extras_require={
         "prod": [],
         "dev": [
+            "mypy",
             "pylint",
         ],
     },

--- a/python_apps/pypo/setup.py
+++ b/python_apps/pypo/setup.py
@@ -27,6 +27,7 @@ setup(
         "bin/airtime-liquidsoap",
         "bin/pyponotify",
     ],
+    python_requires=">=3.6",
     install_requires=[
         "amqplib",
         "configobj",

--- a/python_apps/pypo/setup.py
+++ b/python_apps/pypo/setup.py
@@ -37,5 +37,11 @@ setup(
         "pytz",
         "requests",
     ],
+    extras_require={
+        "prod": [],
+        "dev": [
+            "pylint",
+        ],
+    },
     zip_safe=False,
 )

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -4,8 +4,9 @@ include python.mk
 
 PIP_INSTALL := -r requirements-dev.txt
 PYLINT_ARG := tools
+MYPY_ARG := .
 PYTEST_ARG := .
 
-lint: .pylint
+lint: .pylint .mypy
 test: .pytest
 clean: .clean

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,23 +1,11 @@
-.PHONY: lint test
-.ONESHELL:
-
-SHELL := bash
-CPU_CORES := $(shell nproc)
-
 all: lint test
 
-venv:
-	python3 -m venv venv
-	source venv/bin/activate
-	pip install -r requirements-dev.txt
+include python.mk
 
-lint: venv
-	source venv/bin/activate
-	pylint tools
+PIP_INSTALL := -r requirements-dev.txt
+PYLINT_ARG := tools
+PYTEST_ARG := .
 
-test: venv
-	source venv/bin/activate
-	pytest -n ${CPU_CORES} --color=yes -v .
-
-clean:
-	rm -Rf venv
+lint: .pylint
+test: .pytest
+clean: .clean

--- a/tools/python.mk
+++ b/tools/python.mk
@@ -1,0 +1,29 @@
+.ONESHELL:
+
+SHELL := bash
+CPU_CORES := $(shell nproc)
+
+# PIP_INSTALL := --editable .[dev]
+# PYLINT_ARG :=
+# PYTEST_ARG :=
+
+VENV := venv
+$(VENV):
+	python3 -m venv $(VENV)
+	source $(VENV)/bin/activate
+	pip install --upgrade pip setuptools wheel
+	pip install $(PIP_INSTALL)
+
+.PHONY: .pylint
+.pylint: $(VENV)
+	source $(VENV)/bin/activate
+	pylint --output-format=colorized $(PYLINT_ARG) || true
+
+.PHONY: .pytest
+.pytest: $(VENV)
+	source venv/bin/activate
+	pytest -n $(CPU_CORES) --color=yes -v $(PYTEST_ARG)
+
+.PHONY: .clean
+.clean:
+	rm -Rf $(VENV)

--- a/tools/python.mk
+++ b/tools/python.mk
@@ -5,6 +5,7 @@ CPU_CORES := $(shell nproc)
 
 # PIP_INSTALL := --editable .[dev]
 # PYLINT_ARG :=
+# MYPY_ARG :=
 # PYTEST_ARG :=
 
 VENV := venv
@@ -18,6 +19,11 @@ $(VENV):
 .pylint: $(VENV)
 	source $(VENV)/bin/activate
 	pylint --output-format=colorized $(PYLINT_ARG) || true
+
+.PHONY: .mypy
+.mypy: $(VENV)
+	source $(VENV)/bin/activate
+	mypy $(MYPY_ARG) || true
 
 .PHONY: .pytest
 .pytest: $(VENV)

--- a/tools/requirements-dev.txt
+++ b/tools/requirements-dev.txt
@@ -1,3 +1,4 @@
+mypy
 pylint
 pytest
 pytest-xdist


### PR DESCRIPTION
- Enhance the way we manage development dependencies (slowly moving towards pyproject.toml file structure)
- Require python >=3.6
- Use a shared makefile for python apps
- Start linting every python app ! (With github annotations !)

