### PR TITLE
fix(legacy): advanced search by track type id

### DIFF
--- a/legacy/application/models/Datatables.php
+++ b/legacy/application/models/Datatables.php
@@ -50,8 +50,13 @@ class Application_Model_Datatables
                 }
             } else {
                 if (trim($input1) !== '') {
-                    $where['clause'][$dbname] = $dbname . ' ILIKE :' . $dbname . '1';
-                    $where['params'][$dbname . '1'] = '%' . $input1 . '%';
+                    if ($dbname == 'track_type_id') {
+                        $where['clause'][$dbname] = $dbname . ' = :' . $dbname . '1';
+                        $where['params'][$dbname . '1'] = $input1;
+                    } else {
+                        $where['clause'][$dbname] = $dbname . ' ILIKE :' . $dbname . '1';
+                        $where['params'][$dbname . '1'] = '%' . $input1 . '%';
+                    }
                 }
             }
         }

--- a/legacy/application/models/StoredFile.php
+++ b/legacy/application/models/StoredFile.php
@@ -672,8 +672,6 @@ SQL;
 
     public static function searchLibraryFiles($datatables)
     {
-        $baseUrl = Config::getBasePath();
-
         $con = Propel::getConnection(CcFilesPeer::DATABASE_NAME);
 
         $displayColumns = self::getLibraryColumns();


### PR DESCRIPTION
Advanced where clause didn't support matching integers (primary keys).

Fix #2344