### PR TITLE
feat: enhance libretime shared

### DIFF
--- a/shared/libretime_shared/config.py
+++ b/shared/libretime_shared/config.py
@@ -11,7 +11,7 @@ from pydantic.fields import ModelField
 from yaml import YAMLError, safe_load
 
 DEFAULT_ENV_PREFIX = "LIBRETIME"
-
+DEFAULT_CONFIG_FILEPATH = Path("/etc/libretime/config.yml")
 
 # pylint: disable=too-few-public-methods
 class BaseConfig(BaseModel):


### PR DESCRIPTION
- The path to the configuration file can be changed using env variables through the cli options. So maybe it isn't required to add this helper function.
- A default config filepath constant was created in order to prevent any possible duplication.