### PR TITLE
ci: add semantic pull request linting

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,36 @@
+name: Lint PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          scopes: |
+            analyzer
+            api
+            api_client
+            installer
+            legacy
+            playout
+            ui
+            worker
+
+            ci
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          wip: true
+          validateSingleCommit: true

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -25,12 +25,12 @@ jobs:
             playout
             ui
             worker
-
-            ci
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
+
+            See https://www.conventionalcommits.org/en/v1.0.0/ for more details.
           wip: true
           validateSingleCommit: true


### PR DESCRIPTION
This enforce semantic pull request messages before merging.

Do we want to require a scope or do we allow un-scoped prefixes ?
Did I miss a scope in the allowed scopes ?

The subjects should not start with a uppercase letter.