### PR TITLE
ci: pull code before updating locales

### DIFF
--- a/.github/workflows/analyzer.yml
+++ b/.github/workflows/analyzer.yml
@@ -1,6 +1,7 @@
 name: Analyzer
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/api-client.yml
+++ b/.github/workflows/api-client.yml
@@ -1,6 +1,7 @@
 name: API Client
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/api-schema.yml
+++ b/.github/workflows/api-schema.yml
@@ -1,6 +1,7 @@
 name: API schema
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,6 +1,7 @@
 name: API
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -88,9 +88,15 @@ jobs:
   locale:
     runs-on: ubuntu-latest
 
-    if: github.event_name == 'schedule'
+    if: >
+      github.repository_owner == 'libretime' && (
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch'
+      )
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.LIBRETIME_BOT_TOKEN }}
 
       - name: Install dependencies
         run: |
@@ -99,10 +105,12 @@ jobs:
 
       - name: Update locales
         run: |
-          make -C legacy/locale update
-
           git config --global user.name "libretime-bot"
           git config --global user.email "libretime-bot@users.noreply.github.com"
+
+          git pull
+
+          make -C legacy/locale update
 
           git add legacy/locale
           git diff-index --quiet HEAD -- legacy/locale || {

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -1,6 +1,7 @@
 name: Legacy
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/playout.yml
+++ b/.github/workflows/playout.yml
@@ -1,6 +1,7 @@
 name: Playout
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,6 +1,7 @@
 name: Project
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -1,6 +1,7 @@
 name: Shared
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -1,6 +1,7 @@
 name: Worker
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Since we have a protection on the main branch the locales update could not push the changes to the main branch this night.

https://github.com/libretime/libretime/actions/runs/4278223004/jobs/7455414545

We should probably use the libretime-bot token to clone and push the changes.

The job succeeded on my fork, but I think this was not my intention haha. I limited the job to only run on the repo.