### PR TITLE
Add dependabot check for legacy composer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@ updates:
   #     - docker
   #     - dependencies
 
+  # Maintain dependencies for legacy
+  - package-ecosystem: "composer"
+    directory: "/legacy"
+    schedule:
+      interval: "daily"
+    labels:
+      - php
+      - dependencies
+
   # Maintain dependencies for Python apps
   - package-ecosystem: "pip"
     directory: "/api"


### PR DESCRIPTION
### Description

We might have a lot of PRs popping after merging this. I think most of them can be closed/suppressed.

Maybe we should only merge this after #1354 so we don't have some race between the dependabot PR already handled in the php 7.4 support PR.
