### PR TITLE
feat: add mobile devices stream config field

### DIFF
--- a/docker/config.template.yml
+++ b/docker/config.template.yml
@@ -264,6 +264,10 @@ stream:
         # Icecast stream genre.
         genre: various
 
+        # Whether the stream should be used for mobile devices.
+        # > default is false
+        mobile: false
+
     # Shoutcast output streams.
     # > max items is 1
     shoutcast:
@@ -308,6 +312,10 @@ stream:
         website: https://libretime.org
         # Shoutcast stream genre.
         genre: various
+
+        # Whether the stream should be used for mobile devices.
+        # > default is false
+        mobile: false
 
     # System outputs.
     # > max items is 1

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -264,6 +264,10 @@ stream:
         # Icecast stream genre.
         genre: various
 
+        # Whether the stream should be used for mobile devices.
+        # > default is false
+        mobile: false
+
     # Shoutcast output streams.
     # > max items is 1
     shoutcast:
@@ -308,6 +312,10 @@ stream:
         website: https://libretime.org
         # Shoutcast stream genre.
         genre: various
+
+        # Whether the stream should be used for mobile devices.
+        # > default is false
+        mobile: false
 
     # System outputs.
     # > max items is 1

--- a/docker/example/config.yml
+++ b/docker/example/config.yml
@@ -264,6 +264,10 @@ stream:
         # Icecast stream genre.
         genre: various
 
+        # Whether the stream should be used for mobile devices.
+        # > default is false
+        mobile: false
+
     # Shoutcast output streams.
     # > max items is 1
     shoutcast:
@@ -308,6 +312,10 @@ stream:
         website: https://libretime.org
         # Shoutcast stream genre.
         genre: various
+
+        # Whether the stream should be used for mobile devices.
+        # > default is false
+        mobile: false
 
     # System outputs.
     # > max items is 1

--- a/docs/admin-manual/configuration.md
+++ b/docs/admin-manual/configuration.md
@@ -451,6 +451,10 @@ stream:
         website: "https://libretime.org"
         # Icecast stream genre.
         genre: "various"
+
+        # Whether the stream should be used for mobile devices.
+        # > default is false
+        mobile: false
 ```
 
 #### Shoutcast
@@ -504,6 +508,10 @@ stream:
         website: "https://libretime.org"
         # Shoutcast stream genre.
         genre: "various"
+
+        # Whether the stream should be used for mobile devices.
+        # > default is false
+        mobile: false
 ```
 
 #### System

--- a/installer/config.yml
+++ b/installer/config.yml
@@ -264,6 +264,10 @@ stream:
         # Icecast stream genre.
         genre: various
 
+        # Whether the stream should be used for mobile devices.
+        # > default is false
+        mobile: false
+
     # Shoutcast output streams.
     # > max items is 1
     shoutcast:
@@ -308,6 +312,10 @@ stream:
         website: https://libretime.org
         # Shoutcast stream genre.
         genre: various
+
+        # Whether the stream should be used for mobile devices.
+        # > default is false
+        mobile: false
 
     # System outputs.
     # > max items is 1

--- a/legacy/application/configs/conf.php
+++ b/legacy/application/configs/conf.php
@@ -171,6 +171,7 @@ class Schema implements ConfigurationInterface
             /*  */->scalarNode('description')->end()
             /*  */->scalarNode('website')->end()
             /*  */->scalarNode('genre')->end()
+            /*  */->booleanNode('mobile')->defaultFalse()->end()
             /**/->end()->end()->end()
 
             // Shoutcast outputs
@@ -200,6 +201,7 @@ class Schema implements ConfigurationInterface
             /*  */->scalarNode('name')->end()
             /*  */->scalarNode('website')->end()
             /*  */->scalarNode('genre')->end()
+            /*  */->booleanNode('mobile')->defaultFalse()->end()
             /**/->end()->end()->end()
 
             // System outputs

--- a/legacy/application/models/StreamSetting.php
+++ b/legacy/application/models/StreamSetting.php
@@ -62,7 +62,7 @@ class Application_Model_StreamConfig
                 $prefix . 'description' => $output['description'] ?? '',
                 $prefix . 'genre' => $output['genre'] ?? '',
                 $prefix . 'url' => $output['website'] ?? '',
-                $prefix . 'mobile' => 'false',
+                $prefix . 'mobile' => $output['mobile'] ?? 'false',
                 // $prefix . 'liquidsoap_error' => 'waiting',
             ];
         }

--- a/shared/libretime_shared/config/_models.py
+++ b/shared/libretime_shared/config/_models.py
@@ -220,6 +220,8 @@ class IcecastOutput(BaseModel):
     website: Optional[str] = None
     genre: Optional[str] = None
 
+    mobile: bool = False
+
     _mount_no_leading_slash = no_leading_slash_validator("mount")
 
 
@@ -243,6 +245,8 @@ class ShoutcastOutput(BaseModel):
     name: Optional[str] = None
     website: Optional[str] = None
     genre: Optional[str] = None
+
+    mobile: bool = False
 
 
 class SystemOutputKind(str, Enum):


### PR DESCRIPTION
### Description

Allow to configure streams to be used for mobile devices. The field was removed while moving to the new config file, the feature should be working :tm: .

