### PR TITLE
ci: install git in libretime-dev testing image

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -64,6 +64,7 @@ jobs:
           cat <<EOF >> Dockerfile
           RUN apt-get update && \
               DEBIAN_FRONTEND=noninteractive apt-get -y install \
+              git \
               python3 \
               python3-pip \
               sudo \


### PR DESCRIPTION
This might fix a lot of false positive while downloading the
code to the testing folder.