### PR TITLE
feat: create a control cli

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,7 @@ jobs:
           - analyzer
           - api
           - api_client
+          - console
           - playout
           - shared
           - worker

--- a/console/.pylintrc
+++ b/console/.pylintrc
@@ -1,0 +1,4 @@
+[MESSAGES CONTROL]
+disable=missing-module-docstring,
+        missing-class-docstring,
+        missing-function-docstring,

--- a/console/Makefile
+++ b/console/Makefile
@@ -1,0 +1,13 @@
+all: lint test
+
+include ../tools/python.mk
+
+PIP_INSTALL = --editable .
+PYLINT_ARG = libretime_console
+MYPY_ARG = libretime_console
+PYTEST_ARG = --cov=libretime_console
+
+format: .format
+lint: .pylint .mypy
+test: .pytest
+clean: .clean

--- a/console/README.md
+++ b/console/README.md
@@ -1,0 +1,9 @@
+# `libretime`
+
+`libretime` is a CLI console used to manage a LibreTime installation.
+
+## Installation
+
+```sh
+pip3 install .
+```

--- a/console/libretime_console/db.py
+++ b/console/libretime_console/db.py
@@ -1,0 +1,113 @@
+from secrets import token_hex
+from typing import Optional
+
+import click
+
+from .utils import run_, which
+
+
+def psql(sql: str):
+    return run_(
+        which("sudo"),
+        "-u",
+        "postgres",
+        which("psql"),
+        "--tuples-only",
+        "--no-align",
+        input=sql,
+    )
+
+
+def psql_create_user(name: str, password: str):
+    exist = psql(f"SELECT 1 FROM pg_user WHERE usename = '{name}';")
+
+    if "1" in exist.stdout:
+        raise ValueError(f"postgresql user {name} already exists!")
+
+    return psql(f"CREATE USER {name} WITH ENCRYPTED PASSWORD '{password}';")
+
+
+def psql_update_user_password(name: str, password: str):
+    return psql(f"ALTER USER {name} WITH PASSWORD '{password}';")
+
+
+def psql_create_db(name: str, owner: str):
+    return psql(
+        f"CREATE DATABASE IF NOT EXISTS {name} "
+        "WITH ENCODING 'UTF8' "
+        f"TEMPLATE template0 OWNER {owner};"
+    )
+
+
+@click.group()
+def db():
+    """
+    Manage PostgreSQL.
+
+    Management on remote hosts is not supported.
+    """
+
+
+cli_psql_user_option = click.option(
+    "--user",
+    envvar="POSTGRES_USER",
+    default="libretime",
+    help="PostgreSQL user name.",
+)
+cli_psql_password_option = click.option(
+    "--password",
+    envvar="POSTGRES_PASSWORD",
+    help="PostgreSQL user password.",
+)
+
+cli_psql_database_option = click.option(
+    "--database",
+    envvar="POSTGRES_DB",
+    default="libretime",
+    help="PostgreSQL database.",
+)
+
+
+@db.command()
+@cli_psql_user_option
+@cli_psql_password_option
+def user_create(user: str, password: Optional[str]):
+    """
+    Create a PostgreSQL user.
+
+    If password is not given, a random password will be generated.
+    """
+    if not (isinstance(user, str) and user.isalnum()):
+        raise click.BadParameter("user must be alphanumeric")
+
+    if password is None:
+        password = token_hex(16)
+
+    psql_create_user(user, password)
+    click.echo(f"created user '{user}' with password '{password}'")
+
+
+@db.command()
+@cli_psql_user_option
+@cli_psql_password_option
+def user_password(user: str, password: Optional[str]):
+    """
+    Change a PostgreSQL user password.
+
+    If password is not given, a random password will be generated.
+    """
+    if password is None:
+        password = token_hex(16)
+    psql_update_user_password(user, password)
+    click.echo(f"updated user password '{user}' with '{password}'")
+
+
+@db.command()
+@cli_psql_database_option
+@cli_psql_user_option
+def create(database: str, user: str):
+    """
+    Create a PostgreSQL database.
+    """
+    psql_create_db(database, user)
+    click.echo(f"created database '{database}' with owner '{user}'")

