### PR TITLE
fix(playout):  when shows ends, next shows starts without fade-in/fade-out 

### DIFF
--- a/playout/libretime_playout/liquidsoap/1.4/ls_script.liq
+++ b/playout/libretime_playout/liquidsoap/1.4/ls_script.liq
@@ -23,8 +23,11 @@ def create_source()
     l = cue_cut(l)
     l = amplify(1., override="replay_gain", l)
 
-    # the crossfade function controls fade in/out
-    l = crossfade(duration=0., smart=true, l)
+    # Fade the tracks to avoid hard cuts in between two tracks and at the end of the shows.
+    # Liquidsoap reads the fade in/out durations from the annotation "liq_fade_in/out" which
+    # value can be set via Libretime settings.
+    l = fade.in(l)
+    l = fade.out(l)
 
     l = on_metadata(notify_queue, l)
 


### PR DESCRIPTION
### Description
Liquidsoap did a harsh cut at the end of every show.
This MR fixes this an (re)enables settings for the crossfading by
- adding the values "default_crossfade_duration", "default_fade_in" and "default_fade_out" from the "preference" page to the StreamPreferences api.
- The new values are then used while generating the liquidsoap entrypoint, and can also be changed  via telnet.

### Testing Notes

Created a VM, installed my Libretime branch, scheduled some shows to hear the fade at the end of the show. 
I also run "make test" in the "playout" folder.

### **Links**

Closes: #2070 

https://discourse.libretime.org/t/how-to-fade-out-shows/700
https://discourse.libretime.org/t/no-fadestop-at-the-show-end/1412
