### PR TITLE
chore: use title for image alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](https://github.com/libretime/website/blob/main/static/img/logo-512px.png)](https://github.com/libretime/libretime)
+# [![LibreTime](https://github.com/libretime/website/blob/main/static/img/logo-512px.png)](https://github.com/libretime/libretime)
 
 [![Financial Contributors on Open Collective](https://opencollective.com/libretime/all/badge.svg?label=financial+contributors)](https://opencollective.com/libretime)
 


### PR DESCRIPTION
Fallback to the alternative if the image cannot be loaded (e.g. dockerhub + CORS)

Or for example on Github (this should not happen since we can load the image on Github):
![image](https://user-images.githubusercontent.com/19195485/222459657-b4983ce1-8d66-40f9-8c9f-11809589d86e.png)
