### PR TITLE
test(shared): config with required submodel

### DIFF
--- a/shared/README.md
+++ b/shared/README.md
@@ -32,6 +32,8 @@ class Config(BaseConfig):
 config = Config(filepath="/etc/libretime/config.yml")
 ```
 
+> Don't instantiate a sub model if it has a required field, otherwise the `Config` class import will raise a `ValidationError`.
+
 ### App
 
 Create an app class that inherit from `libretime_shared.app.AbstractApp`.

--- a/shared/tests/config_test.py
+++ b/shared/tests/config_test.py
@@ -2,6 +2,7 @@ from os import environ
 from pathlib import Path
 from unittest import mock
 
+from pydantic import BaseModel
 from pytest import mark, raises
 
 from libretime_shared.config import BaseConfig, DatabaseConfig, RabbitMQConfig
@@ -34,8 +35,9 @@ def test_base_config(tmp_path: Path):
         environ,
         {
             "LIBRETIME_API": "invalid",
-            "LIBRETIME_DATABASE": "invalid",
             "LIBRETIME_DATABASE_PORT": "8888",
+            "LIBRETIME_DATABASE": "invalid",
+            "LIBRETIME_RABBITMQ": "invalid",
             "LIBRETIME_RABBITMQ_HOST": "changed",
             "WRONGPREFIX_API_KEY": "invalid",
         },
@@ -59,6 +61,63 @@ def test_base_config(tmp_path: Path):
         config = FixtureConfig(filepath=config_filepath)
         assert config.rabbitmq.host == "changed"
         assert config.rabbitmq.port == 5672
+
+
+# pylint: disable=too-few-public-methods
+class RequiredModel(BaseModel):
+    api_key: str
+    with_default: str = "original"
+
+
+# pylint: disable=too-few-public-methods
+class FixtureWithRequiredSubmodelConfig(BaseConfig):
+    required: RequiredModel
+
+
+FIXTURE_WITH_REQUIRED_SUBMODEL_CONFIG_RAW = """
+required:
+    api_key: "test_key"
+"""
+
+
+def test_base_config_required_submodel(tmp_path: Path):
+    config_filepath = tmp_path / "config.yml"
+    config_filepath.write_text(FIXTURE_WITH_REQUIRED_SUBMODEL_CONFIG_RAW)
+
+    # With config file
+    with mock.patch.dict(environ, {}):
+        config = FixtureWithRequiredSubmodelConfig(filepath=config_filepath)
+        assert config.required.api_key == "test_key"
+        assert config.required.with_default == "original"
+
+    # With env variables
+    with mock.patch.dict(environ, {"LIBRETIME_REQUIRED_API_KEY": "test_key"}):
+        config = FixtureWithRequiredSubmodelConfig(filepath=None)
+        assert config.required.api_key == "test_key"
+        assert config.required.with_default == "original"
+
+    # With env variables override
+    with mock.patch.dict(environ, {"LIBRETIME_REQUIRED_API_KEY": "changed"}):
+        config = FixtureWithRequiredSubmodelConfig(filepath=config_filepath)
+        assert config.required.api_key == "changed"
+        assert config.required.with_default == "original"
+
+    # With env variables default override
+    with mock.patch.dict(
+        environ,
+        {
+            "LIBRETIME_REQUIRED_API_KEY": "changed",
+            "LIBRETIME_REQUIRED_WITH_DEFAULT": "changed",
+        },
+    ):
+        config = FixtureWithRequiredSubmodelConfig(filepath=config_filepath)
+        assert config.required.api_key == "changed"
+        assert config.required.with_default == "changed"
+
+    # Raise validation error
+    with mock.patch.dict(environ, {}):
+        with raises(SystemExit):
+            FixtureWithRequiredSubmodelConfig(filepath=None)
 
 
 FIXTURE_CONFIG_RAW_INI = """


### PR DESCRIPTION
An extra test, as I wasn't sure of some behavior in the config models.