### PR TITLE
fix(legacy): don't print track_type id in show builder table

### DIFF
--- a/legacy/application/assets.json
+++ b/legacy/application/assets.json
@@ -59,7 +59,7 @@
   "js/airtime/dashboard/versiontooltip.js": "f267c6ec0205e98f1ffba5f636928f7a",
   "js/airtime/library/events/library_playlistbuilder.js": "1e0aa11953c7ff243cd2df241cc8a296",
   "js/airtime/library/events/library_showbuilder.js": "996a5c3008eb17552ee8f891d88c9341",
-  "js/airtime/library/library.js": "d47ed07f83c68271b2e3bb50d4eb2b8f",
+  "js/airtime/library/library.js": "6e8af5c3a9a81c1afd60f726ff25601f",
   "js/airtime/library/plupload.js": "7f754a28ac2d4060aec918c688a74a22",
   "js/airtime/library/podcast.js": "f4fd354d739e7121ba00162496c295df",
   "js/airtime/library/publish.js": "851ef4c4caa9e9220acf945c21760189",

--- a/legacy/public/js/airtime/library/library.js
+++ b/legacy/public/js/airtime/library/library.js
@@ -1096,6 +1096,18 @@ var AIRTIME = (function (AIRTIME) {
               });
             })
             .html(type_button);
+        } else {
+          // Not on dashboard (show builder)
+          if (
+            aData.track_type_id == null ||
+            aData.track_type_id == undefined ||
+            aData.track_type_id == 0
+          ) {
+            var track_type_code = "";
+          } else {
+            var track_type_code = TRACKTYPES[aData.track_type_id].code;
+          }
+          $(nRow).find("td.library_track_type").html(track_type_code);
         }
 
         // add audio preview image/button


### PR DESCRIPTION
The show builder was printing the track type ID instead of printing the expected track type code.