--- a/console/libretime_console/icecast.py
+++ b/console/libretime_console/icecast.py
@@ -1,0 +1,89 @@
+from os import PathLike
+from secrets import token_hex
+from typing import Optional
+
+import click
+
+from .utils import run_, which
+
+
+def xml_update(config_file: PathLike, xpath: str, value):
+    return run_(
+        which("sudo"),
+        which("xmlstarlet"),
+        *("edit", "--inplace"),
+        *("--update", xpath),
+        *("--value", value),
+        config_file,
+    )
+
+
+def icecast_update_passwords(
+    config_filepath: PathLike,
+    *,
+    admin_user: Optional[str] = None,
+    admin_password: Optional[str] = None,
+    source_password: Optional[str] = None,
+    relay_password: Optional[str] = None,
+):
+    for xpath, value in {
+        "/icecast/authentication/admin-user": admin_user,
+        "/icecast/authentication/admin-password": admin_password,
+        "/icecast/authentication/source-password": source_password,
+        "/icecast/authentication/relay-password": relay_password,
+    }.items():
+        if value is not None:
+            xml_update(config_filepath, xpath, value)
+
+
+@click.group()
+def icecast():
+    """
+    Manage Icecast.
+
+    Management on remote hosts is not supported.
+    """
+
+
+@icecast.command()
+@click.argument(
+    "config_filepath",
+    envvar="ICECAST_CONFIG_FILEPATH",
+)
+@click.option(
+    "--admin-password",
+    envvar="ICECAST_ADMIN_PASSWORD",
+    help="Icecast admin password.",
+)
+@click.option(
+    "--source-password",
+    envvar="ICECAST_SOURCE_PASSWORD",
+    help="Icecast source password.",
+)
+@click.option(
+    "--relay-password",
+    envvar="ICECAST_RELAY_PASSWORD",
+    help="Icecast relay password.",
+)
+def update_passwords(
+    config_filepath: PathLike,
+    admin_password: Optional[str],
+    source_password: Optional[str],
+    relay_password: Optional[str],
+):
+    """
+    Change Icecast passwords.
+
+    If passwords are not given, random passwords will be generated.
+    """
+
+    icecast_update_passwords(
+        config_filepath,
+        admin_password=admin_password or token_hex(16),
+        source_password=source_password or token_hex(16),
+        relay_password=relay_password or token_hex(16),
+    )
+    click.echo("updated icecast passwords")
+    click.echo(f"admin_password '{admin_password}'")
+    click.echo(f"source_password '{source_password}'")
+    click.echo(f"relay_password '{relay_password}'")

--- a/console/libretime_console/info.py
+++ b/console/libretime_console/info.py
@@ -1,0 +1,19 @@
+import click
+
+from .utils import run_, which
+
+
+@click.command()
+def status():
+    """
+    Show the status of systemd services.
+    """
+    for service in (
+        "libretime-api",
+        "libretime-playout",
+        "libretime-liquidsoap",
+        "libretime-analyzer",
+        "libretime-celery",
+    ):
+        cmd = run_(which("systemctl"), "status", service)
+        print(cmd.stdout)

--- a/console/libretime_console/main.py
+++ b/console/libretime_console/main.py
@@ -1,0 +1,19 @@
+import click
+
+from .db import db
+from .icecast import icecast
+from .info import status
+from .mq import mq
+from .setup import setup
+
+
+@click.group()
+def cli():
+    pass
+
+
+cli.add_command(db)
+cli.add_command(icecast)
+cli.add_command(mq)
+cli.add_command(setup)
+cli.add_command(status)

