### PR TITLE
feat: use secret_key config field instead of api_key

### DIFF
--- a/api/libretime_api/settings/prod.py
+++ b/api/libretime_api/settings/prod.py
@@ -1,4 +1,5 @@
 from os import getenv
+from warnings import warn
 
 # pylint: disable=unused-import
 from ._internal import (
@@ -24,7 +25,15 @@ LIBRETIME_CONFIG_FILEPATH = getenv("LIBRETIME_CONFIG_FILEPATH")
 
 CONFIG = Config(LIBRETIME_CONFIG_FILEPATH)  # type: ignore[arg-type, misc]
 
-SECRET_KEY = CONFIG.general.api_key
+if CONFIG.general.secret_key is None:
+    warn(
+        "The [general.secret_key] configuration field is not set but will be required "
+        "in the next major release. Using [general.api_key] as fallback.",
+        FutureWarning,
+    )
+    SECRET_KEY = CONFIG.general.api_key
+else:
+    SECRET_KEY = CONFIG.general.secret_key
 
 ALLOWED_HOSTS = ["*"]
 

--- a/api/libretime_api/settings/testing.py
+++ b/api/libretime_api/settings/testing.py
@@ -5,6 +5,7 @@ from .._fixtures import fixture_path
 os.environ.setdefault("LIBRETIME_DEBUG", "true")
 os.environ.setdefault("LIBRETIME_GENERAL_PUBLIC_URL", "http://localhost")
 os.environ.setdefault("LIBRETIME_GENERAL_API_KEY", "testing")
+os.environ.setdefault("LIBRETIME_GENERAL_SECRET_KEY", "testing")
 os.environ.setdefault("LIBRETIME_STORAGE_PATH", str(fixture_path))
 
 # pylint: disable=wrong-import-position,unused-import

--- a/docker/config.dev.yml
+++ b/docker/config.dev.yml
@@ -1,6 +1,7 @@
 general:
   public_url: http://localhost:8080
   api_key: some_secret_api_key
+  secret_key: some_secret_key
 
 database:
   host: postgres

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -7,6 +7,10 @@ general:
   # The internal API authentication key.
   # > this field is REQUIRED
   api_key:
+  # The Django API secret key. If not defined, the value of [general.api_key] will be
+  # used as fallback.
+  # > this field will be REQUIRED starting with LibreTime 4.0.0
+  secret_key:
 
   # List of origins allowed to access resources on the server, the public url
   # origin is automatically included.

--- a/docker/example/config.yml
+++ b/docker/example/config.yml
@@ -7,6 +7,10 @@ general:
   # The internal API authentication key.
   # > this field is REQUIRED
   api_key: some_secret_api_key
+  # The Django API secret key. If not defined, the value of [general.api_key] will be
+  # used as fallback.
+  # > this field will be REQUIRED starting with LibreTime 4.0.0
+  secret_key:
 
   # List of origins allowed to access resources on the server, the public url
   # origin is automatically included.

--- a/docs/admin-manual/setup/configuration.md
+++ b/docs/admin-manual/setup/configuration.md
@@ -42,6 +42,9 @@ general:
   # The internal API authentication key.
   # > this field is REQUIRED
   api_key: "some_random_generated_secret!"
+  # The Django API secret key. If not defined, the value of [general.api_key] will be
+  # used as fallback.
+  secret_key: "some_random_generated_secret!"
 
   # List of origins allowed to access resources on the server,
   # the [general.public_url] origin is automatically included.

--- a/install
+++ b/install
@@ -452,6 +452,8 @@ if $is_first_install; then
   fi
   set_config "$(generate_random_password)" general api_key
 
+  set_config "$(generate_random_password)" general secret_key
+
   if [[ -n "$LIBRETIME_TIMEZONE" ]]; then
     set_config "$LIBRETIME_TIMEZONE"  general timezone
   fi

--- a/installer/config.yml
+++ b/installer/config.yml
@@ -7,6 +7,10 @@ general:
   # The internal API authentication key.
   # > this field is REQUIRED
   api_key:
+  # The Django API secret key. If not defined, the value of [general.api_key] will be
+  # used as fallback.
+  # > this field will be REQUIRED starting with LibreTime 4.0.0
+  secret_key:
 
   # List of origins allowed to access resources on the server, the public url
   # origin is automatically included.

--- a/legacy/application/configs/conf.php
+++ b/legacy/application/configs/conf.php
@@ -35,6 +35,7 @@ class Schema implements ConfigurationInterface
             ->arrayNode('general')->addDefaultsIfNotSet()->children()
             /**/->scalarNode('public_url')->cannotBeEmpty()->end()
             /**/->scalarNode('api_key')->cannotBeEmpty()->end()
+            /**/->scalarNode('secret_key')->end()
             /**/->arrayNode('allowed_cors_origins')->scalarPrototype()->defaultValue([])->end()->end()
             /**/->scalarNode('timezone')->cannotBeEmpty()->defaultValue("UTC")
             /*  */->validate()->ifNotInArray(DateTimeZone::listIdentifiers())

--- a/shared/libretime_shared/config/_models.py
+++ b/shared/libretime_shared/config/_models.py
@@ -44,6 +44,7 @@ def no_leading_slash_validator(key: str) -> "AnyClassMethod":
 class GeneralConfig(BaseModel):
     public_url: AnyHttpUrl
     api_key: str
+    secret_key: Optional[str] = None
 
     timezone: str = "UTC"
 


### PR DESCRIPTION
Related to #2426

This adds a warning about a future required configuration field, that will fallback to the previous behavior (use the `general.api_key` as secret_key) in case of a missing value. We must make the field required on the next major version bump, we will keep track of this in #2426.

New LibreTime setup will have the secret_key field filled during the install process.