### PR TITLE
Remove unused /{,var/}run/airtime/ directory

### DIFF
--- a/install
+++ b/install
@@ -1005,12 +1005,6 @@ loudCmd "$pip_cmd install setuptools --upgrade"
 loudCmd "$pip_cmd install pycairo==1.19.1"
 verbose "...Done"
 
-verbose "\n * Creating /run/airtime..."
-mkdir -p /run/airtime
-chmod 755 /run/airtime
-chown -R "${web_user}:${web_user}" /run/airtime
-verbose "...Done"
-
 if [ ! -d /var/log/airtime ]; then
   loud "\n-----------------------------------------------------"
   loud "              * Installing Log Files *               "

--- a/python_apps/pypo/liquidsoap/1.1/ls_script.liq
+++ b/python_apps/pypo/liquidsoap/1.1/ls_script.liq
@@ -3,8 +3,6 @@
 set("log.file.path", log_file)
 set("server.telnet", true)
 set("server.telnet.port", 1234)
-# set("init.daemon.pidfile.path", "/var/run/airtime/airtime-liquidsoap.pid")
-
 
 #Dynamic source list
 #dyn_sources = ref []

--- a/python_apps/pypo/liquidsoap/1.3/ls_script.liq
+++ b/python_apps/pypo/liquidsoap/1.3/ls_script.liq
@@ -3,8 +3,6 @@
 set("log.file.path", log_file)
 set("server.telnet", true)
 set("server.telnet.port", 1234)
-# set("init.daemon.pidfile.path", "/var/run/airtime/airtime-liquidsoap.pid")
-
 
 #Dynamic source list
 #dyn_sources = ref []

--- a/python_apps/pypo/liquidsoap/1.4/ls_script.liq
+++ b/python_apps/pypo/liquidsoap/1.4/ls_script.liq
@@ -3,8 +3,6 @@
 set("log.file.path", log_file)
 set("server.telnet", true)
 set("server.telnet.port", 1234)
-# set("init.daemon.pidfile.path", "/var/run/airtime/airtime-liquidsoap.pid")
-
 
 #Dynamic source list
 #dyn_sources = ref []


### PR DESCRIPTION
### Description

We aren't using the /var/run/airtime or /run/airtime directory.

CLEANUP:
```sh
sudo rm -Rf \
  /var/run/airtime \
  /run/airtime
```