### PR TITLE
chore: add bump python version tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,11 @@ shell-check:
 VERSION:
 	tools/version.sh
 
+bump-python-version: VERSION
+	tools/bump-python-version.sh
+
 .PHONY: tarball
-tarball: VERSION
+tarball: VERSION bump-python-version
 	$(MAKE) -C legacy build
 	cd .. && tar -czf libretime-$(shell cat VERSION | tr -d [:blank:]).tar.gz \
 		--owner=root --group=root \

--- a/tools/bump-python-version.sh
+++ b/tools/bump-python-version.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Bump the version in the setup.py files.
+
+set -u
+
+error() {
+  echo >&2 "error: $*"
+  exit 1
+}
+
+command -v sed > /dev/null || error "sed command not found!"
+
+version="$(cat VERSION)"
+
+for setup_path in */setup.py; do
+  sed --in-place \
+    "s/version=\".*\",/version=\"$version\",/" \
+    "$setup_path"  ||
+    error "could not bump version for $setup_path!"
+done

--- a/tools/version.sh
+++ b/tools/version.sh
@@ -15,7 +15,9 @@ typeset -r version_file="VERSION"
 if [[ "$(git rev-parse --is-inside-work-tree 2> /dev/null)" == "true" ]]; then
   tag=$(git tag --points-at HEAD | tee "$version_file" || error "could not extract tag")
   if [[ -z "$tag" ]]; then
-    git rev-parse --short HEAD > "$version_file" || error "could not extract commit sha"
+    latest_tag=$(git describe --abbrev=0 --tags || error "could not extract latest tag")
+    latest_commit=$(git rev-parse --short HEAD || error "could not extract commit sha")
+    echo "$latest_tag-dev+$latest_commit" > "$version_file"
   fi
 else
   if [[ ! -f "$version_file" ]]; then


### PR DESCRIPTION
This will bump the version in the setup.py files before creating a tarball, I think we could do this during release and create a version bump commit.

Fixes #864