### PR TITLE
fix(legacy): add log entry on task run

### DIFF
--- a/legacy/application/common/TaskManager.php
+++ b/legacy/application/common/TaskManager.php
@@ -61,6 +61,7 @@ final class TaskManager
     {
         $task = TaskFactory::getTask($taskName);
         if ($task && $task->shouldBeRun()) {
+            Logging::debug("running task {$taskName}");
             $task->run();
         }
         // Mark that the task has been checked/run.


### PR DESCRIPTION
This should give us more insight on whether tasks are run or not. Maybe it is a bit verbose, but that's what logs are for ?!