### PR TITLE
feat(playout): migrate notify cli to click

### DIFF
--- a/playout/libretime_liquidsoap/1.1/ls_lib.liq
+++ b/playout/libretime_liquidsoap/1.1/ls_lib.liq
@@ -1,7 +1,13 @@
-def notify(m)
-  command = "timeout --signal=KILL 45 libretime-playout-notify --media-id=#{m['schedule_table_id']} &"
+def gateway(args)
+  prefix = "timeout --signal=KILL 45"
+  command = "libretime-playout-notify #{args}"
+  suffix = "&"
   log(command)
-  system(command)
+  system("#{prefix} #{command} #{suffix}")
+end
+
+def notify(m)
+  gateway("media '#{m['schedule_table_id']}'")
 end
 
 def notify_queue(m)
@@ -11,15 +17,13 @@ def notify_queue(m)
 end
 
 def notify_stream(m)
-  json_str = string.replace(pattern="\n",(fun (s) -> ""), json_of(m))
-  #if a string has a single apostrophe in it, let's comment it out by ending the string before right before it
-  #escaping the apostrophe, and then starting a new string right after it. This is why we use 3 apostrophes.
-  json_str = string.replace(pattern="'",(fun (s) -> "'\''"), json_str)
-  command = "timeout --signal=KILL 45 libretime-playout-notify --webstream='#{json_str}' --media-id=#{!current_dyn_id} &"
-
   if !current_dyn_id != "-1" then
-    log(command)
-    system(command)
+    json_str = string.replace(pattern="\n",(fun (s) -> ""), json_of(m))
+    #if a string has a single apostrophe in it, let's comment it out by ending the string before right before it
+    #escaping the apostrophe, and then starting a new string right after it. This is why we use 3 apostrophes.
+    json_str = string.replace(pattern="'",(fun (s) -> "'\''"), json_str)
+
+    gateway("webstream '#{!current_dyn_id}' '#{json_str}'")
   end
 end
 
@@ -97,16 +101,12 @@ def output_to(output_type, type, bitrate, host, port, pass, mount_point, url, de
     source = ref s
     def on_error(msg)
         connected := "false"
-        command = "timeout --signal=KILL 45 libretime-playout-notify --error='#{msg}' --stream-id=#{stream} --time=#{!time} &"
-        system(command)
-        log(command)
+        gateway("stream '#{stream}' '#{!time}' --error='#{msg}'")
         5.
     end
     def on_connect()
         connected := "true"
-        command = "timeout --signal=KILL 45 libretime-playout-notify --connect --stream-id=#{stream} --time=#{!time} &"
-        system(command)
-        log(command)
+        gateway("stream '#{stream}' '#{!time}'")
     end
 
     stereo = (channels == "stereo")

--- a/playout/libretime_liquidsoap/1.1/ls_script.liq
+++ b/playout/libretime_liquidsoap/1.1/ls_script.liq
@@ -217,9 +217,7 @@ def make_scheduled_play_unavailable()
 end
 
 def update_source_status(sourcename, status) =
-    command = "timeout --signal=KILL 45 libretime-playout-notify --source-name=#{sourcename} --source-status=#{status} &"
-    system(command)
-    log(command)
+    gateway("live '#{sourcename}' '#{status}'")
 end
 
 def live_dj_connect(header) =
@@ -442,7 +440,4 @@ if s4_enable == true then
                 s4_connected, s4_description, s4_channels)
 end
 
-
-command = "timeout --signal=KILL 45 libretime-playout-notify --liquidsoap-started &"
-log(command)
-system(command)
+gateway("started")

--- a/playout/libretime_liquidsoap/1.3/ls_lib.liq
+++ b/playout/libretime_liquidsoap/1.3/ls_lib.liq
@@ -1,7 +1,13 @@
-def notify(m)
-  command = "timeout --signal=KILL 45 libretime-playout-notify --media-id=#{m['schedule_table_id']} &"
+def gateway(args)
+  prefix = "timeout --signal=KILL 45"
+  command = "libretime-playout-notify #{args}"
+  suffix = "&"
   log(command)
-  system(command)
+  system("#{prefix} #{command} #{suffix}")
+end
+
+def notify(m)
+  gateway("media '#{m['schedule_table_id']}'")
 end
 
 def notify_queue(m)
@@ -11,15 +17,12 @@ def notify_queue(m)
 end
 
 def notify_stream(m)
-  json_str = string.replace(pattern="\n",(fun (s) -> ""), json_of(m))
-  #if a string has a single apostrophe in it, let's comment it out by ending the string before right before it
-  #escaping the apostrophe, and then starting a new string right after it. This is why we use 3 apostrophes.
-  json_str = string.replace(pattern="'",(fun (s) -> "'\''"), json_str)
-  command = "timeout --signal=KILL 45 libretime-playout-notify --webstream='#{json_str}' --media-id=#{!current_dyn_id} &"
-
   if !current_dyn_id != "-1" then
-    log(command)
-    system(command)
+    json_str = string.replace(pattern="\n",(fun (s) -> ""), json_of(m))
+    #if a string has a single apostrophe in it, let's comment it out by ending the string before right before it
+    #escaping the apostrophe, and then starting a new string right after it. This is why we use 3 apostrophes.
+    json_str = string.replace(pattern="'",(fun (s) -> "'\''"), json_str)
+    gateway("webstream '#{!current_dyn_id}' '#{json_str}'")
   end
 end
 
