### PR TITLE
fix: start playout service after liquidsoap

### DIFF
--- a/playout/install/systemd/libretime-playout.service
+++ b/playout/install/systemd/libretime-playout.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=LibreTime Playout Service
 PartOf=libretime.target
+Wants=libretime-liquidsoap.service
+After=libretime-liquidsoap.service
 
 [Service]
 Environment=LIBRETIME_LOG_FILEPATH=@@LOG_DIR@@/playout.log


### PR DESCRIPTION
Do not set a hard requirement on the service, only define the startup order.
