### PR TITLE
fix(installer): move non reusable fields from default output

### DIFF
--- a/installer/config.yml
+++ b/installer/config.yml
@@ -132,12 +132,8 @@ stream:
     .default_icecast_output: &default_icecast_output
       host: localhost
       port: 8000
-      mount: main
       source_password: hackme
       admin_password: hackme
-      audio:
-        format: ogg
-        bitrate: 256
       name: LibreTime!
       description: LibreTime Radio!
       website: https://libretime.org
@@ -149,6 +145,11 @@ stream:
       # The default Icecast output stream
       - <<: *default_icecast_output
         enabled: true
+        public_url:
+        mount: main
+        audio:
+          format: ogg
+          bitrate: 256
 
       # You can define extra outputs by reusing the default output using a yaml anchor
       - <<: *default_icecast_output

--- a/legacy/application/models/StreamSetting.php
+++ b/legacy/application/models/StreamSetting.php
@@ -68,10 +68,7 @@ class Application_Model_StreamConfig
         }
 
         if (!$result[$prefix . 'public_url']) {
-            $host = $result[$prefix . 'host'];
-            if ($host == 'localhost') {
-                $host = Config::get('general.public_url_raw')->getHost();
-            }
+            $host = Config::get('general.public_url_raw')->getHost();
             $port = $result[$prefix . 'port'];
             $mount = $result[$prefix . 'mount'];
 


### PR DESCRIPTION
- Make it explicit that you should not reuse those fields, as they should always be specified.
- Add empty icecast output public_url field.
- Fix inconsistency between docs and outputs public_url code.
