### PR TITLE
ci: add custom user for dev containers

### DIFF
--- a/.github/workflows/_python.yml
+++ b/.github/workflows/_python.yml
@@ -59,7 +59,7 @@ jobs:
 
     container:
       image: ghcr.io/libretime/libretime-dev:${{ matrix.release }}
-      options: --user 1001
+      options: --user 1001:1001
     defaults:
       run:
         shell: bash

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -48,7 +48,7 @@ jobs:
 
     container:
       image: ghcr.io/libretime/libretime-dev:${{ matrix.release }}
-      options: --user 1001
+      options: --user 1001:1001
     defaults:
       run:
         shell: bash

--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -70,7 +70,12 @@ jobs:
               python3 \
               python3-pip \
               python3-venv \
+              sudo \
               $(cat packages.list)
+
+          RUN adduser --disabled-password --gecos '' --uid 1001 runner
+          RUN adduser runner sudo
+          RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
           EOF
 
       - name: Build and push


### PR DESCRIPTION
Liquidsoap does not allow running as uid=0 or even gid=0 for some older versions. A setting to allow running as root has been added in 1.3.4, so bullseye is the only version supporting this setting.

This will allow running liquidsoap in CI for testing.

Related to #2051

The sudo package is always useful for debugging with tmate.