--- a/console/libretime_console/mq.py
+++ b/console/libretime_console/mq.py
@@ -1,0 +1,100 @@
+from secrets import token_hex
+from typing import Optional
+
+import click
+
+from .utils import run_, which
+
+
+def rabbitmq(*args):
+    return run_(which("sudo"), which("rabbitmqctl"), *args)
+
+
+def rabbitmq_create_user(name: str, password: str):
+    return rabbitmq("add_user", name, password)
+
+
+def rabbitmq_update_user_password(name: str, password: str):
+    return rabbitmq("change_password", name, password)
+
+
+def rabbitmq_create_vhost(name: str, owner: str):
+    vhosts = rabbitmq("list_vhosts")
+    print(vhosts)
+    # if name not in vhosts:
+    rabbitmq("add_vhost", name)
+    rabbitmq("set_permissions", "-p", name, owner, ".*", ".*", ".*")
+
+
+@click.group()
+def mq():
+    """
+    Manage RabbitMQ.
+
+    Management on remote hosts is not supported.
+    """
+
+
+cli_rabbitmq_user_option = click.option(
+    "--user",
+    envvar="RABBITMQ_USER",
+    default="libretime",
+    help="RabbitMQ user name.",
+)
+cli_rabbitmq_password_option = click.option(
+    "--password",
+    envvar="RABBITMQ_PASSWORD",
+    help="RabbitMQ user password.",
+)
+
+cli_rabbitmq_vhost_option = click.option(
+    "--vhost",
+    envvar="RABBITMQ_VHOST",
+    default="/libretime",
+    help="RabbitMQ vhost.",
+)
+
+
+@mq.command()
+@cli_rabbitmq_user_option
+@cli_rabbitmq_password_option
+def user_create(user: str, password: Optional[str]):
+    """
+    Create a RabbitMQ user.
+
+    If password is not given, a random password will be generated.
+    """
+    if not (isinstance(user, str) and user.isalnum()):
+        raise click.BadParameter("user must be alphanumeric")
+
+    if password is None:
+        password = token_hex(16)
+
+    rabbitmq_create_user(user, password)
+    click.echo(f"created user '{user}' with password '{password}'")
+
+
+@mq.command()
+@cli_rabbitmq_user_option
+@cli_rabbitmq_password_option
+def user_password(user: str, password: Optional[str]):
+    """
+    Change a RabbitMQ user password.
+
+    If password is not given, a random password will be generated.
+    """
+    if password is None:
+        password = token_hex(16)
+    rabbitmq_update_user_password(user, password)
+    click.echo(f"updated user password '{user}' with '{password}'")
+
+
+@mq.command()
+@cli_rabbitmq_vhost_option
+@cli_rabbitmq_user_option
+def create(vhost: str, user: str):
+    """
+    Create a RabbitMQ vhost.
+    """
+    rabbitmq_create_vhost(vhost, user)
+    click.echo(f"created vhost '{vhost}' with owner '{user}'")

--- a/console/libretime_console/setup.py
+++ b/console/libretime_console/setup.py
@@ -1,0 +1,154 @@
+from pathlib import Path
+from secrets import token_hex
+
+import click
+
+from .db import psql_create_db, psql_create_user
+from .mq import rabbitmq_create_user, rabbitmq_create_vhost
+from .utils import warning
+
+
+def echo_section(text):
+    fill = (80 - len(text)) * " "
+    click.echo()
+    click.secho(text + fill, fg="cyan")
+    click.echo()
+
+
+@click.command()
+def setup():
+    """
+    Setup LibreTime.
+    """
+
+    # Defaults
+    public_url = "http://localhost:80/"
+    database_host = "localhost"
+    database_port = 5432
+    database_name = "libretime"
+    database_user = "libretime"
+    database_password = token_hex(16)
+    message_queue_host = "localhost"
+    message_queue_port = 5672
+    message_queue_vhost = "/libretime"
+    message_queue_user = "libretime"
+    message_queue_password = token_hex(16)
+    storage_path = "/srv/libretime/storage"
+
+    confirmation = False
+    while not confirmation:
+        click.clear()
+
+        echo_section("# Global settings")
+
+        public_url = click.prompt(
+            text="Enter the full public url",
+            default=public_url,
+            type=str,
+        )
+
+        echo_section("# Database settings (Postgresql)")
+
+        database_host = click.prompt(
+            text="Your database host",
+            default=database_host,
+            type=str,
+        )
+        database_port = click.prompt(
+            text="Your database port",
+            default=database_port,
+            type=int,
+        )
+        database_name = click.prompt(
+            text="Your database name",
+            default=database_name,
+            type=str,
+        )
+        database_user = click.prompt(
+            text="Your database user",
+            default=database_user,
+            type=str,
+        )
+        database_password = click.prompt(
+            text="Your database user password",
+            default=database_password,
+            type=str,
+        )
+
+        echo_section("# Message Queue settings (RabbitMQ)")
+
+        message_queue_host = click.prompt(
+            text="Your message queue host",
+            default=message_queue_host,
+            type=str,
+        )
+        message_queue_port = click.prompt(
+            text="Your message queue port",
+            default=message_queue_port,
+            type=int,
+        )
+        message_queue_vhost = click.prompt(
+            text="Your message queue vhost",
+            default=message_queue_vhost,
+            type=str,
+        )
+        message_queue_user = click.prompt(
+            text="Your message queue user",
+            default=message_queue_user,
+            type=str,
+        )
+        message_queue_password = click.prompt(
+            text="Your message queue user password",
+            default=message_queue_password,
+            type=str,
+        )
+
+        echo_section("# Storage settings")
+
+        storage_path = click.prompt(
+            text="Your storage directory path",
+            default=storage_path,
+            type=Path,
+        )
+
+        click.secho(
+            f"""
+public_url: {public_url}
+
+database:
+    host: {database_host}
+    port: {database_port}
+    name: {database_name}
+    user: {database_user}
+    password: {database_password}
+
+rabbitmq:
+    host: {message_queue_host}
+    port: {message_queue_port}
+    vhost: {message_queue_vhost}
+    user: {message_queue_user}
+    password: {message_queue_password}
+
+storage:
+    path: {storage_path}
+""",
+            fg="bright_magenta",
+            bold=True,
+        )
+
+        confirmation = click.confirm(
+            click.style("Do you confirm your choices", fg="red"),
+            default=False,
+        )
+
+    if database_host != "localhost":
+        warning("database management on remote hosts is not supported!")
+    else:
+        psql_create_user(database_user, database_password)
+        psql_create_db(database_name, database_user)
+
+    if message_queue_host != "localhost":
+        warning("message queue management on remote hosts is not supported!")
+    else:
+        rabbitmq_create_user(message_queue_user, message_queue_password)
+        rabbitmq_create_vhost(message_queue_vhost, message_queue_user)

