### PR TITLE
fix(legacy): keep playlists/blocks/podcasts on user removal

### DIFF
--- a/api/libretime_api/legacy/migrations/sql/schema.sql
+++ b/api/libretime_api/legacy/migrations/sql/schema.sql
@@ -754,7 +754,7 @@ ALTER TABLE "cc_show_hosts" ADD CONSTRAINT "cc_perm_host_fkey"
 ALTER TABLE "cc_playlist" ADD CONSTRAINT "cc_playlist_createdby_fkey"
     FOREIGN KEY ("creator_id")
     REFERENCES "cc_subjs" ("id")
-    ON DELETE CASCADE;
+    ON DELETE SET NULL;
 
 ALTER TABLE "cc_playlistcontents" ADD CONSTRAINT "cc_playlistcontents_file_id_fkey"
     FOREIGN KEY ("file_id")
@@ -774,7 +774,7 @@ ALTER TABLE "cc_playlistcontents" ADD CONSTRAINT "cc_playlistcontents_playlist_i
 ALTER TABLE "cc_block" ADD CONSTRAINT "cc_block_createdby_fkey"
     FOREIGN KEY ("creator_id")
     REFERENCES "cc_subjs" ("id")
-    ON DELETE CASCADE;
+    ON DELETE SET NULL;
 
 ALTER TABLE "cc_blockcontents" ADD CONSTRAINT "cc_blockcontents_file_id_fkey"
     FOREIGN KEY ("file_id")
@@ -864,7 +864,7 @@ ALTER TABLE "celery_tasks" ADD CONSTRAINT "celery_service_fkey"
 ALTER TABLE "podcast" ADD CONSTRAINT "podcast_owner_fkey"
     FOREIGN KEY ("owner")
     REFERENCES "cc_subjs" ("id")
-    ON DELETE CASCADE;
+    ON DELETE SET NULL;
 
 ALTER TABLE "station_podcast" ADD CONSTRAINT "podcast_id_fkey"
     FOREIGN KEY ("podcast_id")

