### PR TITLE
ci: run all tests on python tools changes

### DIFF
--- a/.github/workflows/analyzer.yml
+++ b/.github/workflows/analyzer.yml
@@ -9,6 +9,7 @@ on:
       - .github/workflows/analyzer.yml
       - analyzer/**
       - shared/**
+      - tools/python*
 
   pull_request:
     branches: [main]
@@ -17,6 +18,7 @@ on:
       - .github/workflows/analyzer.yml
       - analyzer/**
       - shared/**
+      - tools/python*
 
   schedule:
     - cron: 0 1 * * 1

--- a/.github/workflows/api-client.yml
+++ b/.github/workflows/api-client.yml
@@ -9,6 +9,7 @@ on:
       - .github/workflows/api-client.yml
       - api-client/**
       - shared/**
+      - tools/python*
 
   pull_request:
     branches: [main]
@@ -17,6 +18,7 @@ on:
       - .github/workflows/api-client.yml
       - api-client/**
       - shared/**
+      - tools/python*
 
   schedule:
     - cron: 0 1 * * 1

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -9,6 +9,7 @@ on:
       - .github/workflows/api.yml
       - api/**
       - shared/**
+      - tools/python*
 
   pull_request:
     branches: [main]
@@ -17,6 +18,7 @@ on:
       - .github/workflows/api.yml
       - api/**
       - shared/**
+      - tools/python*
 
   schedule:
     - cron: 0 1 * * 1

--- a/.github/workflows/playout.yml
+++ b/.github/workflows/playout.yml
@@ -10,6 +10,7 @@ on:
       - playout/**
       - api-client/**
       - shared/**
+      - tools/python*
 
   pull_request:
     branches: [main]
@@ -19,6 +20,7 @@ on:
       - playout/**
       - api-client/**
       - shared/**
+      - tools/python*
 
   schedule:
     - cron: 0 1 * * 1

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/_python.yml
       - .github/workflows/shared.yml
       - shared/**
+      - tools/python*
 
   pull_request:
     branches: [main]
@@ -15,6 +16,7 @@ on:
       - .github/workflows/_python.yml
       - .github/workflows/shared.yml
       - shared/**
+      - tools/python*
 
   schedule:
     - cron: 0 1 * * 1

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/_python.yml
       - .github/workflows/worker.yml
       - worker/**
+      - tools/python*
 
   pull_request:
     branches: [main]
@@ -15,6 +16,7 @@ on:
       - .github/workflows/_python.yml
       - .github/workflows/worker.yml
       - worker/**
+      - tools/python*
 
   schedule:
     - cron: 0 1 * * 1


### PR DESCRIPTION
We are not running the linters and tests when the shared python dev requirements or python makefile changes.