### PR TITLE
chore(api): disable duplicate-code check

### DIFF
--- a/api/libretime_api/permission_constants.py
+++ b/api/libretime_api/permission_constants.py
@@ -1,4 +1,4 @@
-from .core.models import Role
+from .core.models.role import Role
 
 GUEST_PERMISSIONS = [
     "view_schedule",

--- a/api/libretime_api/schedule/models/show.py
+++ b/api/libretime_api/schedule/models/show.py
@@ -69,7 +69,7 @@ class Show(models.Model):
     auto_playlist_enabled = models.BooleanField(db_column="has_autoplaylist")
     auto_playlist_repeat = models.BooleanField(db_column="autoplaylist_repeat")
 
-    hosts = models.ManyToManyField(
+    hosts = models.ManyToManyField(  # type: ignore[var-annotated]
         "core.User",
         through="ShowHost",
     )

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -10,6 +10,7 @@ django-settings-module = "libretime_api.settings.testing"
 [tool.pylint.messages_control]
 extension-pkg-whitelist = "pydantic"
 disable = [
+  "duplicate-code",
   "fixme",
   "missing-class-docstring",
   "missing-function-docstring",


### PR DESCRIPTION
Django models will generate too much false positives.