### PR TITLE
feat(installer): remove allow-restart flag

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,14 +80,13 @@ Vagrant.configure('2') do |config|
     LIBRETIME_RABBITMQ_PASSWORD=libretime \
     bash install \
       --listen-port 8080 \
-      --allow-restart \
       --in-place \
       http://192.168.10.100:8080
 
     libretime-api migrate
     libretime-api set_icecast_passwords --from-icecast-config
 
-    systemctl start libretime.target
+    systemctl restart libretime.target
     SCRIPT
 
     config.vm.provision 'install', type: 'shell', inline: $script

--- a/docs/admin-manual/setup/install.md
+++ b/docs/admin-manual/setup/install.md
@@ -152,12 +152,6 @@ The install script will use randomly generated passwords to create the PostgreSQ
 
 :::
 
-:::info
-
-By default, the install script will not restart any service for you, this is to prevent unwanted restarts on production environment. To let the install script restart the services, you need to pass the `--allow-restart` flag.
-
-:::
-
 Feel free to run `./install --help` to get more details.
 
 #### Using hardware audio output

--- a/install
+++ b/install
@@ -67,7 +67,6 @@ Options:
   --user USER, -u USER          User used to run LibreTime.
   --listen-port PORT, -p PORT   Listen port for LibreTime.
 
-  --allow-restart, -r           Allow the installer to restart LibreTime services.
   --in-place, -i                Install LibreTime in place.
 
   --no-setup-icecast            Do not setup Icecast.
@@ -104,9 +103,6 @@ LIBRETIME_LISTEN_PORT=${LIBRETIME_LISTEN_PORT:-"80"}
 # > Public URL for LibreTime.
 LIBRETIME_PUBLIC_URL=${LIBRETIME_PUBLIC_URL:-}
 
-# > Allow the installer to restart LibreTime services. We don't want to restart the
-# > services by default to prevent uncontrolled downtime.
-LIBRETIME_ALLOW_RESTART=${LIBRETIME_ALLOW_RESTART:-false}
 # > Install LibreTime in editable mode.
 # > Will keep working files in the project directory.
 LIBRETIME_INSTALL_IN_PLACE=${LIBRETIME_INSTALL_IN_PLACE:-false}
@@ -129,10 +125,6 @@ while [[ $# -gt 0 ]]; do
     --listen-port | -p)
       LIBRETIME_LISTEN_PORT=$2
       shift 2
-      ;;
-    --allow-restart | -r)
-      LIBRETIME_ALLOW_RESTART=true
-      shift 1
       ;;
     --in-place | -i)
       LIBRETIME_INSTALL_IN_PLACE=true
@@ -289,10 +281,6 @@ install_service() {
 
 # service_restart_if_active <name>
 service_restart_if_active() {
-  if ! $LIBRETIME_ALLOW_RESTART && [[ "$1" =~ libretime ]]; then
-    return
-  fi
-
   if systemctl is-active "$1" > /dev/null; then
     info "restarting $1 service"
     systemctl restart "$1"
@@ -710,12 +698,6 @@ systemctl daemon-reload
 service_restart_if_active "php$PHP_VERSION-fpm"
 service_restart_if_active "nginx"
 
-service_restart_if_active "libretime-api"
-service_restart_if_active "libretime-celery"
-service_restart_if_active "libretime-analyzer"
-service_restart_if_active "libretime-playout"
-service_restart_if_active "libretime-liquidsoap"
-
 # Instructions
 ########################################################################################
 
@@ -741,6 +723,16 @@ Finally, start LibreTime using the following command:
 
 ${cyan}\
 $ sudo systemctl start libretime.target
+
+${reset}"
+
+else
+  printf "
+${yellow}\
+You can restart LibreTime using the following command:
+
+${cyan}\
+$ sudo systemctl restart libretime.target
 
 ${reset}"
 fi


### PR DESCRIPTION
Services management should be handled by the admin. You can use the following command `systemctl restart  libretime.target` after the install/upgrade script.

Start/Stop/Restart of the services should be handled by the admin, we don't want to mess with missing migrations (This is a problem for legacy though, because the files are swapped and take effect immediately).
