### PR TITLE
chore(ci): add closed references notificier workflow

### DIFF
--- a/.github/workflows/closed-references.yml
+++ b/.github/workflows/closed-references.yml
@@ -1,0 +1,29 @@
+name: Closed Reference Notifier
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      issueLimit:
+        description: Max. number of issues to create
+        required: true
+        default: "5"
+
+jobs:
+  find_closed_references:
+    if: github.repository_owner == 'LibreTime'
+    name: Find closed references
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+
+      - uses: ory/closed-reference-notifier@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issueLimit: ${{ github.event.inputs.issueLimit || '5' }}


### PR DESCRIPTION
This workflow will check for issue links in the code
that has been closed upstream and can be dealt with.