--- a/legacy/application/models/airtime/map/CcBlockTableMap.php
+++ b/legacy/application/models/airtime/map/CcBlockTableMap.php
@@ -55,7 +55,7 @@ class CcBlockTableMap extends TableMap
      */
     public function buildRelations()
     {
-        $this->addRelation('CcSubjs', 'CcSubjs', RelationMap::MANY_TO_ONE, array('creator_id' => 'id', ), 'CASCADE', null);
+        $this->addRelation('CcSubjs', 'CcSubjs', RelationMap::MANY_TO_ONE, array('creator_id' => 'id', ), 'SET NULL', null);
         $this->addRelation('CcPlaylistcontents', 'CcPlaylistcontents', RelationMap::ONE_TO_MANY, array('id' => 'block_id', ), 'CASCADE', null, 'CcPlaylistcontentss');
         $this->addRelation('CcBlockcontents', 'CcBlockcontents', RelationMap::ONE_TO_MANY, array('id' => 'block_id', ), 'CASCADE', null, 'CcBlockcontentss');
         $this->addRelation('CcBlockcriteria', 'CcBlockcriteria', RelationMap::ONE_TO_MANY, array('id' => 'block_id', ), 'CASCADE', null, 'CcBlockcriterias');

--- a/legacy/application/models/airtime/map/CcPlaylistTableMap.php
+++ b/legacy/application/models/airtime/map/CcPlaylistTableMap.php
@@ -54,7 +54,7 @@ class CcPlaylistTableMap extends TableMap
      */
     public function buildRelations()
     {
-        $this->addRelation('CcSubjs', 'CcSubjs', RelationMap::MANY_TO_ONE, array('creator_id' => 'id', ), 'CASCADE', null);
+        $this->addRelation('CcSubjs', 'CcSubjs', RelationMap::MANY_TO_ONE, array('creator_id' => 'id', ), 'SET NULL', null);
         $this->addRelation('CcShow', 'CcShow', RelationMap::ONE_TO_MANY, array('id' => 'autoplaylist_id', ), 'SET NULL', null, 'CcShows');
         $this->addRelation('CcPlaylistcontents', 'CcPlaylistcontents', RelationMap::ONE_TO_MANY, array('id' => 'playlist_id', ), 'CASCADE', null, 'CcPlaylistcontentss');
     } // buildRelations()

--- a/legacy/application/models/airtime/map/CcSubjsTableMap.php
+++ b/legacy/application/models/airtime/map/CcSubjsTableMap.php
@@ -63,11 +63,11 @@ class CcSubjsTableMap extends TableMap
         $this->addRelation('CcFilesRelatedByDbOwnerId', 'CcFiles', RelationMap::ONE_TO_MANY, array('id' => 'owner_id', ), null, null, 'CcFilessRelatedByDbOwnerId');
         $this->addRelation('CcFilesRelatedByDbEditedby', 'CcFiles', RelationMap::ONE_TO_MANY, array('id' => 'editedby', ), null, null, 'CcFilessRelatedByDbEditedby');
         $this->addRelation('CcShowHosts', 'CcShowHosts', RelationMap::ONE_TO_MANY, array('id' => 'subjs_id', ), 'CASCADE', null, 'CcShowHostss');
-        $this->addRelation('CcPlaylist', 'CcPlaylist', RelationMap::ONE_TO_MANY, array('id' => 'creator_id', ), 'CASCADE', null, 'CcPlaylists');
-        $this->addRelation('CcBlock', 'CcBlock', RelationMap::ONE_TO_MANY, array('id' => 'creator_id', ), 'CASCADE', null, 'CcBlocks');
+        $this->addRelation('CcPlaylist', 'CcPlaylist', RelationMap::ONE_TO_MANY, array('id' => 'creator_id', ), 'SET NULL', null, 'CcPlaylists');
+        $this->addRelation('CcBlock', 'CcBlock', RelationMap::ONE_TO_MANY, array('id' => 'creator_id', ), 'SET NULL', null, 'CcBlocks');
         $this->addRelation('CcPref', 'CcPref', RelationMap::ONE_TO_MANY, array('id' => 'subjid', ), 'CASCADE', null, 'CcPrefs');
         $this->addRelation('CcSubjsToken', 'CcSubjsToken', RelationMap::ONE_TO_MANY, array('id' => 'user_id', ), 'CASCADE', null, 'CcSubjsTokens');
-        $this->addRelation('Podcast', 'Podcast', RelationMap::ONE_TO_MANY, array('id' => 'owner', ), 'CASCADE', null, 'Podcasts');
+        $this->addRelation('Podcast', 'Podcast', RelationMap::ONE_TO_MANY, array('id' => 'owner', ), 'SET NULL', null, 'Podcasts');
     } // buildRelations()
 
 } // CcSubjsTableMap

