### PR TITLE
fix: add parent function name in setValue exception

### DIFF
--- a/legacy/application/models/Preference.php
+++ b/legacy/application/models/Preference.php
@@ -64,6 +64,7 @@ class Application_Model_Preference
             if ($result > 1) {
                 // this case should not happen.
                 $caller = debug_backtrace()[1]['function'];
+
                 throw new Exception('Invalid number of results returned. Should be ' .
                     "0 or 1, but is '{$result}' instead, caller={$caller}");
             }

--- a/legacy/application/models/Preference.php
+++ b/legacy/application/models/Preference.php
@@ -63,8 +63,9 @@ class Application_Model_Preference
             $paramMap = [];
             if ($result > 1) {
                 // this case should not happen.
+                $caller = debug_backtrace()[1]['function'];
                 throw new Exception('Invalid number of results returned. Should be ' .
-                    "0 or 1, but is '{$result}' instead");
+                    "0 or 1, but is '{$result}' instead, caller={$caller}");
             }
             if ($result == 1) {
                 // result found


### PR DESCRIPTION
This allows to debug when the exception is raised. I've been facing this for a few weeks now, only noticed it now.