### PR TITLE
chore(ci): let dependapot catch up with commit syle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    commit-message:
-      prefix: "chore: "
     labels:
       - ci
       - dependencies
@@ -18,8 +16,6 @@ updates:
   #   directory: "/docker"
   #   schedule:
   #     interval: "weekly"
-  #   commit-message:
-  #     prefix: "chore: "
   #   labels:
   #     - docker
   #     - dependencies
@@ -29,8 +25,6 @@ updates:
     directory: "/legacy"
     schedule:
       interval: "daily"
-    commit-message:
-      prefix: "chore: "
     labels:
       - php
       - dependencies
@@ -40,8 +34,6 @@ updates:
     directory: "/api"
     schedule:
       interval: "daily"
-    commit-message:
-      prefix: "chore: "
     labels:
       - python
       - dependencies
@@ -50,8 +42,6 @@ updates:
     directory: "/analyzer"
     schedule:
       interval: "daily"
-    commit-message:
-      prefix: "chore: "
     labels:
       - python
       - dependencies
@@ -60,8 +50,6 @@ updates:
     directory: "/worker"
     schedule:
       interval: "daily"
-    commit-message:
-      prefix: "chore: "
     labels:
       - python
       - dependencies
@@ -70,8 +58,6 @@ updates:
     directory: "/api_client"
     schedule:
       interval: "daily"
-    commit-message:
-      prefix: "chore: "
     labels:
       - python
       - dependencies
@@ -80,8 +66,6 @@ updates:
     directory: "/playout"
     schedule:
       interval: "daily"
-    commit-message:
-      prefix: "chore: "
     labels:
       - python
       - dependencies
@@ -92,8 +76,6 @@ updates:
   #   directory: "/ui"
   #   schedule:
   #     interval: "daily"
-  #   commit-message:
-  #     prefix: "chore: "
   #   labels:
   #     - javascript
   #     - dependencies


### PR DESCRIPTION
Dependabot should catch up with our commit msg style, I propose we let it auto detect again.

Reverts: #1442