### PR TITLE
ci: enable renovate for 3.0.x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":enablePreCommit", ":preserveSemverRanges"],
+  "baseBranches": ["main", "3.0.x"],
   "lockFileMaintenance": {
     "enabled": true,
     "commitMessageAction": "lock file maintenance",


### PR DESCRIPTION
Actually enable renovate for 3.0.x, the change must be done on the default branch, not on the target branch as I did here: 3694b316105a88c73b630a43304e55bc3c92f1a1