### PR TITLE
chore: rename master branch to main

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,4 +1,4 @@
-![](https://github.com/LibreTime/libretime/raw/master/logo/logotype.png)
+![](https://github.com/LibreTime/libretime/raw/main/logo/logotype.png)
 
 The complete LibreTime documentation is available at [libretime.org](http://libretime.org).
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     types: [opened, reopened, synchronize, edited]
-    branches: [master]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 3 * * 0"
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "**/packages.ini"
       - ".github/workflows/tools.yml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First and foremost, thank you! We appreciate that you want to contribute to
 LibreTime, your time is valuable, and your contributions mean a lot to us.
 
 Before any contribution, read and be prepared to adhere to our
-[code of conduct](https://github.com/libretime/code-of-conduct/blob/master/code_of_conduct.md).
+[code of conduct](https://github.com/libretime/code-of-conduct/blob/main/code_of_conduct.md).
 
 In addition, LibreTime follow the standardized
 [C4 development process](https://rfc.zeromq.org/spec:42/c4/), in which you can

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/LibreTime/libretime/raw/master/logo/logotype.png)
+![](https://github.com/LibreTime/libretime/raw/main/logo/logotype.png)
 
 [![Tests](https://github.com/LibreTime/libretime/actions/workflows/test.yml/badge.svg)](https://github.com/LibreTime/libretime/actions/workflows/test.yml)
 [![Financial Contributors on Open Collective](https://opencollective.com/libretime/all/badge.svg?label=financial+contributors)](https://opencollective.com/libretime)
@@ -16,7 +16,7 @@ Check out the [documentation](http://libretime.org) for more information and
 start broadcasting!
 
 Please note that LibreTime is released with a [Contributor Code
-of Conduct](https://github.com/LibreTime/code-of-conduct/blob/master/CODE_OF_CONDUCT.md).
+of Conduct](https://github.com/LibreTime/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
 By participating in this project you agree to abide by its terms.
 
 Please submit enhancements, bugfixes or comments via GitHub.

--- a/docs/_docs/contribute.md
+++ b/docs/_docs/contribute.md
@@ -12,7 +12,7 @@ permalink: /contribute
 ## Code of conduct
 
 Before any contribution, read and be prepared to adhere to our
-[code of conduct](https://github.com/libretime/code-of-conduct/blob/master/code_of_conduct.md).
+[code of conduct](https://github.com/libretime/code-of-conduct/blob/main/code_of_conduct.md).
 
 In addition, LibreTime follow the standardized
 [C4 development process](https://rfc.zeromq.org/spec:42/c4/), in which you can

--- a/docs/_docs/interface-localization.md
+++ b/docs/_docs/interface-localization.md
@@ -8,7 +8,7 @@ The LibreTime administration interface can be localized using the standard GNU *
 
 ![](/img/Screenshot464-Korean_stream_setting.png)
 
-First, you should check if a localization is already under way for your locale of choice. The best way to do this is to take a look at the 'master' branch in the GitHub repository for LibreTime at <https://github.com/LibreTime/libretime>. You can also ask in the LibreTime development forum at <https://discourse.libretime.org/>, where you might find community members who can help you with the translation.
+First, you should check if a localization is already under way for your locale of choice. The best way to do this is to take a look at the 'main' branch in the GitHub repository for LibreTime at <https://github.com/LibreTime/libretime>. You can also ask in the LibreTime development forum at <https://discourse.libretime.org/>, where you might find community members who can help you with the translation.
 
 GNU **gettext** means using a .po file for each language or dialect, a specially formatted plain text file with groups of three or more lines, like this example from LibreTime's Korean localization:
 
@@ -22,15 +22,15 @@ If you use the cross-platform program **Poedit** (<http://www.poedit.net/>) to e
 
 Before manually translating strings in Poedit from scratch, you should take a look at the online translation services available, such as Lingohub (<https://lingohub.com>) or Google's Translator Toolkit (<http://translate.google.com/toolkit/>), which both support gettext .po files. If using automatic translation, you can then use Poedit to fine-tune the localization and fix any formatting errors.
 
-If you don't already have a GitHub account, you can sign up at <https://github.com/signup/free>. Once you have a GitHub account, you can fork a copy (<https://help.github.com/articles/fork-a-repo>) of the LibreTime project. Work for the next major version of the software is done in the **master** branch of each project, so that's the branch to **checkout** after you have made the initial **git clone**.
+If you don't already have a GitHub account, you can sign up at <https://github.com/signup/free>. Once you have a GitHub account, you can fork a copy (<https://help.github.com/articles/fork-a-repo>) of the LibreTime project. Work for the next major version of the software is done in the **main** branch of each project, so that's the branch to **checkout** after you have made the initial **git clone**.
 
 In the locale code _de_CH_, for example, _de_ represents the German language and the suffix _\_CH_ indicates the dialect spoken in Switzerland. Some languages have a wide variety of dialect localizations, which can be differentiated with a suffix in this way. You should update the header information in the .po file, which includes the language code and a country code, using one of the existing .po files as a guide.
 
-After forking the LibreTime git repository, make sure you're in the **master** branch:
+After forking the LibreTime git repository, make sure you're in the **main** branch:
 
     git branch
       devel
-    * master
+    * main
 
 Create a new locale directory (e.g. _legacy/locale/de_CH/LC_MESSAGES/_ for German as spoken in Switzerland):
 

--- a/docs/_layouts/article.html
+++ b/docs/_layouts/article.html
@@ -55,7 +55,7 @@ layout: default
           </div>
           <br>
           <!-- Edit Page -->
-            <a class="card border-0 bg-primary link-white text-white mb-4" href="https://github.com/Libretime/libretime/edit/master/docs/{{ page.path }}">
+            <a class="card border-0 bg-primary link-white text-white mb-4" href="https://github.com/Libretime/libretime/edit/main/docs/{{ page.path }}">
               <div class="card-body z-index-1">
                 <div class="d-flex align-items-center">
                   <i class="fa fa-pencil-alt fa-3x mr-4"></i>

--- a/legacy/application/configs/constants.php
+++ b/legacy/application/configs/constants.php
@@ -14,8 +14,8 @@ define('SUPPORT_ADDRESS', 'https://discourse.libretime.org/');
 
 define('HELP_URL', 'https://discourse.libretime.org/');
 define('WHOS_USING_URL', 'https://github.com/orgs/LibreTime/people');
-define('TERMS_AND_CONDITIONS_URL', 'https://github.com/LibreTime/libretime/blob/master/README.md');
-define('PRIVACY_POLICY_URL', 'https://github.com/LibreTime/code-of-conduct/blob/master/CODE_OF_CONDUCT.md');
+define('TERMS_AND_CONDITIONS_URL', 'https://github.com/LibreTime/libretime/blob/main/README.md');
+define('PRIVACY_POLICY_URL', 'https://github.com/LibreTime/code-of-conduct/blob/main/CODE_OF_CONDUCT.md');
 define('USER_MANUAL_URL', 'http://libretime.org/docs');
 define('ABOUT_AIRTIME_URL', 'http://libretime.org');
 define('LIBRETIME_CONTRIBUTE_URL', 'https://libretime.org/contribute');


### PR DESCRIPTION
This rename all references to the `master` branch to `main`.

Once the default branch is renamed and this is merged, the following things are left to do:
- Update Weblate Pull/Push configuration
- Pin the #1277 issue to the issue tracker as notice for everyone.  


Fixes #1277
