### PR TITLE
chore: setup bandit on python apps

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -5,9 +5,10 @@ include ../tools/python.mk
 PIP_INSTALL := --editable .[dev]
 PYLINT_ARG := libretime_api || true
 MYPY_ARG := libretime_api || true
+BANDIT_ARG := libretime_api || true
 
 format: .format
-lint: .format-check .pylint .mypy
+lint: .format-check .pylint .mypy .bandit
 clean: .clean
 
 test: $(VENV)

--- a/api_client/Makefile
+++ b/api_client/Makefile
@@ -5,9 +5,10 @@ include ../tools/python.mk
 PIP_INSTALL := --editable .
 PYLINT_ARG := libretime_api_client tests || true
 MYPY_ARG := libretime_api_client tests || true
+BANDIT_ARG := libretime_api_client || true
 PYTEST_ARG := --cov=libretime_api_client tests
 
 format: .format
-lint: .format-check .pylint .mypy
+lint: .format-check .pylint .mypy .bandit
 test: .pytest
 clean: .clean

--- a/playout/Makefile
+++ b/playout/Makefile
@@ -5,7 +5,8 @@ include ../tools/python.mk
 PIP_INSTALL := --editable .[dev]
 PYLINT_ARG := libretime_liquidsoap libretime_playout || true
 MYPY_ARG := libretime_liquidsoap libretime_playout || true
+BANDIT_ARG := libretime_liquidsoap libretime_playout || true
 
 format: .format
-lint: .format-check .pylint .mypy
+lint: .format-check .pylint .mypy .bandit
 clean: .clean

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -5,9 +5,10 @@ include ../tools/python.mk
 PIP_INSTALL = --editable .[dev]
 PYLINT_ARG = libretime_shared tests
 MYPY_ARG = libretime_shared
+BANDIT_ARG := libretime_shared
 PYTEST_ARG = --cov=libretime_shared tests
 
 format: .format
-lint: .format-check .pylint .mypy
+lint: .format-check .pylint .mypy .bandit
 test: .pytest
 clean: .clean

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -8,6 +8,6 @@ MYPY_ARG = libretime_shared
 PYTEST_ARG = --cov=libretime_shared tests
 
 format: .format
-lint: .pylint .mypy
+lint: .format-check .pylint .mypy
 test: .pytest
 clean: .clean

--- a/tools/python.mk
+++ b/tools/python.mk
@@ -1,5 +1,6 @@
 .ONESHELL:
 
+.DEFAULT_GOAL = install
 SHELL = bash
 CPU_CORES = $(shell nproc)
 

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -5,7 +5,8 @@ include ../tools/python.mk
 PIP_INSTALL := --editable .
 PYLINT_ARG := libretime_worker || true
 MYPY_ARG := libretime_worker || true
+BANDIT_ARG := libretime_worker || true
 
 format: .format
-lint: .format-check .pylint .mypy
+lint: .format-check .pylint .mypy .bandit
 clean: .clean


### PR DESCRIPTION
Please do not squash

Also set the default make target to install, so we don't automatically run lint, test, ... when running `make`