### PR TITLE
fix(playout): add locales to libretime-playout-notify calls

### DIFF
--- a/playout/libretime_liquidsoap/1.1/ls_lib.liq
+++ b/playout/libretime_liquidsoap/1.1/ls_lib.liq
@@ -3,7 +3,7 @@ def gateway(args)
   command = "libretime-playout-notify #{args}"
   suffix = "&"
   log(command)
-  system("#{prefix} #{command} #{suffix}")
+  system("LC_ALL=C.UTF-8 LANG=C.UTF-8 #{prefix} #{command} #{suffix}")
 end
 
 def notify(m)


### PR DESCRIPTION
Fix python36 encoding runtime error that was failing on bionic

Fixes #1606 