### PR TITLE
chore: ignore closed ref notifer on releases notes

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issueLimit: ${{ github.event.inputs.issueLimit || '5' }}
+          ignore: .git,/docs/releases/*
 
   find_broken_links:
     if: github.repository_owner == 'LibreTime'


### PR DESCRIPTION
Fixes #1633
