### PR TITLE
feat(legacy): add db config defaults and allow custom port

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,9 +223,10 @@ jobs:
           api_key = test_key
           [database]
           host = postgres
-          dbname = libretime
-          dbuser = postgres
-          dbpass = libretime
+          port = 5432
+          name = libretime
+          user = postgres
+          password = libretime
           EOF
           cat $LIBRETIME_CONFIG_FILEPATH
 

--- a/api/libretime_api/settings.py
+++ b/api/libretime_api/settings.py
@@ -80,11 +80,11 @@ WSGI_APPLICATION = "libretime_api.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": CONFIG.get("database", "dbname", fallback=""),
-        "USER": CONFIG.get("database", "dbuser", fallback=""),
-        "PASSWORD": CONFIG.get("database", "dbpass", fallback=""),
-        "HOST": CONFIG.get("database", "host", fallback=""),
-        "PORT": "5432",
+        "NAME": CONFIG.get("database", "name", fallback="libretime"),
+        "USER": CONFIG.get("database", "user", fallback="libretime"),
+        "PASSWORD": CONFIG.get("database", "password", fallback="libretime"),
+        "HOST": CONFIG.get("database", "host", fallback="localhost"),
+        "PORT": CONFIG.get("database", "port", fallback="5432"),
     }
 }
 

--- a/docs/_docs/host-configuration.md
+++ b/docs/_docs/host-configuration.md
@@ -16,9 +16,10 @@ You can also set options for RabbitMQ messaging and the LibreTime server in this
 
     [database]
     host = localhost
-    dbname = airtime
-    dbuser = airtime
-    dbpass = airtime
+    port = 5432
+    name = libretime
+    user = libretime
+    password = libretime
 
     [rabbitmq]
     host = 127.0.0.1

