### PR TITLE
fix(installer): config dir should be read only

### DIFF
--- a/install
+++ b/install
@@ -395,8 +395,7 @@ if ! id "$LIBRETIME_USER" &> /dev/null; then
 fi
 
 info "creating project directories"
-# TODO: Config dir should not be owned by www-data and should be readonly
-mkdir_and_chown "$LIBRETIME_USER" "$CONFIG_DIR"
+mkdir -p "$CONFIG_DIR"
 mkdir_and_chown "$LIBRETIME_USER" "$WORKING_DIR"
 mkdir_and_chown "$LIBRETIME_USER" "$LOG_DIR"
 

--- a/install
+++ b/install
@@ -402,6 +402,7 @@ mkdir_and_chown "$LIBRETIME_USER" "$LOG_DIR"
 if $is_first_install; then
   [[ -f "$CONFIG_TMP_FILEPATH" ]] || cp "$CONFIG_EXAMPLE_FILEPATH" "$CONFIG_TMP_FILEPATH"
   chown "$LIBRETIME_USER:$LIBRETIME_USER" "$CONFIG_TMP_FILEPATH"
+  chmod 640 "$CONFIG_TMP_FILEPATH"
 
   if [[ -n "$LIBRETIME_PUBLIC_URL" ]]; then
     set_config "$LIBRETIME_PUBLIC_URL" general public_url


### PR DESCRIPTION
Now that liquidsoap does not write any file in /etc/libretime, we can make it read only.