### PR TITLE
Install python apps using pip

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -28,10 +28,11 @@ setup(
         "django-url-filter",
         "markdown",
         "model_bakery",
-        "psycopg2",  # TODO: Move to prod requires
     ],
     extras_require={
-        "prod": [],
+        "prod": [
+            "psycopg2",
+        ],
         "dev": [
             "psycopg2-binary",
         ],

--- a/install
+++ b/install
@@ -1028,7 +1028,7 @@ loudCmd "$pip_cmd install ${AIRTIMEROOT}/python_apps/api_clients"
 verbose "...Done"
 
 verbose "\n * Installing pypo and liquidsoap..."
-loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/pypo/setup.py install --install-scripts=/usr/bin"
+loudCmd "$pip_cmd install ${AIRTIMEROOT}/python_apps/pypo"
 loudCmd "mkdir -p /var/log/airtime/{pypo,pypo-liquidsoap} /var/tmp/airtime/pypo/{cache,files,tmp} /var/tmp/airtime/show-recorder/"
 loudCmd "chown -R ${web_user}:${web_user} /var/log/airtime/{pypo,pypo-liquidsoap} /var/tmp/airtime/pypo/{cache,files,tmp} /var/tmp/airtime/show-recorder/"
 systemInitInstall libretime-liquidsoap "$web_user"

--- a/install
+++ b/install
@@ -995,12 +995,13 @@ loud "-----------------------------------------------------"
 
 python_version=$($python_bin --version 2>&1 | awk '{ print $2 }')
 verbose "Detected Python version: $python_version"
+pip_cmd="$python_bin -m pip"
 
 verbose "\n * Installing necessary python services..."
-loudCmd "$python_bin -mpip install setuptools --upgrade"
+loudCmd "$pip_cmd install setuptools --upgrade"
 # Required here because PyGObject requires it, but it is installed after PyGObject
 # when pip parses the setup.py file in airtime_analyzer
-loudCmd "$python_bin -mpip install pycairo==1.19.1"
+loudCmd "$pip_cmd install pycairo==1.19.1"
 verbose "...Done"
 
 verbose "\n * Creating /run/airtime..."

--- a/install
+++ b/install
@@ -1057,7 +1057,7 @@ systemInitInstall libretime-analyzer "$web_user"
 verbose "...Done"
 
 verbose "\n * Installing API..."
-loudCmd "python3 ${AIRTIMEROOT}/api/setup.py install --install-scripts=/usr/bin"
+loudCmd "$pip_cmd install ${AIRTIMEROOT}/api"
 systemInitInstall libretime-api "$web_user"
 mkdir -p /etc/airtime
 sed -e "s@WEB_USER@${web_user}@g" \

--- a/install
+++ b/install
@@ -1057,7 +1057,7 @@ systemInitInstall libretime-analyzer "$web_user"
 verbose "...Done"
 
 verbose "\n * Installing API..."
-loudCmd "$pip_cmd install ${AIRTIMEROOT}/api"
+loudCmd "$pip_cmd install ${AIRTIMEROOT}/api[prod]"
 systemInitInstall libretime-api "$web_user"
 mkdir -p /etc/airtime
 sed -e "s@WEB_USER@${web_user}@g" \

--- a/install
+++ b/install
@@ -1036,7 +1036,7 @@ systemInitInstall libretime-playout "$web_user"
 verbose "...Done"
 
 verbose "\n * Installing airtime-celery..."
-loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/airtime-celery/setup.py install"
+loudCmd "$pip_cmd install ${AIRTIMEROOT}/python_apps/airtime-celery"
 # Create the Celery user
 if $is_centos_dist; then
   loudCmd "id celery 2>/dev/null || adduser --no-create-home -c 'LibreTime Celery' -r celery || true"

--- a/install
+++ b/install
@@ -1024,7 +1024,7 @@ if [ ! -d /var/log/airtime ]; then
 fi
 
 verbose "\n * Installing API client..."
-loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/api_clients/setup.py install --install-scripts=/usr/bin"
+loudCmd "$pip_cmd install ${AIRTIMEROOT}/python_apps/api_clients"
 verbose "...Done"
 
 verbose "\n * Installing pypo and liquidsoap..."

--- a/install
+++ b/install
@@ -1052,7 +1052,7 @@ systemInitInstall libretime-celery
 verbose "...Done"
 
 verbose "\n * Installing libretime-analyzer..."
-loudCmd "$python_bin ${AIRTIMEROOT}/python_apps/airtime_analyzer/setup.py install --install-scripts=/usr/bin"
+loudCmd "$pip_cmd install ${AIRTIMEROOT}/python_apps/airtime_analyzer"
 systemInitInstall libretime-analyzer "$web_user"
 verbose "...Done"
 

--- a/python_apps/airtime_analyzer/install/systemd/libretime-analyzer.service
+++ b/python_apps/airtime_analyzer/install/systemd/libretime-analyzer.service
@@ -2,7 +2,7 @@
 Description=LibreTime Media Analyzer Service
 
 [Service]
-ExecStart=/usr/bin/libretime-analyzer
+ExecStart=/usr/local/bin/libretime-analyzer
 User=libretime-analyzer
 Group=libretime-analyzer
 Restart=always

--- a/python_apps/pypo/install/systemd/libretime-liquidsoap.service
+++ b/python_apps/pypo/install/systemd/libretime-liquidsoap.service
@@ -2,7 +2,7 @@
 Description=Libretime Liquidsoap Service
 
 [Service]
-ExecStart=/usr/bin/airtime-liquidsoap
+ExecStart=/usr/local/bin/airtime-liquidsoap
 User=libretime-playout
 Group=libretime-playout
 Restart=always

--- a/python_apps/pypo/install/systemd/libretime-playout.service
+++ b/python_apps/pypo/install/systemd/libretime-playout.service
@@ -3,7 +3,7 @@ Description=Libretime Playout Service
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/airtime-playout
+ExecStart=/usr/local/bin/airtime-playout
 User=libretime-pypo
 Group=libretime-pypo
 Restart=always


### PR DESCRIPTION
### Description

- Install the python apps with pip install instead of bare setuptools.
- Change script install prefix to default `/usr/local/bin`.

This will simplify the way we install/uninstall the python apps.

Closes #1343 
Related-To #1350

I tested this on Buster (vagrant) and didn't face any problems.

BREAKING: Previous entrypoints scripts should be removed from `/usr/bin`
```sh
sudo rm -f \
  sqlformat \
  django-admin \
  django-admin.py \
  markdown_py \
  libretime-api \
  mutagen-inspect \
  mutagen-pony \
  mid3cp \
  mid3iconv \
  mid3v2 \
  moggsplit \
  collectiongain \
  replaygain \
  libretime-analyzer \
  airtime-playout \
  pyponotify \
  airtime-liquidsoap
```