### PR TITLE
ci: add missing python3-venv package for testing

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -67,6 +67,7 @@ jobs:
               git \
               python3 \
               python3-pip \
+              python3-venv \
               $(cat packages.list)
           EOF
 


### PR DESCRIPTION
Related to 8c96c0a0949f2de637f9ca10e706162dcd96ef45
