### PR TITLE
fix(playout): remove unused ecasound package

### DIFF
--- a/playout/packages.ini
+++ b/playout/packages.ini
@@ -8,9 +8,6 @@ python3-lxml = focal, bullseye, jammy, bookworm
 # https://github.com/savonet/liquidsoap/blob/main/CHANGES.md
 liquidsoap = focal, bullseye, jammy, bookworm
 
-[recorder]
-ecasound = focal, bullseye, jammy, bookworm
-
 [misc]
 # Used by pypofetch to check if a file is open.
 # TODO: consider using a python library


### PR DESCRIPTION
The recorder has been removed, so the ecasound package isn't used anymore.
