### PR TITLE
fix: assume api client is installed

### DIFF
--- a/playout/setup.py
+++ b/playout/setup.py
@@ -34,7 +34,6 @@ setup(
     },
     python_requires=">=3.6",
     install_requires=[
-        f"libretime-api-client @ file://localhost/{here.parent}/api_client#egg=libretime-api-client",
         "amqplib",
         "configobj",
         "defusedxml",


### PR DESCRIPTION
Until pip out-of-tree dependencies work with our setup and we can update to newer versions of our dependencies, assume api client is installed without explicitly adding it as a dependency. The install script installs api_client anyway

Fixes: #1435