### PR TITLE
Properly import sleep function

### DIFF
--- a/python_apps/api_clients/api_clients/utils.py
+++ b/python_apps/api_clients/api_clients/utils.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import logging
 import socket
-from datetime import time
+from time import sleep
 
 import requests
 from requests.auth import AuthBase
@@ -146,7 +146,7 @@ class ApiRequest:
             try:
                 return self.__req()
             except Exception:
-                time.sleep(delay)
+                sleep(delay)
         return self.__req()
 
 
@@ -198,17 +198,17 @@ class RequestProvider:
             return super(RequestProvider, self).__getattribute__(attr)
 
 
-def time_in_seconds(time):
+def time_in_seconds(value):
     return (
-        time.hour * 60 * 60
-        + time.minute * 60
-        + time.second
-        + time.microsecond / 1000000.0
+        value.hour * 60 * 60
+        + value.minute * 60
+        + value.second
+        + value.microsecond / 1000000.0
     )
 
 
-def time_in_milliseconds(time):
-    return time_in_seconds(time) * 1000
+def time_in_milliseconds(value):
+    return time_in_seconds(value) * 1000
 
 
 def fromisoformat(time_string):


### PR DESCRIPTION
Fix some name collisions...
```
2021-09-29 09:57:44,525 [version1] [ERROR]  type object 'datetime.time' has no attribute 'sleep'
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/api_clients-2.0.0-py3.7.egg/api_clients/utils.py", line 147, in retry
    return self.__req()
  File "/usr/local/lib/python3.7/dist-packages/api_clients-2.0.0-py3.7.egg/api_clients/utils.py", line 139, in <lambda>
    self.__req = lambda: self(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/api_clients-2.0.0-py3.7.egg/api_clients/utils.py", line 122, in __call__
    res.raise_for_status()
  File "/usr/lib/python3/dist-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 503 Server Error: Service Unavailable for url: https://station.aioli-radio.org:443/api/update-source-status/format/json//sourcename/live_dj/status/false

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/api_clients-2.0.0-py3.7.egg/api_clients/version1.py", line 448, in notify_source_status
    ).retry(5)
  File "/usr/local/lib/python3.7/dist-packages/api_clients-2.0.0-py3.7.egg/api_clients/utils.py", line 149, in retry
    time.sleep(delay)
AttributeError: type object 'datetime.time' has no attribute 'sleep'

```