### PR TITLE
feat(worker): don't run with a dedicated user

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -55,6 +55,15 @@ The legacy logrotate config filepath was changed from `/etc/logrotate.d/airtime-
 sudo rm -f /etc/logrotate.d/airtime-php
 ```
 
+### Worker user
+
+The worker service no longer uses a dedicated `celery` user to run. The old `celery` user can be removed from the system:
+
+```bash
+# Remove the celery user
+sudo deluser celery
+```
+
 ### New configuration schema
 
 The configuration schema was updated.

--- a/install
+++ b/install
@@ -1020,21 +1020,10 @@ systemInitInstall libretime-liquidsoap "$web_user"
 systemInitInstall libretime-playout "$web_user"
 verbose "...Done"
 
-verbose "\n * Installing celery..."
+verbose "\n * Installing worker..."
 loudCmd "$pip_install ${AIRTIMEROOT}/worker"
 mkdir_and_chown "${web_user}:${web_user}" "${LIBRETIME_WORKING_DIR}/worker"
-# Create the Celery user
-if $is_centos_dist; then
-  loudCmd "id celery 2>/dev/null || adduser --no-create-home -c 'LibreTime Celery' -r celery || true"
-else
-  loudCmd "id celery 2>/dev/null || adduser --no-create-home --gecos 'LibreTime Celery' --disabled-login --firstuid 1 --lastuid 999 celery"
-fi
-# Add celery to the www-data group
-loudCmd "usermod -G ${web_user} -a celery"
-# CentOS installs celery in /usr/bin which differs from other distros. Make
-# available in /usr/local/bin as systemd requires an absolute path.
-[[ ! -e /usr/local/bin/celery ]] && ln -s /usr/bin/celery /usr/local/bin/celery
-systemInitInstall libretime-celery celery
+systemInitInstall libretime-celery "$web_user"
 verbose "...Done"
 
 verbose "\n * Installing libretime-analyzer..."

--- a/legacy/build/airtime-setup/load.php
+++ b/legacy/build/airtime-setup/load.php
@@ -172,10 +172,7 @@ function checkLiquidsoapService()
  */
 function checkCeleryService()
 {
-    exec('pgrep -f -u celery libretime_worker', $out, $status);
-    if (array_key_exists(0, $out) && $status == 0) {
-        return 1;
-    }
+    exec('systemctl is-active libretime-celery --quiet', $out, $status);
 
     return $status == 0;
 }


### PR DESCRIPTION
BREAKING: The worker service no longer uses a dedicated `celery` user to run. The old `celery` user can be removed from the system.
