### PR TITLE
ci: cancel duplicate test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
     types: [opened, reopened, synchronize, edited]
     branches: [main]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This cancel previous test workflows. Based on https://stackoverflow.com/a/66336834
