### PR TITLE
ci: ensure release pipeline run after tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v4
         with:
+          token: ${{ secrets.LIBRETIME_BOT_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
           target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
By default, Release Please uses the built-in GITHUB_TOKEN secret. However, all resources created by release-please (release tag or release pull request) will not trigger future GitHub actions workflows, and workflows normally triggered by release.created events will also not run.
