### PR TITLE
chore: rename common section to python

### DIFF
--- a/analyzer/packages.ini
+++ b/analyzer/packages.ini
@@ -1,5 +1,5 @@
 # This file contains a list of package dependencies.
-[common]
+[python]
 python3 = buster, bullseye, bionic, focal
 python3-pip = buster, bullseye, bionic, focal
 python3-venv = buster, bullseye, bionic, focal

--- a/api/packages.ini
+++ b/api/packages.ini
@@ -1,5 +1,5 @@
 # This file contains a list of package dependencies.
-[common]
+[python]
 python3 = buster, bullseye, bionic, focal
 python3-pip = buster, bullseye, bionic, focal
 python3-venv = buster, bullseye, bionic, focal

--- a/playout/packages.ini
+++ b/playout/packages.ini
@@ -1,5 +1,5 @@
 # This file contains a list of package dependencies.
-[common]
+[python]
 python3 = buster, bullseye, bionic, focal
 python3-pip = buster, bullseye, bionic, focal
 python3-venv = buster, bullseye, bionic, focal


### PR DESCRIPTION
this will make the section more explicit,
in addition, this allow to exclude python deps
on docker images for example.
