### PR TITLE
fix(legacy): keep datatable settings between views

### DIFF
--- a/legacy/application/assets.json
+++ b/legacy/application/assets.json
@@ -59,7 +59,7 @@
   "js/airtime/dashboard/versiontooltip.js": "f267c6ec0205e98f1ffba5f636928f7a",
   "js/airtime/library/events/library_playlistbuilder.js": "1e0aa11953c7ff243cd2df241cc8a296",
   "js/airtime/library/events/library_showbuilder.js": "996a5c3008eb17552ee8f891d88c9341",
-  "js/airtime/library/library.js": "d47ed07f83c68271b2e3bb50d4eb2b8f",
+  "js/airtime/library/library.js": "aded43b205f22a023cb85724c5945e45",
   "js/airtime/library/plupload.js": "7f754a28ac2d4060aec918c688a74a22",
   "js/airtime/library/podcast.js": "f4fd354d739e7121ba00162496c295df",
   "js/airtime/library/publish.js": "851ef4c4caa9e9220acf945c21760189",

--- a/legacy/public/js/airtime/library/library.js
+++ b/legacy/public/js/airtime/library/library.js
@@ -864,6 +864,12 @@ var AIRTIME = (function (AIRTIME) {
                             DATATABLES
             ############################################ */
 
+    if (onDashboard) {
+      var dataTableLocalStorageKey = "datatables-library-dashboard";
+    } else {
+      var dataTableLocalStorageKey = "datatables-library-builder";
+    }
+
     mod.libraryDataTable = $libTable.dataTable({
       // put hidden columns at the top to insure they can never be visible
       // on the table through column reordering.
@@ -882,7 +888,7 @@ var AIRTIME = (function (AIRTIME) {
         delete oData.aoSearchCols;
       },
       fnStateSave: function (oSettings, oData) {
-        localStorage.setItem("datatables-library", JSON.stringify(oData));
+        localStorage.setItem(dataTableLocalStorageKey, JSON.stringify(oData));
 
         // Sadly, this is necessary because we need to unscramble the colReorder map on the backend
         $.ajax({
@@ -895,7 +901,9 @@ var AIRTIME = (function (AIRTIME) {
         colReorderMap = oData.ColReorder;
       },
       fnStateLoad: function fnLibStateLoad(oSettings) {
-        var settings = JSON.parse(localStorage.getItem("datatables-library"));
+        var settings = JSON.parse(
+          localStorage.getItem(dataTableLocalStorageKey)
+        );
 
         // local storage was empty lets get something from the backend
         if (settings === null) {
@@ -907,7 +915,10 @@ var AIRTIME = (function (AIRTIME) {
             async: false, // <<< every sane browser will warn that this is not nice
             dataType: "json",
             success: function (oData) {
-              localStorage.setItem("datatables-library", JSON.stringify(oData));
+              localStorage.setItem(
+                dataTableLocalStorageKey,
+                JSON.stringify(oData)
+              );
               settings = oData;
             },
           });


### PR DESCRIPTION
Use a different storage key for datatable settings for the dashboard and builder views. The settings were overwritten when the other view was loaded.

