### PR TITLE
chore: add auto-apt-proxy to vagrant prepare

### DIFF
--- a/installer/vagrant/debian.sh
+++ b/installer/vagrant/debian.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
+sed --in-place 's/deb\.debian\.org/cdn-fastly.deb.debian.org/g' /etc/apt/sources.list
+
 DEBIAN_FRONTEND=noninteractive apt-get update --allow-releaseinfo-change
 DEBIAN_FRONTEND=noninteractive apt-get -y install alsa-utils auto-apt-proxy
+
 usermod -a -G audio vagrant
 usermod -a -G audio www-data

--- a/installer/vagrant/debian.sh
+++ b/installer/vagrant/debian.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 DEBIAN_FRONTEND=noninteractive apt-get update --allow-releaseinfo-change
-DEBIAN_FRONTEND=noninteractive apt-get -y install alsa-utils
+DEBIAN_FRONTEND=noninteractive apt-get -y install alsa-utils auto-apt-proxy
 usermod -a -G audio vagrant
 usermod -a -G audio www-data


### PR DESCRIPTION
While this should be working out of the box, I had some issues when using `deb.debian.org`, and using the old mirrors urls fixed it. See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=986356

Fixes #1396