### PR TITLE
fix: use ';' as the deliminator in CSV export

### DIFF
--- a/legacy/public/js/libs/CSVexport.js
+++ b/legacy/public/js/libs/CSVexport.js
@@ -18,7 +18,7 @@ Compress with: http://jscompress.com/
             csvOutput = "",
             csvRows = [],
             BREAK = '\r\n',
-            DELIMITER = ',',
+            DELIMITER = ';',
 			FILENAME = "export.csv";
 
         // Get and Write the headers


### PR DESCRIPTION
Change delimiter from "," to ";" as some metadata - like copyright - could contain a comma that breaks the CSV.