### PR TITLE
feat(playout): configure device for alsa and pulseaudio system outputs

### DIFF
--- a/docker/config.template.yml
+++ b/docker/config.template.yml
@@ -328,5 +328,5 @@ stream:
         kind: pulseaudio
 
         # System output device.
-        # > only available for kind=pulseaudio or kind=alsa
+        # > only available for kind=(alsa, pulseaudio)
         device:

--- a/docker/config.template.yml
+++ b/docker/config.template.yml
@@ -326,3 +326,7 @@ stream:
         # > must be one of (alsa, ao, oss, portaudio, pulseaudio)
         # > default is pulseaudio
         kind: pulseaudio
+
+        # System output device.
+        # > only available for kind=pulseaudio or kind=alsa
+        device:

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -328,5 +328,5 @@ stream:
         kind: pulseaudio
 
         # System output device.
-        # > only available for kind=pulseaudio or kind=alsa
+        # > only available for kind=(alsa, pulseaudio)
         device:

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -326,3 +326,7 @@ stream:
         # > must be one of (alsa, ao, oss, portaudio, pulseaudio)
         # > default is pulseaudio
         kind: pulseaudio
+
+        # System output device.
+        # > only available for kind=pulseaudio or kind=alsa
+        device:

--- a/docker/example/config.yml
+++ b/docker/example/config.yml
@@ -328,5 +328,5 @@ stream:
         kind: pulseaudio
 
         # System output device.
-        # > only available for kind=pulseaudio or kind=alsa
+        # > only available for kind=(alsa, pulseaudio)
         device:

--- a/docker/example/config.yml
+++ b/docker/example/config.yml
@@ -326,3 +326,7 @@ stream:
         # > must be one of (alsa, ao, oss, portaudio, pulseaudio)
         # > default is pulseaudio
         kind: pulseaudio
+
+        # System output device.
+        # > only available for kind=pulseaudio or kind=alsa
+        device:

--- a/docs/admin-manual/configuration.md
+++ b/docs/admin-manual/configuration.md
@@ -526,11 +526,15 @@ stream:
     system:
       - # Whether the output is enabled.
         # > default is false
-        enabled: false
+        enabled: true
         # System output kind.
         # > must be one of (alsa, ao, oss, portaudio, pulseaudio)
         # > default is pulseaudio
         kind: "pulseaudio"
+
+        # System output device.
+        # > only available for kind=pulseaudio or kind=alsa
+        device: "alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink"
 ```
 
 ## LDAP

--- a/docs/admin-manual/configuration.md
+++ b/docs/admin-manual/configuration.md
@@ -533,7 +533,7 @@ stream:
         kind: "pulseaudio"
 
         # System output device.
-        # > only available for kind=pulseaudio or kind=alsa
+        # > only available for kind=(alsa, pulseaudio)
         device: "alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink"
 ```
 

--- a/installer/config.yml
+++ b/installer/config.yml
@@ -328,5 +328,5 @@ stream:
         kind: pulseaudio
 
         # System output device.
-        # > only available for kind=pulseaudio or kind=alsa
+        # > only available for kind=(alsa, pulseaudio)
         device:

--- a/installer/config.yml
+++ b/installer/config.yml
@@ -326,3 +326,7 @@ stream:
         # > must be one of (alsa, ao, oss, portaudio, pulseaudio)
         # > default is pulseaudio
         kind: pulseaudio
+
+        # System output device.
+        # > only available for kind=pulseaudio or kind=alsa
+        device:

--- a/legacy/application/configs/conf.php
+++ b/legacy/application/configs/conf.php
@@ -211,6 +211,7 @@ class Schema implements ConfigurationInterface
             /*    */->validate()->ifNotInArray(["alsa", "ao", "oss", "portaudio", "pulseaudio"])
             /*    */->thenInvalid('invalid stream.outputs.system.kind %s')
             /*  */->end()->end()
+            /*  */->scalarNode('device')->end()
             /**/->end()->end()->end()
 
             ->end()->end()

--- a/playout/libretime_playout/liquidsoap/templates/outputs.liq.j2
+++ b/playout/libretime_playout/liquidsoap/templates/outputs.liq.j2
@@ -117,20 +117,41 @@ output.shoutcast(
 )
 {%- endmacro -%}
 
