### PR TITLE
fix(playout): liquidsoap aac output syntax errors

### DIFF
--- a/playout/libretime_playout/liquidsoap/templates/outputs.liq.j2
+++ b/playout/libretime_playout/liquidsoap/templates/outputs.liq.j2
@@ -32,8 +32,8 @@
 
 {%- elif audio.format == "aac" -%}
 %fdkaac(
-  bitrate=bitrate={{ audio.bitrate }},
-  aot={{ "mpeg4_he_aac_v2" if audio.bitrate <= 64 else "mpeg4_aac_lc" }},
+  bitrate={{ audio.bitrate }},
+  aot={{ ("mpeg4_he_aac_v2" if audio.bitrate <= 64 else "mpeg4_aac_lc") | quote }},
   afterburner={{ "false" if audio.bitrate <= 128 else "true" }},
   sbr_mode=true
 )

--- a/playout/tests/liquidsoap/entrypoint_test.py
+++ b/playout/tests/liquidsoap/entrypoint_test.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from subprocess import check_call
+from subprocess import CalledProcessError, check_call, check_output
 from unittest import mock
 
 import pytest
@@ -10,7 +10,7 @@ from libretime_playout.liquidsoap.models import Info, StreamPreferences
 from libretime_playout.liquidsoap.version import get_liquidsoap_version
 
 from .conftest import LIQ_VERSION
-from .fixtures import TEST_STREAM_CONFIGS
+from .fixtures import TEST_STREAM_CONFIGS, make_config_with_stream
 
 
 @pytest.mark.parametrize(
@@ -73,3 +73,44 @@ def test_liquidsoap_syntax(tmp_path: Path, stream_config):
     )
 
     check_call(["liquidsoap", "--check", str(entrypoint_filepath)])
+
+
+@pytest.mark.skipif(
+    LIQ_VERSION >= (2, 0, 0),
+    reason="unsupported liquidsoap >= 2.0.0",
+)
+def test_liquidsoap_unsupported_output_aac(tmp_path: Path):
+    entrypoint_filepath = tmp_path / "radio.liq"
+    log_filepath = tmp_path / "radio.log"
+
+    entrypoint_filepath.write_text(
+        generate_entrypoint(
+            log_filepath=log_filepath,
+            config=make_config_with_stream(
+                outputs={
+                    "icecast": [
+                        {
+                            "enabled": True,
+                            "mount": "main.aac",
+                            "source_password": "hackme",
+                            "audio": {"format": "aac", "bitrate": 128},
+                        }
+                    ]
+                }
+            ),
+            preferences=StreamPreferences(
+                input_fade_transition=0.0,
+                message_format=0,
+                message_offline="LibreTime - offline",
+            ),
+            info=Info(
+                station_name="LibreTime",
+            ),
+            version=get_liquidsoap_version(),
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CalledProcessError) as exception:
+        check_output(["liquidsoap", "--check", str(entrypoint_filepath)])
+    assert b"You must be missing an optional dependency." in exception.value.stdout


### PR DESCRIPTION
The aac output template was broken, only found out while going over #2569 again.