@@ -97,16 +100,12 @@ def output_to(output_type, type, bitrate, host, port, pass, mount_point, url, de
     source = ref s
     def on_error(msg)
         connected := "false"
-        command = "timeout --signal=KILL 45 libretime-playout-notify --error='#{msg}' --stream-id=#{stream} --time=#{!time} &"
-        system(command)
-        log(command)
+        gateway("stream '#{stream}' '#{!time}' --error='#{msg}'")
         5.
     end
     def on_connect()
         connected := "true"
-        command = "timeout --signal=KILL 45 libretime-playout-notify --connect --stream-id=#{stream} --time=#{!time} &"
-        system(command)
-        log(command)
+        gateway("stream '#{stream}' '#{!time}'")
     end
 
     stereo = (channels == "stereo")

--- a/playout/libretime_liquidsoap/1.3/ls_script.liq
+++ b/playout/libretime_liquidsoap/1.3/ls_script.liq
@@ -217,9 +217,7 @@ def make_scheduled_play_unavailable()
 end
 
 def update_source_status(sourcename, status) =
-    command = "timeout --signal=KILL 45 libretime-playout-notify --source-name=#{sourcename} --source-status=#{status} &"
-    system(command)
-    log(command)
+    gateway("live '#{sourcename}' '#{status}'")
 end
 
 def live_dj_connect(header) =
@@ -457,6 +455,4 @@ if s4_enable == true then
 end
 
 
-command = "timeout --signal=KILL 45 libretime-playout-notify --liquidsoap-started &"
-log(command)
-system(command)
+gateway("started")

--- a/playout/libretime_liquidsoap/1.4/ls_lib.liq
+++ b/playout/libretime_liquidsoap/1.4/ls_lib.liq
@@ -1,7 +1,11 @@
-def notify(m)
-  command = "timeout --signal=KILL 45 libretime-playout-notify --media-id=#{m['schedule_table_id']} &"
+def gateway(args)
+  command = "timeout --signal=KILL 45 libretime-playout-notify #{args} &"
   log(command)
   system(command)
+end
+
+def notify(m)
+  gateway("media '#{m['schedule_table_id']}'")
 end
 
 def notify_queue(m)
@@ -11,15 +15,13 @@ def notify_queue(m)
 end
 
 def notify_stream(m)
-  json_str = string.replace(pattern="\n",(fun (s) -> ""), json_of(m))
-  #if a string has a single apostrophe in it, let's comment it out by ending the string before right before it
-  #escaping the apostrophe, and then starting a new string right after it. This is why we use 3 apostrophes.
-  json_str = string.replace(pattern="'",(fun (s) -> "'\''"), json_str)
-  command = "timeout --signal=KILL 45 libretime-playout-notify --webstream='#{json_str}' --media-id=#{!current_dyn_id} &"
-
   if !current_dyn_id != "-1" then
-    log(command)
-    system(command)
+    json_str = string.replace(pattern="\n",(fun (s) -> ""), json_of(m))
+    #if a string has a single apostrophe in it, let's comment it out by ending the string before right before it
+    #escaping the apostrophe, and then starting a new string right after it. This is why we use 3 apostrophes.
+    json_str = string.replace(pattern="'",(fun (s) -> "'\''"), json_str)
+
+    gateway("webstream '#{!current_dyn_id}' '#{json_str}'")
   end
 end
 
@@ -88,16 +90,12 @@ def output_to(output_type, type, bitrate, host, port, pass, mount_point, url, de
     source = ref s
     def on_error(msg)
         connected := "false"
-        command = "timeout --signal=KILL 45 libretime-playout-notify --error='#{msg}' --stream-id=#{stream} --time=#{!time} &"
-        system(command)
-        log(command)
+        gateway("stream '#{stream}' '#{!time}' --error='#{msg}'")
         5.
     end
     def on_connect()
         connected := "true"
-        command = "timeout --signal=KILL 45 libretime-playout-notify --connect --stream-id=#{stream} --time=#{!time} &"
-        system(command)
-        log(command)
+        gateway("stream '#{stream}' '#{!time}'")
     end
 
     stereo = (channels == "stereo")

--- a/playout/libretime_liquidsoap/1.4/ls_script.liq
+++ b/playout/libretime_liquidsoap/1.4/ls_script.liq
@@ -220,9 +220,7 @@ def make_scheduled_play_unavailable()
 end
 
 def update_source_status(sourcename, status) =
-    command = "timeout --signal=KILL 45 libretime-playout-notify --source-name=#{sourcename} --source-status=#{status} &"
-    system(command)
-    log(command)
+    gateway("live '#{sourcename}' '#{status}'")
 end
 
 def live_dj_connect(header) =
@@ -460,6 +458,4 @@ if s4_enable == true then
 end
 
 
-command = "timeout --signal=KILL 45 libretime-playout-notify --liquidsoap-started &"
-log(command)
-system(command)
+gateway("started")

--- a/playout/setup.py
+++ b/playout/setup.py
@@ -29,7 +29,7 @@ setup(
         "console_scripts": [
             "libretime-playout=libretime_playout.main:cli",
             "libretime-liquidsoap=libretime_liquidsoap.main:cli",
-            "libretime-playout-notify=libretime_playout.notify.main:run",
+            "libretime-playout-notify=libretime_playout.notify.main:cli",
         ]
     },
     python_requires=">=3.6",


### PR DESCRIPTION
Fixes #1502

- replace notify option parser with click
- refactor call from liquidsoap to playout-notify

BREAKING CHANGE: the playout-notify log file in '/var/log/airtime/pypo-liquidsoap/notify.log' was removed and merged into the existing '/var/log/libretime/liquidsoap.log' log file.