--- a/docs/_docs/upgrading.md
+++ b/docs/_docs/upgrading.md
@@ -61,7 +61,9 @@ upgrading, please [file a bug](https://github.com/libretime/libretime/issues/new
    [install](/install).
 3. Before running the web-configuration, restore the Airtime database to the new
    PostgreSQL server, media database and configuration file
-4. Edit the configuration file to update any changed values
+4. Update the configuration file to match the new configuration schema and update any
+   changed values. See the [host configuration](/docs/host-configuration) documentation
+   for more details.
 5. Edit the Icecast password in `/etc/icecast2/icecast.xml` to reflect the
    password used in Airtime
 6. Restart the LibreTime services

--- a/legacy/application/configs/airtime-conf-production.php
+++ b/legacy/application/configs/airtime-conf-production.php
@@ -11,7 +11,8 @@
 
 $CC_CONFIG = Config::getConfig();
 
-$dbhost = $CC_CONFIG['dsn']['hostspec'];
+$dbhost = $CC_CONFIG['dsn']['host'];
+$dbport = $CC_CONFIG['dsn']['port'];
 $dbname = $CC_CONFIG['dsn']['database'];
 $dbuser = $CC_CONFIG['dsn']['username'];
 $dbpass = $CC_CONFIG['dsn']['password'];
@@ -21,7 +22,7 @@ $conf = [
         'airtime' => [
             'adapter' => 'pgsql',
             'connection' => [
-                'dsn' => "pgsql:host={$dbhost};port=5432;dbname={$dbname};user={$dbuser};password={$dbpass}",
+                'dsn' => "pgsql:host={$dbhost};port={$dbport};dbname={$dbname};user={$dbuser};password={$dbpass}",
             ],
         ],
         'default' => 'airtime',

--- a/legacy/application/configs/conf.php
+++ b/legacy/application/configs/conf.php
@@ -49,11 +49,12 @@ class Config
         $CC_CONFIG['cache_ahead_hours'] = $values['general']['cache_ahead_hours'];
 
         // Database config
-        $CC_CONFIG['dsn']['username'] = $values['database']['dbuser'];
-        $CC_CONFIG['dsn']['password'] = $values['database']['dbpass'];
-        $CC_CONFIG['dsn']['hostspec'] = $values['database']['host'];
         $CC_CONFIG['dsn']['phptype'] = 'pgsql';
-        $CC_CONFIG['dsn']['database'] = $values['database']['dbname'];
+        $CC_CONFIG['dsn']['host'] = $values['database']['host'];
+        $CC_CONFIG['dsn']['port'] = $values['database']['port'] ?? 5432;
+        $CC_CONFIG['dsn']['database'] = $values['database']['name'];
+        $CC_CONFIG['dsn']['username'] = $values['database']['user'];
+        $CC_CONFIG['dsn']['password'] = $values['database']['password'];
 
         $CC_CONFIG['apiKey'] = [$values['general']['api_key']];
 

--- a/legacy/application/configs/conf.php
+++ b/legacy/application/configs/conf.php
@@ -50,11 +50,11 @@ class Config
 
         // Database config
         $CC_CONFIG['dsn']['phptype'] = 'pgsql';
-        $CC_CONFIG['dsn']['host'] = $values['database']['host'];
+        $CC_CONFIG['dsn']['host'] = $values['database']['host'] ?? 'localhost';
         $CC_CONFIG['dsn']['port'] = $values['database']['port'] ?? 5432;
-        $CC_CONFIG['dsn']['database'] = $values['database']['name'];
-        $CC_CONFIG['dsn']['username'] = $values['database']['user'];
-        $CC_CONFIG['dsn']['password'] = $values['database']['password'];
+        $CC_CONFIG['dsn']['database'] = $values['database']['name'] ?? 'libretime';
+        $CC_CONFIG['dsn']['username'] = $values['database']['user'] ?? 'libretime';
+        $CC_CONFIG['dsn']['password'] = $values['database']['password'] ?? 'libretime';
 
         $CC_CONFIG['apiKey'] = [$values['general']['api_key']];
 

--- a/legacy/application/models/Auth.php
+++ b/legacy/application/models/Auth.php
@@ -83,7 +83,8 @@ class Application_Model_Auth
 
         // Database config
         $db = Zend_Db::factory('PDO_' . $CC_CONFIG['dsn']['phptype'], [
-            'host' => $CC_CONFIG['dsn']['hostspec'],
+            'host' => $CC_CONFIG['dsn']['host'],
+            'port' => $CC_CONFIG['dsn']['port'],
             'username' => $CC_CONFIG['dsn']['username'],
             'password' => $CC_CONFIG['dsn']['password'],
             'dbname' => $CC_CONFIG['dsn']['database'],

--- a/legacy/build/airtime.example.conf
+++ b/legacy/build/airtime.example.conf
@@ -78,23 +78,27 @@ auth = local
 #
 # These settings are used to configure your database connection.
 #
-# host:   The hostname of the database server.
-#         On a default Airtime installation, set this to localhost.
+# host:     The hostname of the database server.
+#           On a default Airtime installation, set this to localhost.
 #
-# dbname: The name of the Airtime database.
-#         The default is airtime.
+# port:     The port of the database server.
+#           On a default Airtime installation, set this to 5432.
 #
-# dbuser: The username for the Airtime database user.
-#         The default is airtime.
+# name:     The name of the Airtime database.
+#           The default is airtime.
 #
-# dbpass: The password for the Airtime database user.
-#         The default is airtime.
+# user:     The username for the Airtime database user.
+#           The default is airtime.
+#
+# password: The password for the Airtime database user.
+#           The default is airtime.
 #
 [database]
 host = localhost
-dbname = airtime
-dbuser = airtime
-dbpass = airtime
+port = 5432
+name = airtime
+user = airtime
+password = airtime
 #
 # ----------------------------------------------------------------------
 

--- a/legacy/tests/application/helpers/TestHelper.php
+++ b/legacy/tests/application/helpers/TestHelper.php
@@ -28,7 +28,8 @@ class TestHelper
 
         return new Zend_Config(
             [
-                'host' => $config['dsn']['hostspec'],
+                'host' => $config['dsn']['host'],
+                'port' => $config['dsn']['port'],
                 'dbname' => $config['dsn']['database'],
                 'username' => $config['dsn']['username'],
                 'password' => $config['dsn']['password'],
@@ -42,10 +43,11 @@ class TestHelper
         //is normally
         $CC_CONFIG = Config::getConfig();
 
+        $dbhost = $CC_CONFIG['dsn']['host'];
+        $dbport = $CC_CONFIG['dsn']['port'];
+        $dbname = $CC_CONFIG['dsn']['database'];
         $dbuser = $CC_CONFIG['dsn']['username'];
         $dbpasswd = $CC_CONFIG['dsn']['password'];
-        $dbname = $CC_CONFIG['dsn']['database'];
-        $dbhost = $CC_CONFIG['dsn']['hostspec'];
 
         $databaseAlreadyExists = AirtimeInstall::createDatabase();
         if ($databaseAlreadyExists) {
@@ -123,7 +125,7 @@ class TestHelper
             $con->commit();
         } else {
             //Create all the database tables
-            AirtimeInstall::CreateDatabaseTables($dbuser, $dbpasswd, $dbname, $dbhost);
+            AirtimeInstall::CreateDatabaseTables($dbuser, $dbpasswd, $dbname, $dbhost, $dbport);
             AirtimeInstall::UpdateDatabaseTables();
         }
     }

--- a/legacy/tests/config/airtime.conf
+++ b/legacy/tests/config/airtime.conf
@@ -1,9 +1,9 @@
 [database]
-
 host = localhost
-dbname = libretime_test
-dbuser = libretime
-dbpass = libretime
+port = 5432
+name = libretime_test
+user = libretime
+password = libretime
 
 [rabbitmq]
 host = 127.0.0.1


### PR DESCRIPTION
Add a port field (`database.port`) to the database config section.

BREAKING CHANGE: the database section in the config file has been updated:
- `database.dbname` was renamed to `database.name`
- `database.dbuser` was renamed to `database.user`
- `database.dbpass` was renamed to `database.password`