### PR TITLE
fix(shared): install tzdata distibutions package

### DIFF
--- a/install
+++ b/install
@@ -551,6 +551,10 @@ $PIP install --upgrade setuptools~=58.0
 ########################################################################################
 
 section "Shared"
+
+# shellcheck disable=SC2046
+install_packages $(list_packages "$SCRIPT_DIR/shared")
+
 install_python_app "$SCRIPT_DIR/shared"
 
 section "API client"

--- a/shared/packages.ini
+++ b/shared/packages.ini
@@ -1,0 +1,3 @@
+# This file contains a list of package dependencies.
+[tzdata]
+tzdata = buster, bullseye, bookworm, bionic, focal, jammy


### PR DESCRIPTION
zoneinfo rely on the system tzdata package to work.