### PR TITLE
chore(legacy): upgrade propel1 dependency

### DIFF
--- a/legacy/composer.lock
+++ b/legacy/composer.lock
@@ -160,21 +160,23 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jooola/propel1.git",
-                "reference": "419193e7f7fe3b7123cd4fc475264adef7005831"
+                "reference": "9758036652d6da204f4680adfcb8583ab819a21f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jooola/propel1/zipball/419193e7f7fe3b7123cd4fc475264adef7005831",
-                "reference": "419193e7f7fe3b7123cd4fc475264adef7005831",
+                "url": "https://api.github.com/repos/jooola/propel1/zipball/9758036652d6da204f4680adfcb8583ab819a21f",
+                "reference": "9758036652d6da204f4680adfcb8583ab819a21f",
                 "shasum": ""
             },
             "require": {
                 "phing/phing": "~2.4",
-                "php": ">=5.2.4"
+                "php": "^7.1"
             },
             "require-dev": {
                 "pear-pear.php.net/pear_packagefilemanager2": "@stable",
-                "phpunit/phpunit": "~4.0||~5.0"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^9.0.0",
+                "squizlabs/php_codesniffer": "^3.5"
             },
             "default-branch": true,
             "bin": [
@@ -197,6 +199,14 @@
                 "runtime/lib",
                 "generator/lib"
             ],
+            "scripts": {
+                "post-install-cmd": [
+                    "\"vendor/bin/phpcs\" --config-set installed_paths vendor/phpcompatibility/php-compatibility"
+                ],
+                "post-update-cmd": [
+                    "\"vendor/bin/phpcs\" --config-set installed_paths vendor/phpcompatibility/php-compatibility"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -219,7 +229,7 @@
             "support": {
                 "source": "https://github.com/jooola/propel1/tree/master"
             },
-            "time": "2021-10-03T22:21:13+00:00"
+            "time": "2022-01-13T02:39:05+00:00"
         },
         {
             "name": "massivescale/celery-php",


### PR DESCRIPTION
In the propel fork I setup for libretime, I merged the changes from https://github.com/propelorm/Propel/pull/1086 as it brings a lot of fixes and it appears that his branch was working perfectly for over a year in one of the author's project. As I am not a propel / php expert I would rather rely on his code than mine. 

His branch passed the testsuite with php7.4, but I couldn't reproduce it, and didn't want to dig too much into it. If someone wants to make the testsuite pass, it would be great !

This PR will include these changes.

Maybe this can fix #1448, I haven't tested it yet, but that in my plans.