### PR TITLE
feat(playout): change liquidsoap working dir

### DIFF
--- a/playout/install/systemd/libretime-liquidsoap.service
+++ b/playout/install/systemd/libretime-liquidsoap.service
@@ -4,6 +4,7 @@ Description=Libretime Liquidsoap Service
 [Service]
 Environment=LIBRETIME_LOG_FILEPATH=/var/log/libretime/liquidsoap.log
 Environment=LIBRETIME_CONFIG_FILEPATH=/etc/airtime/airtime.conf
+WorkingDirectory=/var/lib/libretime/playout
 
 ExecStart=/usr/local/bin/libretime-liquidsoap
 User=libretime-playout

--- a/playout/libretime_liquidsoap/main.py
+++ b/playout/libretime_liquidsoap/main.py
@@ -12,8 +12,6 @@ from loguru import logger
 
 from . import generate_liquidsoap_cfg
 
-PYPO_HOME = "/var/tmp/airtime/pypo/"
-
 
 @click.command()
 @cli_logging_options()
@@ -23,8 +21,6 @@ def cli(log_level: int, log_filepath: Optional[Path]):
     """
     log_level = level_from_name(log_level)
     setup_logger(log_level, log_filepath)
-
-    os.environ["HOME"] = PYPO_HOME
 
     generate_liquidsoap_cfg.run(log_filepath)
     # check liquidsoap version so we can run a scripts matching the liquidsoap minor version


### PR DESCRIPTION
BREAKING CHANGE: When running liquidsoap as a systemd service, the working directory is now /var/lib/libretime/playout.