### PR TITLE
chore: release 3.1.0

### DIFF
--- a/analyzer/setup.py
+++ b/analyzer/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="libretime-analyzer",
-    version="3.0.2",
+    version="3.1.0",
     description="Libretime Analyzer",
     author="LibreTime Contributors",
     url="https://github.com/libretime/libretime",

--- a/api-client/setup.py
+++ b/api-client/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="libretime-api-client",
-    version="3.0.2",
+    version="3.1.0",
     description="LibreTime API Client",
     author="LibreTime Contributors",
     url="https://github.com/libretime/libretime",

--- a/api/setup.py
+++ b/api/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="libretime-api",
-    version="3.0.2",
+    version="3.1.0",
     description="LibreTime API",
     author="LibreTime Contributors",
     url="https://github.com/libretime/libretime",

--- a/docs/releases/3.1.0.md
+++ b/docs/releases/3.1.0.md
@@ -1,0 +1,157 @@
+---
+title: LibreTime 3.1.0
+---
+
+import ReleaseHead from './\_release-head.md';
+
+<ReleaseHead date='2023-05-26' version='3.1.0'/>
+
+## :sparkling_heart: Contributors
+
+The LibreTime project wants to thank the following contributors for authoring PRs to this release:
+
+- @ihorhordiichuk
+- @jooola
+- @paddatrapper
+- @togir2
+
+## :rocket: Features
+
+- drop Ubuntu Bionic support
+- drop Python 3.6 support
+- drop Debian Buster support
+- drop Liquidsoap 1.1 support
+- drop Liquidsoap 1.3 support
+- drop Python 3.7 support
+- drop cc_stream_setting table
+- delete cc_pref stream preferences rows
+- **legacy:** remove db allowed_cors_origins preference ([#2095](https://github.com/libretime/libretime/issues/2095))
+- configure cue points analysis per track type
+- **playout:** use jinja2 env for template loading
+- **playout:** add jinja2 quote filter for liquidsoap
+- **playout:** use liquidsoap interactive variables
+- **playout:** remove unused liquidsoap outputs connection status
+- **playout:** remove unused liquidsoap restart function
+- **playout:** remove unused liquidsoap output namespace
+- replace loguru with logging
+- **playout:** use jinja to configure liquidsoap outputs
+- **playout:** enable vorbis metadata per icecast output
+- **playout:** use shared app for cli commands
+- **installer:** configure timezone using timedatectl ([#2418](https://github.com/libretime/libretime/issues/2418))
+- **playout:** don't serialize message twice
+- add python packages version
+- add sentry sdk
+- use secret_key config field instead of api_key ([#2444](https://github.com/libretime/libretime/issues/2444))
+- **api-client:** remove unused api v1 calls
+- **api-client:** rewrite api-client v1 using abstract client
+- **playout:** move liquidsoap auth to notify cli
+- **playout:** replace schedule event dicts with objects
+- **api:** add cors headers middleware ([#2479](https://github.com/libretime/libretime/issues/2479))
+- **playout:** replace thread timeout with socket timeout
+- remove dev files from tarball
+- include tarball checksums in releases
+- set icecast mount default charset to UTF-8
+- **playout:** allow harbor ssl configuration
+- **api:** install gunicorn/uvicorn from pip
+- install inside a python3 venv
+
+## :bug: Bug fixes
+
+- **deps:** update dependency adbario/php-dot-notation to v3 ([#2226](https://github.com/libretime/libretime/issues/2226))
+- **deps:** update dependency league/uri to v6.7.2
+- **legacy:** set platform requirements to php ^7.4
+- **playout:** remove outdated liquidsoap code
+- **playout:** add types
+- **api:** allow single digit version for legacy schema
+- **deps:** update dependency friendsofphp/php-cs-fixer to <3.12.1
+- remove systemd ProtectHome feature ([#2243](https://github.com/libretime/libretime/issues/2243))
+- **deps:** update dependency friendsofphp/php-cs-fixer to <3.13.1 ([#2249](https://github.com/libretime/libretime/issues/2249))
+- **worker:** replace deprecated cgi.parse_header
+- **installer:** install missing sudo
+- **installer:** set home and login when running as postgres
+- **legacy:** add log entry on task run ([#2316](https://github.com/libretime/libretime/issues/2316))
+- **legacy:** log errors on connect check failure ([#2317](https://github.com/libretime/libretime/issues/2317))
+- **deps:** update dependency friendsofphp/php-cs-fixer to <3.13.2
+- **deps:** update dependency friendsofphp/php-cs-fixer to <3.13.3
+- **legacy:** advanced search by track type id
+- **legacy:** move forked deps to the libretime namespace
+- **deps:** update dependency friendsofphp/php-cs-fixer to <3.14.4
+- **deps:** update dependency friendsofphp/php-cs-fixer to <3.14.5
+- **legacy:** ensure options is a dict during json encoding
+- **legacy:** don't use dict assignment on object ([#2384](https://github.com/libretime/libretime/issues/2384))
+- **playout:** quote escape strings in liquidsoap entrypoint
+- **legacy:** don't delete audio file when removing artwork ([#2395](https://github.com/libretime/libretime/issues/2395))
+- **playout:** use explicit ids for liquidsoap components
+- **playout:** skip the identified queue instead of the current
+- **playout:** use the same number of schedule queues
+- **legacy:** on air light fails when no shows are scheduled
+- **playout:** flush liquidsoap response before sending new
+- **playout:** use package loader for liquidsoap templates
+- **playout:** %else isn't defined
+- **playout:** when shows ends, next shows starts without fade-in/fade-out ([#2412](https://github.com/libretime/libretime/issues/2412))
+- **playout:** legacy pushes non validated data
+- **playout:** explicit ogg vorbis icecast encoder
+- **playout:** prevent unbound variables
+- **playout:** use int for liquidsoap queues map
+- **shared:** return type confusion
+- **deps:** update dependency friendsofphp/php-cs-fixer to <3.15.2
+- **api:** explicit FileImportStatusEnum in schema
+- pin postgresql version in docker-compose
+- pin rabbitmq version in docker-compose
+- allow overriding docker-compose predefined environment
+- move docker specific setup to dockerfile
+- **api:** cast string value to int enum ([#2461](https://github.com/libretime/libretime/issues/2461))
+- **playout:** quote incompatible <py3.9 type hints
+- **installer:** bump setuptools to ~=67.3 ([#2387](https://github.com/libretime/libretime/issues/2387))
+- **playout:** use new api-client v1
+- **playout:** catch oserror in liquidsoap client
+- **deps:** update dependency friendsofphp/php-cs-fixer to <3.16.1 (main) ([#2490](https://github.com/libretime/libretime/issues/2490))
+- **api:** require django >=4.2.0,<4.3
+- **api:** upgrade psycopg to v3.1
+- **playout:** remove unused ecasound package ([#2496](https://github.com/libretime/libretime/issues/2496))
+- **installer:** ignore whitespace during diff
+- **legacy:** don't print track_type id in show builder table ([#2510](https://github.com/libretime/libretime/issues/2510))
+- **legacy:** remove composer superuser warning ([#2515](https://github.com/libretime/libretime/issues/2515))
+- **legacy:** keep datatable settings between views ([#2519](https://github.com/libretime/libretime/issues/2519))
+- **api:** upgrade django code (pre-commit)
+- **analyzer:** remove unused python3 package
+- **deps:** update dependency friendsofphp/php-cs-fixer to <3.17.1 (main) ([#2556](https://github.com/libretime/libretime/issues/2556))
+
+## :arrow_up: Upgrading
+
+### New `general.secret_key` configuration
+
+This release adds the `general.secret_key` configuration field in the [configuration file](../admin-manual/configuration.md#general), to prevent reusing the `general.api_key` for cryptographic usage. If the field is missing, it will fallback to the previous behavior, use the `general.api_key` and print a warning.
+
+To silence the warning about the missing field, make sure to add the `general.secret_key` field to your configuration file. The field will be required on the [next major release](./README.md#versioning-schema).
+
+### Icecast mount default charset
+
+During the first installation, the installer will configure Icecast to use UTF-8 as default charset for mounts. To upgrade an existing installation, you may want to manually apply the changes in the `/etc/icecast2/icecast.xml`:
+
+```xml
+    <mount type="default">
+        <charset>UTF-8</charset>
+    </mount>
+```
+
+Or if only want to set the charset to UTF-8 for specific mounts (for example `/main.mp3`):
+
+```xml
+    <mount type="normal">
+        <mount-name>/main.mp3</mount-name>
+        <charset>UTF-8</charset>
+    </mount>
+```
+
+Please, see the [documentation for more details](../admin-manual/stream-configuration.md#utf-8-metadata-in-icecast-mp3-streams).
+
+### Unused packages and dependencies
+
+Starting with this release, LibreTime installs `gunicorn`, `uvicorn` and `pika` from PyPi. This renders some previously installed distribution packages useless. You can remove them from your system using the following command:
+
+```bash
+sudo apt remove gunicorn python3-gunicorn python3-httptools python3-uvicorn python3-uvloop python3-pika
+```
+
+In addition, LibreTime now install its dependencies in a python virtual environment. This renders the python packages that LibreTime installed globally useless. There is no clean way to remove those python packages, because there is no safe way to know if other tools depend on them. If you are experienced enough with CLI and system administration, you may prune the entire `/usr/local/lib/python3.*/dist-packages/` directory, but do this **at your own risk**. Those globally installed python packages may stay on the system, they shouldn't break LibreTime.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -29,3 +29,4 @@ New releases target the current stable distributions release, and development sh
 | End of life  |   2023-04    |  2024-06   |   2025-04    |   2026-06   |
 | Versions     |              |            |              |             |
 | 3.0.x        |  deprecated  | deprecated | recommended  | recommended |
+| 3.1.x        |              |            | recommended  | recommended |

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -26,37 +26,6 @@ Please follow this **before the upgrade procedure**.
 
 ## :arrow_up: Upgrading
 
-### Icecast mount default charset
-
-During the first installation, the installer will configure Icecast to use UTF-8 as default charset for mounts. To upgrade an existing installation, you may want to manually apply the changes in the `/etc/icecast2/icecast.xml`:
-
-```xml
-    <mount type="default">
-        <charset>UTF-8</charset>
-    </mount>
-```
-
-Or if only want to set the charset to UTF-8 for specific mounts (for example `/main.mp3`):
-
-```xml
-    <mount type="normal">
-        <mount-name>/main.mp3</mount-name>
-        <charset>UTF-8</charset>
-    </mount>
-```
-
-Please, see the [documentation for more details](../admin-manual/stream-configuration.md#utf-8-metadata-in-icecast-mp3-streams).
-
-### Unused packages and dependencies
-
-Starting with this release, LibreTime installs `gunicorn`, `uvicorn` and `pika` from PyPi. This renders some previously installed distribution packages useless. You can remove them from your system using the following command:
-
-```bash
-sudo apt remove gunicorn python3-gunicorn python3-httptools python3-uvicorn python3-uvloop python3-pika
-```
-
-In addition, LibreTime now install its dependencies in a python virtual environment. This renders the python packages that LibreTime installed globally useless. There is no clean way to remove those python packages, because there is no safe way to know if other tools depend on them. If you are experienced enough with CLI and system administration, you may prune the entire `/usr/local/lib/python3.*/dist-packages/` directory, but do this **at your own risk**. Those globally installed python packages may stay on the system, they shouldn't break LibreTime.
-
 ## :warning: Known issues
 
 The following issues may need a workaround for the time being. Please search the [issues](https://github.com/libretime/libretime/issues) before reporting problems not listed below.

--- a/playout/setup.py
+++ b/playout/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="libretime-playout",
-    version="3.0.2",
+    version="3.1.0",
     description="LibreTime Playout",
     author="LibreTime Contributors",
     url="https://github.com/libretime/libretime",

--- a/shared/setup.py
+++ b/shared/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="libretime-shared",
-    version="3.0.2",
+    version="3.1.0",
     description="LibreTime Shared",
     url="https://github.com/libretime/libretime",
     author="LibreTime Contributors",

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="libretime-worker",
-    version="3.0.2",
+    version="3.1.0",
     description="LibreTime Worker",
     author="LibreTime Contributors",
     url="https://github.com/libretime/libretime",


### PR DESCRIPTION
I'd like to start thinking about releasing 3.1.0.

There are some issues still open on the 3.1.0 milestone, I've moved some of them to the 3.2.0 milestone. Is there anythingelse that must go into 3.1.0 ?