### PR TITLE
fix(playout): also shutdown on SIGTERM

### DIFF
--- a/playout/libretime_playout/main.py
+++ b/playout/libretime_playout/main.py
@@ -30,8 +30,8 @@ from .player.push import PypoPush
 from .recorder import Recorder
 
 
-def keyboardInterruptHandler(signum, frame):
-    logger.info("\nKeyboard Interrupt\n")
+def shutdown_handler(signum, frame):
+    logger.info("shutting down")
     sys.exit(0)
 
 
@@ -63,7 +63,8 @@ def cli(log_level: str, log_filepath: Optional[Path], config_filepath: Optional[
     logger.info("Timezone: %s" % str(time.tzname))
     logger.info("UTC time: %s" % str(datetime.utcnow()))
 
-    signal.signal(signal.SIGINT, keyboardInterruptHandler)
+    signal.signal(signal.SIGINT, shutdown_handler)
+    signal.signal(signal.SIGTERM, shutdown_handler)
 
     legacy_client = LegacyClient()
     api_client = ApiClient(

--- a/playout/libretime_playout/player/fetch.py
+++ b/playout/libretime_playout/player/fetch.py
@@ -23,12 +23,13 @@ from .liquidsoap import PypoLiquidsoap
 from .schedule import get_schedule
 
 
-def keyboardInterruptHandler(signum, frame):
-    logger.info("\nKeyboard Interrupt\n")
+def shutdown_handler(signum, frame):
+    logger.info("shutting down")
     sys.exit(0)
 
 
-signal.signal(signal.SIGINT, keyboardInterruptHandler)
+signal.signal(signal.SIGINT, shutdown_handler)
+signal.signal(signal.SIGTERM, shutdown_handler)
 
 
 class PypoFetch(Thread):

--- a/playout/libretime_playout/player/queue.py
+++ b/playout/libretime_playout/player/queue.py
@@ -11,12 +11,13 @@ from ..utils import seconds_between
 from .liquidsoap import PypoLiquidsoap
 
 
-def keyboardInterruptHandler(signum, frame):
-    logger.info("\nKeyboard Interrupt\n")
+def shutdown_handler(signum, frame):
+    logger.info("shutting down")
     sys.exit(0)
 
 
-signal.signal(signal.SIGINT, keyboardInterruptHandler)
+signal.signal(signal.SIGINT, shutdown_handler)
+signal.signal(signal.SIGTERM, shutdown_handler)
 
 
 class PypoLiqQueue(Thread):


### PR DESCRIPTION
Further improvement could be done by disabling the daemon flags and using thread events, but it requires lot of work. This is a quick fix for handling sigterm.