### PR TITLE
fix(legacy): make playlist model compatible with php74 null arrays

### DIFF
--- a/legacy/application/controllers/ApiController.php
+++ b/legacy/application/controllers/ApiController.php
@@ -303,24 +303,43 @@ class ApiController extends Zend_Controller_Action
                 $result = Application_Model_Schedule::GetPlayOrderRangeOld($limit);
             }
 
+            if (!isset($result)) {
+                $this->returnJsonOrJsonp($request, []);
+            }
+
             $stationUrl = Application_Common_HTTPHelper::getStationUrl();
 
-            if (($result['previous']['type'] != 'livestream') && isset($result['previous']['metadata'])) {
-                $previousID = $result['previous']['metadata']['id'];
-                $get_prev_artwork_url = $stationUrl . 'api/track?id=' . $previousID . '&return=artwork';
-                $result['previous']['metadata']['artwork_url'] = $get_prev_artwork_url;
+            if (isset($result['previous'])) {
+                if (
+                    (isset($result['previous']['type']) && $result['previous']['type'] != 'livestream')
+                    && isset($result['previous']['metadata'])
+                ) {
+                    $previousID = $result['previous']['metadata']['id'];
+                    $get_prev_artwork_url = $stationUrl . 'api/track?id=' . $previousID . '&return=artwork';
+                    $result['previous']['metadata']['artwork_url'] = $get_prev_artwork_url;
+                }
             }
 
-            if (($result['current']['type'] != 'livestream') && isset($result['current']['metadata'])) {
-                $currID = $result['current']['metadata']['id'];
-                $get_curr_artwork_url = $stationUrl . 'api/track?id=' . $currID . '&return=artwork';
-                $result['current']['metadata']['artwork_url'] = $get_curr_artwork_url;
+            if (isset($result['current'])) {
+                if (
+                    (isset($result['current']['type']) & $result['current']['type'] != 'livestream')
+                    && isset($result['current']['metadata'])
+                ) {
+                    $currID = $result['current']['metadata']['id'];
+                    $get_curr_artwork_url = $stationUrl . 'api/track?id=' . $currID . '&return=artwork';
+                    $result['current']['metadata']['artwork_url'] = $get_curr_artwork_url;
+                }
             }
 
-            if (($result['next']['type'] != 'livestream') && isset($result['next']['metadata'])) {
-                $nextID = $result['next']['metadata']['id'];
-                $get_next_artwork_url = $stationUrl . 'api/track?id=' . $nextID . '&return=artwork';
-                $result['next']['metadata']['artwork_url'] = $get_next_artwork_url;
+            if (isset($result['next'])) {
+                if (
+                    (isset($result['next']['type']) && $result['next']['type'] != 'livestream')
+                    && isset($result['next']['metadata'])
+                ) {
+                    $nextID = $result['next']['metadata']['id'];
+                    $get_next_artwork_url = $stationUrl . 'api/track?id=' . $nextID . '&return=artwork';
+                    $result['next']['metadata']['artwork_url'] = $get_next_artwork_url;
+                }
             }
 
             // apply user-defined timezone, or default to station

--- a/legacy/application/controllers/PlaylistController.php
+++ b/legacy/application/controllers/PlaylistController.php
@@ -230,8 +230,6 @@ class PlaylistController extends Zend_Controller_Action
             $this->createFullResponse($obj);
         } catch (PlaylistNotFoundException $e) {
             $this->playlistNotFound($type);
-        } catch (Exception $e) {
-            $this->playlistUnknownError($e);
         }
     }
 

--- a/legacy/application/models/Playlist.php
+++ b/legacy/application/models/Playlist.php
@@ -266,8 +266,8 @@ SQL;
 
             //format the fades in format 00(.000000)
             $fades = $this->getFadeInfo($row['position']);
-            $row['fadein'] = $fades[0];
-            $row['fadeout'] = $fades[1];
+            $row['fadein'] = $fades[0] ?? null;
+            $row['fadeout'] = $fades[1] ?? null;
 
             // format the cues in format 00:00:00(.0)
             // we need to add the '.0' for cues and not fades


### PR DESCRIPTION
Should close #1448

More of those PR's might come in the future as we start using Libretime with php74. Hunting down every possible case would be a huge work, we should use and fix what is broken.