### PR TITLE
feat(api): improve api settings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,7 @@ jobs:
       run:
         shell: bash
     env:
-      LIBRETIME_CONF_FILE: /tmp/libretime-test.conf
+      LIBRETIME_CONFIG_FILEPATH: /tmp/libretime-test.conf
 
     steps:
       - uses: actions/checkout@v2
@@ -222,7 +222,7 @@ jobs:
 
       - name: Setup libretime configuration
         run: |
-          cat <<EOF > $LIBRETIME_CONF_FILE
+          cat <<EOF > $LIBRETIME_CONFIG_FILEPATH
           [general]
           api_key = test_key
           [database]
@@ -231,7 +231,7 @@ jobs:
           dbuser = postgres
           dbpass = libretime
           EOF
-          cat $LIBRETIME_CONF_FILE
+          cat $LIBRETIME_CONFIG_FILEPATH
 
       - name: Test
         run: make test

--- a/api/install/systemd/libretime-api.service
+++ b/api/install/systemd/libretime-api.service
@@ -2,6 +2,8 @@
 Description=LibreTime API Service
 
 [Service]
+Environment=LIBRETIME_LOG_FILEPATH=/var/log/libretime/api.log
+
 ExecStart=/usr/bin/uwsgi /etc/airtime/libretime-api.ini
 User=libretime-api
 Group=libretime-api

--- a/api/libretime_api/settings.py
+++ b/api/libretime_api/settings.py
@@ -148,6 +148,23 @@ AUTH_USER_MODEL = "libretime_api.User"
 
 TEST_RUNNER = "libretime_api.tests.runners.ManagedModelTestRunner"
 
+
+LOGGING_HANDLERS = {
+    "console": {
+        "level": "INFO",
+        "class": "logging.StreamHandler",
+        "formatter": "simple",
+    },
+}
+
+if LIBRETIME_LOG_FILEPATH is not None:
+    LOGGING_HANDLERS["file"] = {
+        "level": "DEBUG",
+        "class": "logging.FileHandler",
+        "filename": LIBRETIME_LOG_FILEPATH,
+        "formatter": "verbose",
+    }
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -161,30 +178,15 @@ LOGGING = {
             "style": "{",
         },
     },
-    "handlers": {
-        "file": {
-            "level": "DEBUG",
-            "class": "logging.FileHandler",
-            "filename": os.path.join(
-                CONFIG.get("pypo", "log_base_dir", fallback=".").replace("'", ""),
-                "api.log",
-            ),
-            "formatter": "verbose",
-        },
-        "console": {
-            "level": "INFO",
-            "class": "logging.StreamHandler",
-            "formatter": "simple",
-        },
-    },
+    "handlers": LOGGING_HANDLERS,
     "loggers": {
         "django": {
-            "handlers": ["file", "console"],
+            "handlers": LOGGING_HANDLERS.keys(),
             "level": "INFO",
             "propagate": True,
         },
         "libretime_api": {
-            "handlers": ["file", "console"],
+            "handlers": LOGGING_HANDLERS.keys(),
             "level": "INFO",
             "propagate": True,
         },

--- a/api/libretime_api/settings.py
+++ b/api/libretime_api/settings.py
@@ -4,16 +4,22 @@ import sys
 
 from .utils import get_random_string, read_config_file
 
-LIBRETIME_CONF_DIR = os.getenv("LIBRETIME_CONF_DIR", "/etc/airtime")
-DEFAULT_CONFIG_PATH = os.getenv(
-    "LIBRETIME_CONF_FILE", os.path.join(LIBRETIME_CONF_DIR, "airtime.conf")
-)
 API_VERSION = "2.0.0"
 
+LIBRETIME_LOG_FILEPATH = os.getenv("LIBRETIME_LOG_FILEPATH")
+LIBRETIME_CONFIG_FILEPATH = os.getenv(
+    "LIBRETIME_CONFIG_FILEPATH",
+    "/etc/airtime/airtime.conf",
+)
+LIBRETIME_STATIC_ROOT = os.getenv(
+    "LIBRETIME_STATIC_ROOT",
+    "/usr/share/airtime/api",
+)
+
 try:
-    CONFIG = read_config_file(DEFAULT_CONFIG_PATH)
+    CONFIG = read_config_file(LIBRETIME_CONFIG_FILEPATH)
 except IOError as e:
-    print(f"Unable to read config file {DEFAULT_CONFIG_PATH}", file=sys.stderr)
+    print(f"Unable to read config file {LIBRETIME_CONFIG_FILEPATH}", file=sys.stderr)
     print(e, file=sys.stderr)
     CONFIG = configparser.ConfigParser()
 
@@ -144,7 +150,7 @@ USE_TZ = True
 
 STATIC_URL = "/api/static/"
 if not DEBUG:
-    STATIC_ROOT = os.getenv("LIBRETIME_STATIC_ROOT", "/usr/share/airtime/api")
+    STATIC_ROOT = LIBRETIME_STATIC_ROOT
 
 AUTH_USER_MODEL = "libretime_api.User"
 

--- a/api/libretime_api/settings.py
+++ b/api/libretime_api/settings.py
@@ -1,6 +1,4 @@
-import configparser
 import os
-import sys
 
 from .utils import get_random_string, read_config_file
 
@@ -15,13 +13,7 @@ LIBRETIME_STATIC_ROOT = os.getenv(
     "LIBRETIME_STATIC_ROOT",
     "/usr/share/airtime/api",
 )
-
-try:
-    CONFIG = read_config_file(LIBRETIME_CONFIG_FILEPATH)
-except IOError as e:
-    print(f"Unable to read config file {LIBRETIME_CONFIG_FILEPATH}", file=sys.stderr)
-    print(e, file=sys.stderr)
-    CONFIG = configparser.ConfigParser()
+CONFIG = read_config_file(LIBRETIME_CONFIG_FILEPATH)
 
 
 # Quick-start development settings - unsuitable for production

--- a/api/libretime_api/utils.py
+++ b/api/libretime_api/utils.py
@@ -1,23 +1,24 @@
-import configparser
 import random
 import string
 import sys
+from configparser import ConfigParser
 
 
-def read_config_file(config_path):
+def read_config_file(config_filepath):
     """Parse the application's config file located at config_path."""
-    config = configparser.ConfigParser()
+    config = ConfigParser()
     try:
-        config.readfp(open(config_path))
-    except IOError as e:
+        with open(config_filepath, encoding="utf-8") as config_file:
+            config.read_file(config_file)
+    except IOError as error:
         print(
-            "Failed to open config file at {}: {}".format(config_path, e.strerror),
+            f"Unable to read config file at {config_filepath}: {error.strerror}",
             file=sys.stderr,
         )
-        raise e
-    except Exception as e:
-        print(e.strerror, file=sys.stderr)
-        raise e
+        return ConfigParser()
+    except Exception as error:
+        print(error, file=sys.stderr)
+        raise error
     return config
 
 


### PR DESCRIPTION
:warning: Do not squash

As side effect, this allow to run collect static without having a configuration file or log directory deployed. 

- feat(api): update env var settings loading

BREAKING CHANGE: environment variables names changed
"LIBRETIME_CONF_DIR" was removed
"LIBRETIME_CONF_FILE" was renamed to "LIBRETIME_CONFIG_FILEPATH"

- fix(api): duplicate exception raising and close file

- feat(api): allow to run without log file for dev

BREAKING CHANGE: moved production api log file
from '/var/log/airtime/api.log' to '/var/log/libretime/api.log'