### PR TITLE
chore: add docs dev setup with the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *~
 VERSION
 
+/website/
+
 ## Github Python .gitignore
 ## See https://github.com/github/gitignore/blob/master/Python.gitignore
 ################################################################################

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,12 @@ clean:
 docs-lint:
 	vale sync
 	vale docs
+
+website:
+	git clone git@github.com:libretime/website.git
+
+website/node_modules: website
+	yarn --cwd website install
+
+docs-dev: website website/node_modules
+	DOCS_PATH="../docs" yarn --cwd website start


### PR DESCRIPTION
This will clone the website repo, install the website dependencies and override the docs path to the current main repository docs path.
