### PR TITLE
Fix pip install failing with setuptools install-options (revert)

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -28,11 +28,10 @@ setup(
         "django-url-filter",
         "markdown",
         "model_bakery",
+        "psycopg2",  # TODO: Move to prod requires
     ],
     extras_require={
-        "prod": [
-            "psycopg2",
-        ],
+        "prod": [],
         "dev": [
             "psycopg2-binary",
         ],

--- a/install
+++ b/install
@@ -1023,11 +1023,11 @@ if [ ! -d /var/log/airtime ]; then
 fi
 
 verbose "\n * Installing API client..."
-loudCmd "$python_bin" -m pip install "${AIRTIMEROOT}/python_apps/api_clients"
+loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/api_clients/setup.py install --install-scripts=/usr/bin"
 verbose "...Done"
 
 verbose "\n * Installing pypo and liquidsoap..."
-loudCmd "$python_bin" -m pip install "${AIRTIMEROOT}/python_apps/pypo" --install-option="--install-scripts=/usr/bin"
+loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/pypo/setup.py install --install-scripts=/usr/bin"
 loudCmd "mkdir -p /var/log/airtime/{pypo,pypo-liquidsoap} /var/tmp/airtime/pypo/{cache,files,tmp} /var/tmp/airtime/show-recorder/"
 loudCmd "chown -R ${web_user}:${web_user} /var/log/airtime/{pypo,pypo-liquidsoap} /var/tmp/airtime/pypo/{cache,files,tmp} /var/tmp/airtime/show-recorder/"
 systemInitInstall libretime-liquidsoap "$web_user"
@@ -1035,7 +1035,7 @@ systemInitInstall libretime-playout "$web_user"
 verbose "...Done"
 
 verbose "\n * Installing airtime-celery..."
-loudCmd "$python_bin" -m pip install "${AIRTIMEROOT}/python_apps/airtime-celery"
+loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/airtime-celery/setup.py install"
 # Create the Celery user
 if $is_centos_dist; then
   loudCmd "id celery 2>/dev/null || adduser --no-create-home -c 'LibreTime Celery' -r celery || true"
@@ -1051,12 +1051,12 @@ systemInitInstall libretime-celery
 verbose "...Done"
 
 verbose "\n * Installing libretime-analyzer..."
-loudCmd "$python_bin" -m pip install "${AIRTIMEROOT}/python_apps/airtime_analyzer" --install-option="--install-scripts=/usr/bin"
+loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/airtime_analyzer/setup.py install --install-scripts=/usr/bin"
 systemInitInstall libretime-analyzer "$web_user"
 verbose "...Done"
 
 verbose "\n * Installing API..."
-loudCmd "$python_bin" -m pip install "${AIRTIMEROOT}/api[prod]"
+loudCmd "python3 ${AIRTIMEROOT}/api/setup.py install --install-scripts=/usr/bin"
 systemInitInstall libretime-api "$web_user"
 mkdir -p /etc/airtime
 sed -e "s@WEB_USER@${web_user}@g" \


### PR DESCRIPTION
Also remove prod extra requires for api because ./setup.py install don't handle extra requires.

Closes #1350 