### PR TITLE
chore: improve python packages configuration

### DIFF
--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -3,8 +3,8 @@ all: lint test
 include ../tools/python.mk
 
 PIP_INSTALL := --editable .[dev]
-PYLINT_ARG := libretime_analyzer tests
-MYPY_ARG := libretime_analyzer tests
+PYLINT_ARG := libretime_analyzer tests || true
+MYPY_ARG := libretime_analyzer tests || true
 PYTEST_ARG := --cov=libretime_analyzer tests
 
 format: .format

--- a/analyzer/pyproject.toml
+++ b/analyzer/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/analyzer/pyproject.toml
+++ b/analyzer/pyproject.toml
@@ -1,3 +1,11 @@
+[tool.pylint.messages_control]
+extension-pkg-whitelist = "pydantic"
+disable = [
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "missing-module-docstring",
+]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/analyzer/setup.py
+++ b/analyzer/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from setuptools import setup
 
 # Change directory since setuptools uses relative paths
-here = Path(__file__).parent
+here = Path(__file__).parent.resolve()
 chdir(here)
 
 setup(

--- a/analyzer/setup.py
+++ b/analyzer/setup.py
@@ -38,8 +38,8 @@ setup(
     extras_require={
         "dev": [
             "distro",
-            f"libretime-api-client @ file://localhost/{here.parent / 'api_client'}#egg=libretime_api_client",
-            f"libretime-shared @ file://localhost/{here.parent / 'shared'}#egg=libretime_shared",
+            f"libretime-api-client @ file://localhost{here.parent / 'api_client'}",
+            f"libretime-shared @ file://localhost{here.parent / 'shared'}",
         ],
     },
     zip_safe=False,

--- a/api/Makefile
+++ b/api/Makefile
@@ -3,8 +3,8 @@ all: lint
 include ../tools/python.mk
 
 PIP_INSTALL := --editable .[dev]
-PYLINT_ARG := libretime_api
-MYPY_ARG := libretime_api
+PYLINT_ARG := libretime_api || true
+MYPY_ARG := libretime_api || true
 
 format: .format
 lint: .format-check .pylint .mypy

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,3 +1,11 @@
+[tool.pylint.messages_control]
+extension-pkg-whitelist = "pydantic"
+disable = [
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "missing-module-docstring",
+]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/api/setup.py
+++ b/api/setup.py
@@ -1,9 +1,12 @@
-import os
+from os import chdir
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
 # Change directory since setuptools uses relative paths
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
+here = Path(__file__).parent.resolve()
+chdir(here)
+
 
 setup(
     name="libretime-api",

--- a/api_client/Makefile
+++ b/api_client/Makefile
@@ -3,8 +3,8 @@ all: lint test
 include ../tools/python.mk
 
 PIP_INSTALL := --editable .
-PYLINT_ARG := libretime_api_client tests
-MYPY_ARG := libretime_api_client tests
+PYLINT_ARG := libretime_api_client tests || true
+MYPY_ARG := libretime_api_client tests || true
 PYTEST_ARG := --cov=libretime_api_client tests
 
 format: .format

--- a/api_client/pyproject.toml
+++ b/api_client/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/api_client/pyproject.toml
+++ b/api_client/pyproject.toml
@@ -1,3 +1,11 @@
+[tool.pylint.messages_control]
+extension-pkg-whitelist = "pydantic"
+disable = [
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "missing-module-docstring",
+]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/api_client/setup.py
+++ b/api_client/setup.py
@@ -1,9 +1,11 @@
-import os
+from os import chdir
+from pathlib import Path
 
 from setuptools import setup
 
 # Change directory since setuptools uses relative paths
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
+here = Path(__file__).parent.resolve()
+chdir(here)
 
 setup(
     name="libretime-api-client",

--- a/playout/.pylintrc
+++ b/playout/.pylintrc
@@ -1,4 +1,0 @@
-[MESSAGES CONTROL]
-disable=missing-module-docstring,
-        missing-class-docstring,
-        missing-function-docstring,

--- a/playout/Makefile
+++ b/playout/Makefile
@@ -3,8 +3,8 @@ all: lint
 include ../tools/python.mk
 
 PIP_INSTALL := --editable .[dev]
-PYLINT_ARG := libretime_liquidsoap libretime_playout
-MYPY_ARG := libretime_liquidsoap libretime_playout
+PYLINT_ARG := libretime_liquidsoap libretime_playout || true
+MYPY_ARG := libretime_liquidsoap libretime_playout || true
 
 format: .format
 lint: .format-check .pylint .mypy

--- a/playout/pyproject.toml
+++ b/playout/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/playout/pyproject.toml
+++ b/playout/pyproject.toml
@@ -1,3 +1,11 @@
+[tool.pylint.messages_control]
+extension-pkg-whitelist = "pydantic"
+disable = [
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "missing-module-docstring",
+]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/playout/setup.py
+++ b/playout/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from setuptools import setup
 
 # Change directory since setuptools uses relative paths
-here = Path(__file__).parent
+here = Path(__file__).parent.resolve()
 chdir(here)
 
 setup(

--- a/playout/setup.py
+++ b/playout/setup.py
@@ -46,8 +46,8 @@ setup(
     ],
     extras_require={
         "dev": [
-            f"libretime-shared @ file://localhost/{here.parent / 'shared'}#egg=libretime_shared",
-            f"libretime-api-client @ file://localhost/{here.parent / 'api_client'}#egg=libretime_api_client",
+            f"libretime-api-client @ file://localhost{here.parent / 'api_client'}",
+            f"libretime-shared @ file://localhost{here.parent / 'shared'}",
         ],
     },
     zip_safe=False,

--- a/shared/.pylintrc
+++ b/shared/.pylintrc
@@ -1,5 +1,0 @@
-[MESSAGES CONTROL]
-extension-pkg-whitelist = pydantic
-disable=missing-module-docstring,
-        missing-class-docstring,
-        missing-function-docstring,

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -4,10 +4,7 @@ include ../tools/python.mk
 
 PIP_INSTALL = --editable .[dev]
 PYLINT_ARG = libretime_shared tests || true
-MYPY_ARG =	--disallow-untyped-calls \
-			--disallow-untyped-defs \
-			--disallow-incomplete-defs \
-			libretime_shared || true
+MYPY_ARG = libretime_shared || true
 PYTEST_ARG = --cov=libretime_shared tests
 
 format: .format

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -3,8 +3,8 @@ all: lint test
 include ../tools/python.mk
 
 PIP_INSTALL = --editable .[dev]
-PYLINT_ARG = libretime_shared tests || true
-MYPY_ARG = libretime_shared || true
+PYLINT_ARG = libretime_shared tests
+MYPY_ARG = libretime_shared
 PYTEST_ARG = --cov=libretime_shared tests
 
 format: .format

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -3,11 +3,11 @@ all: lint test
 include ../tools/python.mk
 
 PIP_INSTALL = --editable .[dev]
-PYLINT_ARG = libretime_shared tests
+PYLINT_ARG = libretime_shared tests || true
 MYPY_ARG =	--disallow-untyped-calls \
 			--disallow-untyped-defs \
 			--disallow-incomplete-defs \
-			libretime_shared
+			libretime_shared || true
 PYTEST_ARG = --cov=libretime_shared tests
 
 format: .format

--- a/shared/libretime_shared/config.py
+++ b/shared/libretime_shared/config.py
@@ -85,6 +85,7 @@ class BaseConfig(BaseModel):
         if filepath is None:
             return {}
 
+        # pylint: disable=fixme
         # TODO: Remove ability to load ini files once yaml if fully supported.
         if filepath.suffix == ".conf":
             config = ConfigParser()

--- a/shared/libretime_shared/logging.py
+++ b/shared/libretime_shared/logging.py
@@ -64,18 +64,18 @@ def setup_logger(
     :param serialize: generate JSON formatted log records
     :returns: log level guessed from the verbosity
     """
-    handlers = [dict(sink=sys.stderr, level=level.no, serialize=serialize)]
+    handlers = [{"sink": sys.stderr, "level": level.no, "serialize": serialize}]
 
     if filepath is not None:
         handlers.append(
-            dict(
-                sink=filepath,
-                enqueue=True,
-                level=level.no,
-                serialize=serialize,
-                rotation="12:00",
-                retention="7 days",
-            )
+            {
+                "sink": filepath,
+                "enqueue": True,
+                "level": level.no,
+                "serialize": serialize,
+                "rotation": "12:00",
+                "retention": "7 days",
+            }
         )
 
     logger.configure(handlers=handlers)
@@ -101,14 +101,14 @@ def create_task_logger(
 
     task_logger.configure(
         handlers=[
-            dict(
-                sink=filepath,
-                enqueue=True,
-                level=level.no,
-                serialize=serialize,
-                rotation="12:00",
-                retention="7 days",
-            )
+            {
+                "sink": filepath,
+                "enqueue": True,
+                "level": level.no,
+                "serialize": serialize,
+                "rotation": "12:00",
+                "retention": "7 days",
+            }
         ],
     )
 

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -1,3 +1,17 @@
+[tool.pylint.messages_control]
+extension-pkg-whitelist = "pydantic"
+disable = [
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "missing-module-docstring",
+]
+
+[tool.mypy]
+allow_redefinition = true
+disallow_incomplete_defs= true
+disallow_untyped_calls= true
+disallow_untyped_defs= true
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/shared/setup.py
+++ b/shared/setup.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 from setuptools import setup
 
-here = Path(__file__).parent
+# Change directory since setuptools uses relative paths
+here = Path(__file__).parent.resolve()
 chdir(here)
 
 setup(

--- a/shared/tests/config_test.py
+++ b/shared/tests/config_test.py
@@ -32,13 +32,13 @@ def test_base_config(tmp_path: Path):
 
     with mock.patch.dict(
         environ,
-        dict(
-            LIBRETIME_API="invalid",
-            LIBRETIME_DATABASE="invalid",
-            LIBRETIME_DATABASE_PORT="8888",
-            LIBRETIME_RABBITMQ_HOST="changed",
-            WRONGPREFIX_API_KEY="invalid",
-        ),
+        {
+            "LIBRETIME_API": "invalid",
+            "LIBRETIME_DATABASE": "invalid",
+            "LIBRETIME_DATABASE_PORT": "8888",
+            "LIBRETIME_RABBITMQ_HOST": "changed",
+            "WRONGPREFIX_API_KEY": "invalid",
+        },
     ):
         config = FixtureConfig(filepath=config_filepath)
 
@@ -49,13 +49,13 @@ def test_base_config(tmp_path: Path):
         assert config.rabbitmq.port == 5672
 
     # Optional model: loading default values (rabbitmq)
-    with mock.patch.dict(environ, dict()):
+    with mock.patch.dict(environ, {}):
         config = FixtureConfig(filepath=config_filepath)
         assert config.rabbitmq.host == "localhost"
         assert config.rabbitmq.port == 5672
 
     # Optional model: overriding using environment (rabbitmq)
-    with mock.patch.dict(environ, dict(LIBRETIME_RABBITMQ_HOST="changed")):
+    with mock.patch.dict(environ, {"LIBRETIME_RABBITMQ_HOST": "changed"}):
         config = FixtureConfig(filepath=config_filepath)
         assert config.rabbitmq.host == "changed"
         assert config.rabbitmq.port == 5672
@@ -74,7 +74,7 @@ def test_base_config_ini(tmp_path: Path):
 
     with mock.patch.dict(
         environ,
-        dict(LIBRETIME_API_KEY="f3bf04fc"),
+        {"LIBRETIME_API_KEY": "f3bf04fc"},
     ):
         config = FixtureConfig(filepath=config_filepath)
 

--- a/tools/.pylintrc
+++ b/tools/.pylintrc
@@ -1,3 +1,0 @@
-[MESSAGES CONTROL]
-disable=missing-module-docstring,
-        missing-function-docstring

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,8 +3,8 @@ all: lint test
 include python.mk
 
 PIP_INSTALL =
-PYLINT_ARG = tools || true
-MYPY_ARG = . || true
+PYLINT_ARG = tools
+MYPY_ARG = .
 PYTEST_ARG = .
 
 format: .format

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,8 +3,8 @@ all: lint test
 include python.mk
 
 PIP_INSTALL =
-PYLINT_ARG = tools
-MYPY_ARG = .
+PYLINT_ARG = tools || true
+MYPY_ARG = . || true
 PYTEST_ARG = .
 
 format: .format

--- a/tools/packages_test.py
+++ b/tools/packages_test.py
@@ -28,7 +28,7 @@ def test_load_packages():
     assert load_packages(PACKAGE_INI, "focal", True, ["legacy"]) == result_exclude
 
 
-def test_list_packages(tmp_path: Path):
+def test_list_packages(tmp_path: Path) -> None:
     package_file = tmp_path / "packages.ini"
     package_file.write_text(PACKAGE_INI)
 

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -9,8 +9,6 @@ disable = [
 [tool.mypy]
 allow_redefinition = true
 disallow_incomplete_defs= true
-disallow_untyped_calls= true
-disallow_untyped_defs= true
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,3 +1,17 @@
+[tool.pylint.messages_control]
+extension-pkg-whitelist = "pydantic"
+disable = [
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "missing-module-docstring",
+]
+
+[tool.mypy]
+allow_redefinition = true
+disallow_incomplete_defs= true
+disallow_untyped_calls= true
+disallow_untyped_defs= true
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/tools/python.mk
+++ b/tools/python.mk
@@ -43,12 +43,12 @@ install: $(VENV)
 .PHONY: .pylint
 .pylint: $(VENV)
 	source $(VENV)/bin/activate
-	pylint --jobs=$(CPU_CORES) --output-format=colorized $(PYLINT_ARG) || true
+	pylint --jobs=$(CPU_CORES) --output-format=colorized $(PYLINT_ARG)
 
 .PHONY: .mypy
 .mypy: $(VENV)
 	source $(VENV)/bin/activate
-	mypy $(MYPY_ARG) || true
+	mypy $(MYPY_ARG)
 
 .PHONY: .pytest
 .pytest: $(VENV)

--- a/tools/python.mk
+++ b/tools/python.mk
@@ -26,7 +26,8 @@ $(VENV):
 install: $(VENV)
 	source $(VENV)/bin/activate
 	pip install --upgrade pip setuptools wheel
-	pip install $(SHARED_DEV_REQUIREMENTS) $(PIP_INSTALL)
+	pip install $(SHARED_DEV_REQUIREMENTS)
+	[[ -z "$(PIP_INSTALL)" ]] || pip install $(PIP_INSTALL)
 
 .PHONY: .format
 .format: $(VENV)

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -3,8 +3,8 @@ all: lint
 include ../tools/python.mk
 
 PIP_INSTALL := --editable .
-PYLINT_ARG := libretime_worker
-MYPY_ARG := libretime_worker
+PYLINT_ARG := libretime_worker || true
+MYPY_ARG := libretime_worker || true
 
 format: .format
 lint: .format-check .pylint .mypy

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -1,3 +1,11 @@
+[tool.pylint.messages_control]
+extension-pkg-whitelist = "pydantic"
+disable = [
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "missing-module-docstring",
+]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -1,9 +1,11 @@
-import os
+from os import chdir
+from pathlib import Path
 
 from setuptools import setup
 
 # Change directory since setuptools uses relative paths
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
+here = Path(__file__).parent.resolve()
+chdir(here)
 
 setup(
     name="libretime-celery",


### PR DESCRIPTION
Related to #1154 

This makes our different python package more consistent and use pep 517 with the pyproject.toml file for configuration.
 This also starts making our linters fail in CI for some package: shared, tools

:warning: Please do not squash