### PR TITLE
docs: add DOCKER_BUILDKIT environment variable

### DIFF
--- a/docs/developer-manual/development/environment.md
+++ b/docs/developer-manual/development/environment.md
@@ -10,7 +10,7 @@ To setup a docker-compose development environment, run the following commands:
 # Clean and build
 make clean
 cp .env.dev .env
-docker-compose build
+DOCKER_BUILDKIT=1 docker-compose build
 
 # Setup
 docker-compose run --rm legacy make build


### PR DESCRIPTION
This is required for the --mount cache used to cache pip packages - https://docs.docker.com/build/buildkit/#getting-started