### PR TITLE
Fix bad argument name, use kwargs

### DIFF
--- a/python_apps/api_clients/api_clients/version1.py
+++ b/python_apps/api_clients/api_clients/version1.py
@@ -429,12 +429,14 @@ class AirtimeApiClient(object):
     def notify_liquidsoap_status(self, msg, stream_id, time):
         logger = self.logger
         try:
-            post_data = {"msg_post": msg}
-
             # encoded_msg is no longer used server_side!!
             encoded_msg = urllib.parse.quote("dummy")
+
             self.services.update_liquidsoap_status.req(
-                post_data, msg=encoded_msg, stream_id=stream_id, boot_time=time
+                _post_data={"msg_post": msg},
+                msg=encoded_msg,
+                stream_id=stream_id,
+                boot_time=time,
             ).retry(5)
         except Exception as e:
             self.logger.exception(e)


### PR DESCRIPTION
Argument should be `_post_data` and we only allow kwargs in `ApiRequest.__call__`.