### PR TITLE
feat(playout): use single clients instance

### DIFF
--- a/playout/libretime_playout/liquidsoap/entrypoint.py
+++ b/playout/libretime_playout/liquidsoap/entrypoint.py
@@ -5,7 +5,7 @@ import traceback
 from pathlib import Path
 from typing import Optional
 
-from libretime_api_client.v1 import ApiClient
+from libretime_api_client.v1 import ApiClient as LegacyClient
 from loguru import logger
 
 
@@ -50,8 +50,8 @@ def generate_entrypoint(log_filepath: Optional[Path]):
 
     while not successful:
         try:
-            ac = ApiClient(logger)
-            ss = ac.get_stream_setting()
+            legacy_client = LegacyClient(logger)
+            ss = legacy_client.get_stream_setting()
             generate_liquidsoap_config(ss, log_filepath)
             successful = True
         except Exception as e:

--- a/playout/libretime_playout/liquidsoap/liquidsoap_auth.py
+++ b/playout/libretime_playout/liquidsoap/liquidsoap_auth.py
@@ -1,8 +1,8 @@
 import sys
 
-from libretime_api_client.v1 import ApiClient
+from libretime_api_client.v1 import ApiClient as LegacyClient
 
-api_client = ApiClient()
+legacy_client = LegacyClient()
 
 dj_type = sys.argv[1]
 username = sys.argv[2]
@@ -14,7 +14,7 @@ if dj_type == "--master":
 elif dj_type == "--dj":
     source_type = "dj"
 
-response = api_client.check_live_stream_auth(username, password, source_type)
+response = legacy_client.check_live_stream_auth(username, password, source_type)
 
 if "msg" in response and response["msg"] == True:
     print(response["msg"])

--- a/playout/libretime_playout/notify/main.py
+++ b/playout/libretime_playout/notify/main.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Optional
 
 import click
-from libretime_api_client.v1 import ApiClient
+from libretime_api_client.v1 import ApiClient as LegacyClient
 from libretime_shared.cli import cli_logging_options
 from libretime_shared.config import DEFAULT_ENV_PREFIX
 from libretime_shared.logging import level_from_name, setup_logger
@@ -24,7 +24,7 @@ from loguru import logger
 
 
 def api_client():
-    return ApiClient(logger=logger)
+    return LegacyClient(logger=logger)
 
 
 @click.group(context_settings={"auto_envvar_prefix": DEFAULT_ENV_PREFIX})

--- a/playout/libretime_playout/player/file.py
+++ b/playout/libretime_playout/player/file.py
@@ -12,11 +12,11 @@ from requests.exceptions import ConnectionError, Timeout
 
 
 class PypoFile(Thread):
-    def __init__(self, schedule_queue):
+    def __init__(self, schedule_queue, api_client: ApiClient):
         Thread.__init__(self)
         self.media_queue = schedule_queue
         self.media = None
-        self.api_client = ApiClient()
+        self.api_client = api_client
 
     def copy_file(self, media_item):
         """

--- a/playout/libretime_playout/player/push.py
+++ b/playout/libretime_playout/player/push.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from queue import Queue
 from threading import Thread
 
-from libretime_api_client.v1 import ApiClient
 from loguru import logger
 
 from ..config import PUSH_INTERVAL, Config
@@ -25,7 +24,6 @@ def is_file(media_item):
 class PypoPush(Thread):
     def __init__(self, q, telnet_lock, pypo_liquidsoap, config: Config):
         Thread.__init__(self)
-        self.api_client = ApiClient()
         self.queue = q
 
         self.telnet_lock = telnet_lock

--- a/playout/libretime_playout/stats.py
+++ b/playout/libretime_playout/stats.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from threading import Thread
 
 import defusedxml.minidom
-from libretime_api_client.v1 import ApiClient
+from libretime_api_client.v1 import ApiClient as LegacyClient
 from loguru import logger
 
 from .config import Config
@@ -17,10 +17,10 @@ class ListenerStat(Thread):
 
     HTTP_REQUEST_TIMEOUT = 30  # 30 second HTTP request timeout
 
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, legacy_client: LegacyClient):
         Thread.__init__(self)
         self.config = config
-        self.api_client = ApiClient()
+        self.legacy_client = legacy_client
 
     def get_node_text(self, nodelist):
         rc = []
@@ -31,7 +31,7 @@ class ListenerStat(Thread):
 
     def get_stream_parameters(self):
         # [{"user":"", "password":"", "url":"", "port":""},{},{}]
-        return self.api_client.get_stream_parameters()
+        return self.legacy_client.get_stream_parameters()
 
     def get_stream_server_xml(self, ip, url, is_shoutcast=False):
         auth_string = "%(admin_user)s:%(admin_pass)s" % ip
@@ -132,12 +132,12 @@ class ListenerStat(Thread):
         return stats
 
     def push_stream_stats(self, stats):
-        self.api_client.push_stream_stats(stats)
+        self.legacy_client.push_stream_stats(stats)
 
     def update_listener_stat_error(self, stream_id, error):
         keyname = "%s_listener_stat_error" % stream_id
         data = {keyname: error}
-        self.api_client.update_stream_setting_table(data)
+        self.legacy_client.update_stream_setting_table(data)
 
     def run(self):
         # Wake up every 120 seconds and gather icecast statistics. Note that we


### PR DESCRIPTION
- Use legacy_client across playout code to make the difference between the old and new clients.
- Setup clients during initialization, and pass clients down to the different apps.
