### PR TITLE
chore: ignore docusaurus extra packages upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,3 +94,7 @@ updates:
     labels:
       - javascript
       - dependencies
+    ignore:
+      # All @docusaurus/* packages should be updated with the @docusaurus/core package
+      - dependency-name: "@docusaurus/module-type-aliases"
+      - dependency-name: "@docusaurus/preset-classic"


### PR DESCRIPTION
those packages need to be upgraded alongside with @docusaurus/core so we can ignore any individual version bump.