### PR TITLE
chore: backport #2461

### DIFF
--- a/api/libretime_api/core/models/preference.py
+++ b/api/libretime_api/core/models/preference.py
@@ -78,7 +78,9 @@ class Preference(models.Model):
         entries = dict(cls.site.values_list("key", "value"))
         return StreamPreferences(
             input_fade_transition=float(entries.get("default_transition_fade") or 0.0),
-            message_format=MessageFormatKind(entries.get("stream_label_format") or 0),
+            message_format=MessageFormatKind(
+                int(entries.get("stream_label_format") or 0)
+            ),
             message_offline=entries.get("off_air_meta") or "Offline",
         )
 


### PR DESCRIPTION
fix(api): cast string value to int enum (#2461)

c7381a4f809114708838f86aead0d9c769bc3b79