### PR TITLE
feat: optionally load systemd env from /etc/libretime/env

### DIFF
--- a/analyzer/install/systemd/libretime-analyzer.service
+++ b/analyzer/install/systemd/libretime-analyzer.service
@@ -3,6 +3,7 @@ Description=LibreTime Media Analyzer Service
 PartOf=libretime.target
 
 [Service]
+EnvironmentFile=-@@CONFIG_DIR@@/env
 Environment=LIBRETIME_LOG_FILEPATH=@@LOG_DIR@@/analyzer.log
 Environment=LIBRETIME_CONFIG_FILEPATH=@@CONFIG_FILEPATH@@
 WorkingDirectory=@@WORKING_DIR@@/analyzer

--- a/api/install/systemd/libretime-api.service
+++ b/api/install/systemd/libretime-api.service
@@ -8,6 +8,7 @@ Type=notify
 KillMode=mixed
 PrivateTmp=true
 
+EnvironmentFile=-@@CONFIG_DIR@@/env
 Environment=LIBRETIME_LOG_FILEPATH=@@LOG_DIR@@/api.log
 Environment=LIBRETIME_CONFIG_FILEPATH=@@CONFIG_FILEPATH@@
 

--- a/installer/vagrant/post-install.sh
+++ b/installer/vagrant/post-install.sh
@@ -20,3 +20,8 @@ rabbitmqctl set_user_tags libretime administrator
 DEBIAN_FRONTEND=noninteractive apt-get -y -qq install alsa-utils
 usermod -a -G audio vagrant
 usermod -a -G audio libretime
+
+# Setup debug environment for services
+cat << EOF > /etc/libretime/env
+LIBRETIME_LOG_LEVEL=debug
+EOF

--- a/playout/install/systemd/libretime-liquidsoap.service
+++ b/playout/install/systemd/libretime-liquidsoap.service
@@ -3,6 +3,7 @@ Description=LibreTime Liquidsoap Service
 PartOf=libretime.target
 
 [Service]
+EnvironmentFile=-@@CONFIG_DIR@@/env
 Environment=LIBRETIME_LOG_FILEPATH=@@LOG_DIR@@/liquidsoap.log
 Environment=LIBRETIME_CONFIG_FILEPATH=@@CONFIG_FILEPATH@@
 WorkingDirectory=@@WORKING_DIR@@/playout

--- a/playout/install/systemd/libretime-playout.service
+++ b/playout/install/systemd/libretime-playout.service
@@ -3,6 +3,7 @@ Description=LibreTime Playout Service
 PartOf=libretime.target
 
 [Service]
+EnvironmentFile=-@@CONFIG_DIR@@/env
 Environment=LIBRETIME_LOG_FILEPATH=@@LOG_DIR@@/playout.log
 Environment=LIBRETIME_CONFIG_FILEPATH=@@CONFIG_FILEPATH@@
 WorkingDirectory=@@WORKING_DIR@@/playout

--- a/worker/install/systemd/libretime-worker.service
+++ b/worker/install/systemd/libretime-worker.service
@@ -3,6 +3,7 @@ Description=LibreTime Worker Service
 PartOf=libretime.target
 
 [Service]
+EnvironmentFile=-@@CONFIG_DIR@@/env
 Environment=LIBRETIME_LOG_FILEPATH=@@LOG_DIR@@/worker.log
 Environment=LIBRETIME_CONFIG_FILEPATH=@@CONFIG_FILEPATH@@
 WorkingDirectory=@@WORKING_DIR@@/worker


### PR DESCRIPTION
This allow to override some configuration globally in the systemd services.

Useful to enable debug logs in all the python apps.