--- a/console/libretime_console/utils.py
+++ b/console/libretime_console/utils.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+from shutil import which as which_base
+from subprocess import CalledProcessError, run
+
+import click
+
+
+def warning(msg):
+    click.secho(f"warning: {msg}", fg="magenta")
+
+
+def error(msg):
+    click.secho(f"error: {msg}", fg="red")
+
+
+def fatal(msg):
+    error(msg)
+    sys.exit(1)
+
+
+def which(cmd: str) -> Path:
+    """
+    Given a command name, return the path of the command or exit.
+    """
+    cmd_path = which_base(cmd)
+    if cmd_path is None:
+        fatal(f"could not find executable '{cmd}'")
+
+    return Path(cmd_path)
+
+
+def run_(*args, **kwargs):
+    try:
+        return run(args, check=True, capture_output=True, text=True, **kwargs)
+    except CalledProcessError as exception:
+        error(exception.stderr)
+        fatal(exception)

--- a/console/packages.ini
+++ b/console/packages.ini
@@ -1,0 +1,7 @@
+# This file contains a list of package dependencies.
+[common]
+python3 = buster, bullseye, bionic, focal
+python3-pip = buster, bullseye, bionic, focal
+
+[icecast]
+xmlstarlet = buster, bullseye, bionic, focal

--- a/console/setup.py
+++ b/console/setup.py
@@ -1,0 +1,32 @@
+from os import chdir
+from pathlib import Path
+
+from setuptools import setup
+
+# Change directory since setuptools uses relative paths
+here = Path(__file__).parent
+chdir(here)
+
+setup(
+    name="libretime-console",
+    version="0.1",
+    description="Libretime Console",
+    author="LibreTime Contributors",
+    url="https://github.com/libretime/libretime",
+    project_urls={
+        "Bug Tracker": "https://github.com/libretime/libretime/issues",
+        "Documentation": "https://libretime.org",
+        "Source Code": "https://github.com/libretime/libretime",
+    },
+    license="AGPLv3",
+    packages=["libretime_console"],
+    entry_points={
+        "console_scripts": [
+            "libretime=libretime_console.main:cli",
+        ]
+    },
+    install_requires=[
+        "click",
+    ],
+    zip_safe=False,
+)


### PR DESCRIPTION
This PR will replace the current bash installer, with a python based installer.

- No dependencies for the install script.
- Use templates to deploy configuration files.
- Removed old configuration files.
- Moved and improved  some configuration files (apache/php). 
- Rename remaining paths to libretime.
- Fine grained install configuration using env variables.
- Support debian based systems (~~centos support on the way~~) and Systemd
- Group all config file in a single directory and use symlinks to deploy them on the system.
- Install/uninstall/clean commands
- (Still WIP...)

To consider:
- Use systemd WorkingDir to dedicate a working directopry for each app.
- More install config variables.
- Document installation options.
- CI Testing.

Most of the old names and files are renamed to Libretime as this is a good occasion to do so.
But I am wondering how we want to handle the upgrade path between airtime v2=> libretime v3=> v*.
If we keep old airtime paths in the Libretime v3 release we will have to maintain a complex upgrade path from v3 to v*.
Since Airtime user have to start fresh and we can still make breaking changes, I think we should update all the paths before v3.