### PR TITLE
fix(api): enum schema description

### DIFF
--- a/api/schema.yml
+++ b/api/schema.yml
@@ -5312,7 +5312,7 @@ components:
           readOnly: true
         import_status:
           allOf:
-            - $ref: "#/components/schemas/PlaylistContentKindEnum"
+            - $ref: "#/components/schemas/FileImportStatusEnum"
           minimum: -2147483648
           maximum: 2147483647
         filepath:
@@ -5564,6 +5564,16 @@ components:
         - mime
         - name
         - size
+    FileImportStatusEnum:
+      enum:
+        - 0
+        - 1
+        - 2
+      type: integer
+      description: |-
+        * `0` - Success
+        * `1` - Pending
+        * `2` - Failed
     ImportedPodcast:
       type: object
       properties:
@@ -5714,7 +5724,7 @@ components:
           readOnly: true
         import_status:
           allOf:
-            - $ref: "#/components/schemas/PlaylistContentKindEnum"
+            - $ref: "#/components/schemas/FileImportStatusEnum"
           minimum: -2147483648
           maximum: 2147483647
         filepath:
@@ -6857,9 +6867,9 @@ components:
         - 2
       type: integer
       description: |-
-        * `0` - Success
-        * `1` - Pending
-        * `2` - Failed
+        * `0` - File
+        * `1` - Stream
+        * `2` - Block
     PlayoutHistory:
       type: object
       properties:


### PR DESCRIPTION
### Description

drf-spectular now properly split the different kind of enums.

