### PR TITLE
fix: libretime process leaks and lsof high cpu usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
 
   playout:
     image: ghcr.io/libretime/libretime-playout:${LIBRETIME_VERSION:-latest}
+    init: true
+    ulimits:
+      nofile: 1024
     depends_on:
       - rabbitmq
     volumes:
@@ -33,6 +36,9 @@ services:
   liquidsoap:
     image: ghcr.io/libretime/libretime-playout:${LIBRETIME_VERSION:-latest}
     command: /usr/local/bin/libretime-liquidsoap
+    init: true
+    ulimits:
+      nofile: 1024
     ports:
       - 8001:8001
       - 8002:8002
@@ -46,6 +52,9 @@ services:
 
   analyzer:
     image: ghcr.io/libretime/libretime-analyzer:${LIBRETIME_VERSION:-latest}
+    init: true
+    ulimits:
+      nofile: 1024
     depends_on:
       - rabbitmq
     volumes:
@@ -56,6 +65,9 @@ services:
 
   worker:
     image: ghcr.io/libretime/libretime-worker:${LIBRETIME_VERSION:-latest}
+    init: true
+    ulimits:
+      nofile: 1024
     depends_on:
       - rabbitmq
     volumes:
@@ -65,6 +77,9 @@ services:
 
   api:
     image: ghcr.io/libretime/libretime-api:${LIBRETIME_VERSION:-latest}
+    init: true
+    ulimits:
+      nofile: 1024
     depends_on:
       - postgres
       - rabbitmq
@@ -74,6 +89,9 @@ services:
 
   legacy:
     image: ghcr.io/libretime/libretime-legacy:${LIBRETIME_VERSION:-latest}
+    init: true
+    ulimits:
+      nofile: 1024
     depends_on:
       - postgres
       - rabbitmq


### PR DESCRIPTION
### Description

The default docker composition had several problems like leaking processes and high lsof cpu usage. The processes were leaking because of [this call](https://github.com/libretime/libretime/blob/3.1.0/playout/libretime_playout/liquidsoap/1.4/ls_lib.liq#L2) and no init process to reap the processes once they finished. The [lsof](https://github.com/libretime/libretime/blob/3.1.0/playout/libretime_playout/player/fetch.py#L224) thing [is a know issue with docker](https://bugzilla.redhat.com/show_bug.cgi?id=1715254).

### Testing Notes

**What I did:**

_Ran libretime with these changes and everything worked as expected_

**How you can replicate my testing:**

_Run the docker composition and observe process leak and high cpu usage:_

```
root     3192950  0.0  0.0 720496  9588 ?        Sl   04:03   0:00 /usr/bin/containerd-shim-runc-v2 -namespace moby -id f8742179f10197ea27612dc855a761b6f93fbcdba3e0428f0d2eb31f5587590d -address /run/containerd/containerd.sock
almalin+ 3192970  3.1  0.1 963584 81564 ?        SLsl 04:03   0:05  \_ libretime-liquidsoap --verbose /app/radio.liq
almalin+ 3197149  0.0  0.0      0     0 ?        Z    04:04   0:00      \_ [timeout] <defunct>
almalin+ 3197199  0.0  0.0      0     0 ?        Z    04:04   0:00      \_ [timeout] <defunct>
...
root       26497  0.0  0.0 720752  6620 ?        Sl   Jun28   1:51 /usr/bin/containerd-shim-runc-v2 -namespace moby -id 262d9318917de816be525b437b1f1634ab4d240333053075a375f6293eb28da7 -address /run/containerd/containerd.sock
almalin+   26570  0.0  0.0 574872 44016 ?        Ssl  Jun28   1:49  \_ /usr/local/bin/python /usr/local/bin/libretime-playout
almalin+ 3139332 18.8  0.0   3836   808 ?        S    03:55   2:07      \_ lsof -- /app/scheduler/15.mp3
almalin+ 3196381 46.0  0.0   3836   148 ?        R    04:04   1:10          \_ lsof -- /app/scheduler/15.mp3
```
