### PR TITLE
fix(legacy): do not delete audio file when removing artwork

### DIFF
--- a/legacy/application/common/FileDataHelper.php
+++ b/legacy/application/common/FileDataHelper.php
@@ -305,12 +305,18 @@ class FileDataHelper
 
         $fp = Config::getStoragePath();
 
-        $dbAudioPath = $md['MDATA_KEY_ARTWORK'];
-        $fullpath = $fp . $dbAudioPath;
+        $dbMetadataPath = $md['MDATA_KEY_ARTWORK'];
+        $fullpath = $fp . $dbMetadataPath;
+
+        $audioPath = $fp . $md['MDATA_KEY_FILEPATH'];
 
         if (file_exists($fullpath)) {
             foreach (glob("{$fullpath}*", GLOB_NOSORT) as $filename) {
-                unlink($filename);
+                
+                // Do not delete the audio file.
+                if($filename !== $audioPath){
+                    unlink($filename);
+                }
             }
         } else {
             throw new Exception('Could not locate file ' . $filepath);

--- a/legacy/application/common/FileDataHelper.php
+++ b/legacy/application/common/FileDataHelper.php
@@ -305,21 +305,31 @@ class FileDataHelper
 
         $fp = Config::getStoragePath();
 
-        $dbMetadataPath = $md['MDATA_KEY_ARTWORK'];
-        $fullpath = $fp . $dbMetadataPath;
-
+        $artworkBasePath = $fp . $md['MDATA_KEY_ARTWORK'];
         $audioPath = $fp . $md['MDATA_KEY_FILEPATH'];
 
-        if (file_exists($fullpath)) {
-            foreach (glob("{$fullpath}*", GLOB_NOSORT) as $filename) {
-                
-                // Do not delete the audio file.
-                if($filename !== $audioPath){
-                    unlink($filename);
-                }
+        $artworkPaths = [
+            $artworkBasePath,
+            $artworkBasePath . '-32.jpg',
+            $artworkBasePath . '-64.jpg',
+            $artworkBasePath . '-128.jpg',
+            $artworkBasePath . '-256.jpg',
+            $artworkBasePath . '-512.jpg',
+            $artworkBasePath . '-32',
+            $artworkBasePath . '-64',
+            $artworkBasePath . '-128',
+            $artworkBasePath . '-256',
+        ];
+
+        foreach ($artworkPaths as $filename) {
+            // This should never happen. Make sure we don't delete the audio file.
+            if ($filename == $audioPath) {
+                continue;
             }
-        } else {
-            throw new Exception('Could not locate file ' . $filepath);
+
+            if (file_exists($filename)) {
+                unlink($filename);
+            }
         }
 
         return '';


### PR DESCRIPTION
### Description

While removing a custom artwork the audio file is also deleted.

**This is a new feature**:

No

**I have updated the documentation to reflect these changes**:
No

### Testing Notes

This bug does only appear with custom cover images.
The default ones are not affected because they are in a different folder than the custom ones

1. Edit track
2. Add custom cover image and save
3. remove cover image => audio_file deleted

#### After the patch:

1. Edit track
2. Add custom cover image and save
3. remove cover image => audio_file is not deleted
