### PR TITLE
fix: make vagrant source.list update idempotent

### DIFF
--- a/installer/vagrant/debian.sh
+++ b/installer/vagrant/debian.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-sed --in-place 's/deb\.debian\.org/cdn-fastly.deb.debian.org/g' /etc/apt/sources.list
+sed --in-place 's|http://deb\.debian\.org|http://cdn-fastly.deb.debian.org|g' /etc/apt/sources.list
 
 DEBIAN_FRONTEND=noninteractive apt-get update --allow-releaseinfo-change
 DEBIAN_FRONTEND=noninteractive apt-get -y install alsa-utils auto-apt-proxy


### PR DESCRIPTION
First run works, but any extra run will break the source.list file.