-{% for output in config.stream.outputs.system -%}
-{% if output.enabled -%}
-# {{ output.kind.value }}:{{ loop.index }}
+{#-
+  Build a system output configuration.
+#}
+{%- macro output_system(output_id, output) -%}
+# {{ output.kind.value }}:{{ output_id }}
 %ifndef output.{{ output.kind.value }}
 log("output.{{ output.kind.value }} is not defined!")
 %endif
 %ifdef output.{{ output.kind.value }}
-output.{{ output.kind.value }}(id="{{ output.kind.value }}:{{ loop.index }}", s)
+output.{{ output.kind.value }}(
+  id="{{ output.kind.value }}:{{ output_id }}",
+{%- if output.kind.value == "alsa" %}
+{%- if output.device is not none %}
+  device="{{ output.device }}",
+{%- endif %}
+{%- elif output.kind.value == "pulseaudio" %}
+{%- if output.device is not none %}
+  device="{{ output.device }}",
+{%- endif %}
+{%- endif %}
+  s
+)
 %endif
+{%- endmacro -%}
+
+{# ############################### #}
+
+{%- for output in config.stream.outputs.system -%}
+{% if output.enabled -%}
+{{ output_system(loop.index, output) }}
 
 {% endif -%}
 {% endfor -%}
 
-{% for output in config.stream.outputs.icecast -%}
+{%- for output in config.stream.outputs.icecast -%}
 {% if output.enabled -%}
 {{ output_icecast(loop.index, output) }}
 

--- a/playout/tests/liquidsoap/__snapshots__/entrypoint_test.ambr
+++ b/playout/tests/liquidsoap/__snapshots__/entrypoint_test.ambr
@@ -315,7 +315,10 @@
   log("output.pulseaudio is not defined!")
   %endif
   %ifdef output.pulseaudio
-  output.pulseaudio(id="pulseaudio:1", s)
+  output.pulseaudio(
+    id="pulseaudio:1",
+    s
+  )
   %endif
   
   
@@ -325,6 +328,55 @@
   '''
 # ---
 # name: test_generate_entrypoint[stream_config6-1.4]
+  '''
+  # THIS FILE IS AUTO GENERATED. PLEASE DO NOT EDIT!
+  ###########################################################
+  # The ignore() lines are to squash unused variable warnings
+  
+  # Inputs
+  input_main_mount = "main"
+  input_main_port = 8001
+  input_main_secure = false
+  input_show_mount = "show"
+  input_show_port = 8002
+  input_show_secure = false
+  
+  # Settings
+  set("log.file.path", "/var/log/radio.log")
+  
+  set("server.telnet", true)
+  set("server.telnet.bind_addr", "127.0.0.1")
+  set("server.telnet.port", 1234)
+  
+  set("harbor.bind_addrs", ["0.0.0.0"])
+  
+  station_name = interactive.string("station_name", "LibreTime")
+  
+  message_offline = interactive.string("message_offline", "LibreTime - offline")
+  message_format = interactive.string("message_format", "0")
+  input_fade_transition = interactive.float("input_fade_transition", 0.0)
+  
+  %include "/fake/1.4/ls_script.liq"
+  
+  # pulseaudio:1
+  %ifndef output.pulseaudio
+  log("output.pulseaudio is not defined!")
+  %endif
+  %ifdef output.pulseaudio
+  output.pulseaudio(
+    id="pulseaudio:1",
+    device="alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink",
+    s
+  )
+  %endif
+  
+  
+  
+  gateway("started")
+  
+  '''
+# ---
+# name: test_generate_entrypoint[stream_config7-1.4]
   '''
   # THIS FILE IS AUTO GENERATED. PLEASE DO NOT EDIT!
   ###########################################################

--- a/playout/tests/liquidsoap/__snapshots__/entrypoint_test.ambr
+++ b/playout/tests/liquidsoap/__snapshots__/entrypoint_test.ambr
@@ -365,7 +365,7 @@
   %ifdef output.pulseaudio
   output.pulseaudio(
     id="pulseaudio:1",
-    device="alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink",
+    device="alsa_output.pci-0000_00_sink",
     s
   )
   %endif

--- a/playout/tests/liquidsoap/fixtures/__init__.py
+++ b/playout/tests/liquidsoap/fixtures/__init__.py
@@ -94,6 +94,17 @@ TEST_STREAM_CONFIGS: List[Config] = [
     ),
     make_config_with_stream(
         outputs={
+            "system": [
+                {
+                    "enabled": True,
+                    "kind": "pulseaudio",
+                    "device": "alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink",
+                }
+            ],
+        }
+    ),
+    make_config_with_stream(
+        outputs={
             "system": [{"enabled": False, "kind": "alsa"}],
         }
     ),

--- a/playout/tests/liquidsoap/fixtures/__init__.py
+++ b/playout/tests/liquidsoap/fixtures/__init__.py
@@ -98,7 +98,7 @@ TEST_STREAM_CONFIGS: List[Config] = [
                 {
                     "enabled": True,
                     "kind": "pulseaudio",
-                    "device": "alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__hw_sofhdadsp__sink",
+                    "device": "alsa_output.pci-0000_00_sink",
                 }
             ],
         }

--- a/shared/libretime_shared/config/_models.py
+++ b/shared/libretime_shared/config/_models.py
@@ -216,7 +216,7 @@ class ShoutcastOutput(BaseModel):
     mobile: bool = False
 
 
-class SystemOutputKind(str, Enum):
+class SystemOutput(str, Enum):
     ALSA = "alsa"
     AO = "ao"
     OSS = "oss"
@@ -224,16 +224,49 @@ class SystemOutputKind(str, Enum):
     PULSEAUDIO = "pulseaudio"
 
 
-class SystemOutput(BaseModel):
+class BaseSystemOutput(BaseModel):
     enabled: bool = False
-    kind: SystemOutputKind = SystemOutputKind.PULSEAUDIO
+
+
+class ALSASystemOutput(BaseSystemOutput):
+    kind: Literal[SystemOutput.ALSA] = SystemOutput.ALSA
+    device: Optional[str] = None
+
+
+class AOSystemOutput(BaseSystemOutput):
+    kind: Literal[SystemOutput.AO] = SystemOutput.AO
+
+
+class OSSSystemOutput(BaseSystemOutput):
+    kind: Literal[SystemOutput.OSS] = SystemOutput.OSS
+
+
+class PortAudioSystemOutput(BaseSystemOutput):
+    kind: Literal[SystemOutput.PORTAUDIO] = SystemOutput.PORTAUDIO
+
+
+class PulseAudioSystemOutput(BaseSystemOutput):
+    kind: Literal[SystemOutput.PULSEAUDIO] = SystemOutput.PULSEAUDIO
+    device: Optional[str] = None
+
+
+AnySystemOutput = Annotated[
+    Union[
+        ALSASystemOutput,
+        AOSystemOutput,
+        OSSSystemOutput,
+        PortAudioSystemOutput,
+        PulseAudioSystemOutput,
+    ],
+    Field(discriminator="kind", default=SystemOutput.PULSEAUDIO),
+]
 
 
 # pylint: disable=too-few-public-methods
 class Outputs(BaseModel):
     icecast: List[IcecastOutput] = Field([], max_length=3)
     shoutcast: List[ShoutcastOutput] = Field([], max_length=1)
-    system: List[SystemOutput] = Field([], max_length=1)
+    system: List[AnySystemOutput] = Field([], max_length=1)
 
     @property
     def merged(self) -> List[Union[IcecastOutput, ShoutcastOutput]]:


### PR DESCRIPTION
### Description
Attempting to add hardware configuration to liquidsoap so that users may set hardware output in config.yml. I'm focusing my efforts on ALSA for now, but PulseAudio should be easy enough to implement after ALSA is successful.

**This is a new feature**:

Add hardware configuration


### Testing Notes

**What I did:**

I'm using docker-compose on Ubuntu 20.04.
```
docker --version
Docker version 20.10.25, build 20.10.25-0ubuntu1~20.04.1
```

```
docker-compose --version
Docker Compose version v2.20.2
```

### Links

see my forum post for full notes:
https://discourse.libretime.org/t/hardware-configuration/1229/12
