### PR TITLE
ci: generate schema and push to api-client repo

### DIFF
--- a/.github/workflows/api-schema.yml
+++ b/.github/workflows/api-schema.yml
@@ -1,0 +1,32 @@
+name: Push API schema
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Clone api-client repo
+        uses: actions/checkout@v3
+        with:
+          repository: "${{ github.repository_owner }}/api-client"
+          path: api-client-repo
+          ssh-key: "${{ secrets.API_CLIENT_DEPLOY_KEY }}"
+      - name: Generate schema
+        run: |
+          make schema
+          cp schema.yml ../api-client-repo/schema.yml
+        working-directory: api
+      - name: Push schema changes to API clients
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update schema for ${{ github.sha }}
+          repository: ./api-client-repo

--- a/api/Makefile
+++ b/api/Makefile
@@ -14,3 +14,7 @@ clean: .clean
 test: $(VENV)
 	source $(VENV)/bin/activate
 	DJANGO_SETTINGS_MODULE=libretime_api.settings.testing libretime-api test libretime_api
+
+schema: $(VENV)
+	source $(VENV)/bin/activate
+	DJANGO_SETTINGS_MODULE=libretime_api.settings.testing libretime-api spectacular --file schema.yml

--- a/api/libretime_api/settings/testing.py
+++ b/api/libretime_api/settings/testing.py
@@ -20,6 +20,7 @@ from .prod import (
     REST_FRAMEWORK,
     ROOT_URLCONF,
     SECRET_KEY,
+    SPECTACULAR_SETTINGS,
     STATIC_URL,
     TEMPLATES,
     TIME_ZONE,


### PR DESCRIPTION
Allows automatic generation of api clients based on the Django schema. They still need testing, but the workflow is now up and running to generate them.