### PR TITLE
fix(legacy): improve error messages and troubleshooting

### DIFF
--- a/docs/admin-manual/troubleshooting.md
+++ b/docs/admin-manual/troubleshooting.md
@@ -5,6 +5,18 @@ sidebar_position: 90
 
 This guide walk you though the steps required to troubleshoot LibreTime.
 
+## FAQ
+
+### I cannot login the interface "Oops! Something went wrong!"
+
+You might be accessing the interface from an invalid URL. Make sure that the URL in your browser and the one set in your configuration file in `[general.public_url]` are the same.
+
+Make sure to check the legacy logs at `/var/log/libretime/legacy.log`.
+
+References:
+
+- https://discourse.libretime.org/t/version-3-0-1-debian-oops-something-went-wrong/1400
+
 ## Logs
 
 The first place to search for details on potential errors are the log files.

--- a/docs/admin-manual/troubleshooting.md
+++ b/docs/admin-manual/troubleshooting.md
@@ -5,36 +5,9 @@ sidebar_position: 90
 
 This guide walk you though the steps required to troubleshoot LibreTime.
 
-## Services status
-
-When facing a problem with LibreTime the first reflex is to verify whether the services are running.
-
-In the web interface, go to **Settings** > **Status** to see the state of the services.
-
-![](./troubleshooting-status-page.png)
-
-Or directly from a terminal:
-
-```bash
-sudo systemctl --all --plain | egrep 'libretime|nginx|php.*-fpm'
-```
-
-If a service isn't running, you should search for details using the tool running those services.
-On a common setup, you should use the systemd service status:
-
-```bash
-sudo systemctl status libretime-worker
-```
-
-:::note
-
-Be sure to replace the service name with the problematic one.
-
-:::
-
 ## Logs
 
-The next place to search for details on potential errors are the log files.
+The first place to search for details on potential errors are the log files.
 
 The `/var/log/syslog` file contains most of the system logs combined. This log file may contain information that the application logger wasn't able to log, such as early startup errors. You can follow the logs using:
 
@@ -60,6 +33,33 @@ sudo -u libretime libretime-analyzer --config /etc/libretime/config.yml --log-le
 ```
 
 The `/var/log/nginx/libretime.error.log` file contains logs from the web server.
+
+## Services status
+
+The next reflex is to verify whether the services are running.
+
+In the web interface, go to **Settings** > **Status** to see the state of the services.
+
+![](./troubleshooting-status-page.png)
+
+Or directly from a terminal:
+
+```bash
+sudo systemctl --all --plain | egrep 'libretime|nginx|php.*-fpm'
+```
+
+If a service isn't running, you should search for details using the tool running those services.
+On a common setup, you should use the systemd service status:
+
+```bash
+sudo systemctl status libretime-worker
+```
+
+:::note
+
+Be sure to replace the service name with the problematic one.
+
+:::
 
 ## Test the stream inputs
 

--- a/legacy/application/common/CORSHelper.php
+++ b/legacy/application/common/CORSHelper.php
@@ -10,7 +10,9 @@ class CORSHelper
 
         if (!($origin == '' || preg_match('/https?:\/\/localhost/', $origin) === 1 || in_array($origin, $allowedOrigins))) {
             // Don't allow CORS from other domains to prevent XSS.
-            Logging::error("request origin '{$origin}' is not in allowed '" . implode(', ', $allowedOrigins) . "'!");
+            Logging::error(
+                "request origin '{$origin}' is not in the configured 'allowed_cors_origins' '" . implode(', ', $allowedOrigins) . "'"
+            );
 
             throw new Zend_Controller_Action_Exception('Forbidden', 403);
         }

--- a/legacy/application/configs/constants.php
+++ b/legacy/application/configs/constants.php
@@ -41,6 +41,7 @@ define('WHOS_USING_URL', 'https://github.com/orgs/libretime/people');
 define('TERMS_AND_CONDITIONS_URL', 'https://github.com/libretime/libretime/blob/main/README.md');
 define('PRIVACY_POLICY_URL', 'https://github.com/libretime/organization/blob/main/CODE_OF_CONDUCT.md');
 define('USER_MANUAL_URL', 'https://libretime.org/docs');
+define('TROUBLESHOOTING_URL', 'https://libretime.org/docs/admin-manual/troubleshooting/');
 define('ABOUT_AIRTIME_URL', 'https://libretime.org');
 define('LIBRETIME_CONTRIBUTE_URL', 'https://libretime.org/contribute');
 define('LIBRETIME_DISCOURSE_URL', 'https://discourse.libretime.org');

--- a/legacy/application/views/scripts/error/error-500.phtml
+++ b/legacy/application/views/scripts/error/error-500.phtml
@@ -12,7 +12,12 @@
         <h2><?php echo _("Oops!") ?></h2>
         <p><?php echo _("Something went wrong!") ?></p>
         <div class="button-bar">
-            <a class="toggle-button" href="<?php echo $this->helpUrl; ?>"><?php echo _("Help") ?></a>
+            <a class="toggle-button" href="<?php echo TROUBLESHOOTING_URL; ?>" target="_blank">
+                <?php echo _("Troubleshooting help") ?>
+            </a>
+            <a class="toggle-button" href="<?php echo $this->helpUrl; ?>" target="_blank">
+                <?php echo _("More help") ?>
+            </a>
         </div>
     </div>
 </body>

--- a/tools/packages.py
+++ b/tools/packages.py
@@ -49,7 +49,7 @@ def list_packages_files(
             path = path / DEFAULT_PACKAGES_FILENAME
 
         if not path.is_file():
-            raise Exception(f"{path} is not a file!")
+            raise ValueError(f"{path} is not a file!")
 
         yield path
 


### PR DESCRIPTION
Add a link to the troubleshooting docs on the error page.

![image](https://user-images.githubusercontent.com/19195485/216140574-3248d0e3-0542-4ff5-bb62-c6f1d75c2e53.png)

I hope this will guide the users to the troubleshooting guide first before the discourse forum.

The cors log message is now a bit more explicit and might help users to understand why they cannot login.