### PR TITLE
chore: check for spelling errors in commit-msg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ---
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+default_stages: [commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
@@ -56,6 +57,7 @@ repos:
     rev: v2.1.0
     hooks:
       - id: codespell
+        stages: [commit, commit-msg]
         args:
           - --ignore-words=.codespellignore
           - --builtin=clear,rare,informal

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ SHELL = bash
 all: setup
 
 setup:
-	command -v pre-commit > /dev/null && pre-commit install
+	command -v pre-commit > /dev/null && pre-commit install \
+		--hook-type pre-commit \
+		--hook-type commit-msg
 
 # https://google.github.io/styleguide/shellguide.html
 shell-format:


### PR DESCRIPTION
Add pre-commit commit-msg hook.

Sadly if an error occur, the commit message is not recovered, see https://github.com/pre-commit/pre-commit/issues/833.