### PR TITLE
fix: nginx depends on legacy in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,8 @@ services:
     image: nginx
     ports:
       - 8080:80
+    depends_on:
+      - legacy
     volumes:
       - libretime_assets:/var/www/html:ro
       - ${NGINX_CONFIG_FILEPATH:-./nginx.conf}:/etc/nginx/conf.d/default.conf:ro


### PR DESCRIPTION
Nginx is failing because of the missing php-fpm upstream server.

Do we prefer to have a 3rd layer of dependency (nginx > legacy > postgres and rabbitmq) or should we configure nginx to retry multiple times before failing ?