### PR TITLE
chore: move shell tools to pre-commit (via docker)

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -28,48 +28,6 @@ jobs:
 
       - uses: pre-commit/action@v3.0.0
 
-  check-shell:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-project-check-shell-pip
-          restore-keys: |
-            ${{ runner.os }}-project-check-shell-pip
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            /usr/local/bin/shellcheck*
-            /usr/local/bin/shfmt*
-          key: ${{ runner.os }}-project-check-shell-tools
-          restore-keys: |
-            ${{ runner.os }}-project-check-shell-tools
-
-      - run: |
-          python -m venv venv && source venv/bin/activate
-          pip install gh-release-install
-
-          sudo venv/bin/gh-release-install \
-            koalaman/shellcheck \
-            shellcheck-{tag}.linux.x86_64.tar.xz --extract shellcheck-{tag}/shellcheck \
-            /usr/local/bin/shellcheck \
-            --version-file '{destination}.version'
-
-          sudo venv/bin/gh-release-install \
-            mvdan/sh \
-            shfmt_{tag}_linux_amd64 \
-            /usr/local/bin/shfmt \
-            --version-file '{destination}.version'
-
-      - run: SEVERITY=warning make shell-check
-
   test-tools:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,18 @@ repos:
 
   - repo: local
     hooks:
+      - id: shfmt
+        name: shfmt
+        language: docker_image
+        entry: mvdan/shfmt -i 2 -ci -sr -kp -w
+        types: [shell]
+
+      - id: shellcheck
+        name: shellcheck
+        language: docker_image
+        entry: koalaman/shellcheck --color=always --severity=warning
+        types: [shell]
+
       - id: requirements.txt
         name: requirements.txt
         description: Generate requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,6 @@ all: setup
 setup:
 	command -v pre-commit > /dev/null && pre-commit install
 
-# https://google.github.io/styleguide/shellguide.html
-shell-format:
-	shfmt -f . | xargs git ls-files | xargs shfmt -i 2 -ci -sr -kp -w
-
-shell-check:
-	shfmt -f . | xargs git ls-files | xargs shfmt -i 2 -ci -sr -kp -d
-	shfmt -f . | xargs git ls-files | xargs shellcheck --color=always --severity=$${SEVERITY:-style}
-
 .PHONY: VERSION
 VERSION:
 	tools/version.sh


### PR DESCRIPTION
Puts a hard dependency on docker if we want to run pre-commit, but this is easier than having to install the many shfmt/shellcheck/... tools on the system.