--- a/legacy/application/models/airtime/map/PodcastTableMap.php
+++ b/legacy/application/models/airtime/map/PodcastTableMap.php
@@ -62,7 +62,7 @@ class PodcastTableMap extends TableMap
      */
     public function buildRelations()
     {
-        $this->addRelation('CcSubjs', 'CcSubjs', RelationMap::MANY_TO_ONE, array('owner' => 'id', ), 'CASCADE', null);
+        $this->addRelation('CcSubjs', 'CcSubjs', RelationMap::MANY_TO_ONE, array('owner' => 'id', ), 'SET NULL', null);
         $this->addRelation('StationPodcast', 'StationPodcast', RelationMap::ONE_TO_MANY, array('id' => 'podcast_id', ), 'CASCADE', null, 'StationPodcasts');
         $this->addRelation('ImportedPodcast', 'ImportedPodcast', RelationMap::ONE_TO_MANY, array('id' => 'podcast_id', ), 'CASCADE', null, 'ImportedPodcasts');
         $this->addRelation('PodcastEpisodes', 'PodcastEpisodes', RelationMap::ONE_TO_MANY, array('id' => 'podcast_id', ), 'CASCADE', null, 'PodcastEpisodess');

--- a/legacy/application/models/airtime/om/BaseCcSubjs.php
+++ b/legacy/application/models/airtime/om/BaseCcSubjs.php
@@ -1058,9 +1058,10 @@ abstract class BaseCcSubjs extends BaseObject implements Persistent
 
             if ($this->ccPlaylistsScheduledForDeletion !== null) {
                 if (!$this->ccPlaylistsScheduledForDeletion->isEmpty()) {
-                    CcPlaylistQuery::create()
-                        ->filterByPrimaryKeys($this->ccPlaylistsScheduledForDeletion->getPrimaryKeys(false))
-                        ->delete($con);
+                    foreach ($this->ccPlaylistsScheduledForDeletion as $ccPlaylist) {
+                        // need to save related object because we set the relation to null
+                        $ccPlaylist->save($con);
+                    }
                     $this->ccPlaylistsScheduledForDeletion = null;
                 }
             }
@@ -1075,9 +1076,10 @@ abstract class BaseCcSubjs extends BaseObject implements Persistent
 
             if ($this->ccBlocksScheduledForDeletion !== null) {
                 if (!$this->ccBlocksScheduledForDeletion->isEmpty()) {
-                    CcBlockQuery::create()
-                        ->filterByPrimaryKeys($this->ccBlocksScheduledForDeletion->getPrimaryKeys(false))
-                        ->delete($con);
+                    foreach ($this->ccBlocksScheduledForDeletion as $ccBlock) {
+                        // need to save related object because we set the relation to null
+                        $ccBlock->save($con);
+                    }
                     $this->ccBlocksScheduledForDeletion = null;
                 }
             }
@@ -1126,9 +1128,10 @@ abstract class BaseCcSubjs extends BaseObject implements Persistent
 
             if ($this->podcastsScheduledForDeletion !== null) {
                 if (!$this->podcastsScheduledForDeletion->isEmpty()) {
-                    PodcastQuery::create()
-                        ->filterByPrimaryKeys($this->podcastsScheduledForDeletion->getPrimaryKeys(false))
-                        ->delete($con);
+                    foreach ($this->podcastsScheduledForDeletion as $podcast) {
+                        // need to save related object because we set the relation to null
+                        $podcast->save($con);
+                    }
                     $this->podcastsScheduledForDeletion = null;
                 }
             }

--- a/legacy/build/schema.xml
+++ b/legacy/build/schema.xml
@@ -203,7 +203,7 @@
       <parameter name="foreign_table" value="cc_playlistcontents" />
       <parameter name="expression" value="SUM(cliplength)" />
     </behavior>
-    <foreign-key foreignTable="cc_subjs" name="cc_playlist_createdby_fkey" onDelete="CASCADE">
+    <foreign-key foreignTable="cc_subjs" name="cc_playlist_createdby_fkey" onDelete="SETNULL">
       <reference local="creator_id" foreign="id" />
     </foreign-key>
   </table>
@@ -251,7 +251,7 @@
       <parameter name="foreign_table" value="cc_blockcontents" />
       <parameter name="expression" value="SUM(cliplength)" />
     </behavior>
-    <foreign-key foreignTable="cc_subjs" name="cc_block_createdby_fkey" onDelete="CASCADE">
+    <foreign-key foreignTable="cc_subjs" name="cc_block_createdby_fkey" onDelete="SETNULL">
       <reference local="creator_id" foreign="id" />
     </foreign-key>
   </table>
@@ -522,7 +522,7 @@
     <column name="itunes_category" phpName="DbItunesCategory" type="VARCHAR" size="4096" />
     <column name="itunes_explicit" phpName="DbItunesExplicit" type="VARCHAR" size="4096" />
     <column name="owner" phpName="DbOwner" type="INTEGER" />
-    <foreign-key foreignTable="cc_subjs" name="podcast_owner_fkey" onDelete="CASCADE">
+    <foreign-key foreignTable="cc_subjs" name="podcast_owner_fkey" onDelete="SETNULL">
       <reference local="owner" foreign="id" />
     </foreign-key>
   </table>


### PR DESCRIPTION
I don't know if this is good enough. Reassign to admin seem dirty as well.

Ideally we should have dialog to check what to do with the content of the user to remove.

Fixes #1944 