### PR TITLE
feat!: default system output is now `pulseaudio`

### DIFF
--- a/docker/config.template.yml
+++ b/docker/config.template.yml
@@ -324,5 +324,5 @@ stream:
         enabled: false
         # System output kind.
         # > must be one of (alsa, ao, oss, portaudio, pulseaudio)
-        # > default is alsa
-        kind: alsa
+        # > default is pulseaudio
+        kind: pulseaudio

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -324,5 +324,5 @@ stream:
         enabled: false
         # System output kind.
         # > must be one of (alsa, ao, oss, portaudio, pulseaudio)
-        # > default is alsa
-        kind: alsa
+        # > default is pulseaudio
+        kind: pulseaudio

--- a/docker/example/config.yml
+++ b/docker/example/config.yml
@@ -324,5 +324,5 @@ stream:
         enabled: false
         # System output kind.
         # > must be one of (alsa, ao, oss, portaudio, pulseaudio)
-        # > default is alsa
-        kind: alsa
+        # > default is pulseaudio
+        kind: pulseaudio

--- a/docs/admin-manual/configuration.md
+++ b/docs/admin-manual/configuration.md
@@ -529,8 +529,8 @@ stream:
         enabled: false
         # System output kind.
         # > must be one of (alsa, ao, oss, portaudio, pulseaudio)
-        # > default is alsa
-        kind: "alsa"
+        # > default is pulseaudio
+        kind: "pulseaudio"
 ```
 
 ## LDAP

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -30,6 +30,10 @@ Please follow this **before the upgrade procedure**.
 
 The `general.secret_key` field in the [configuration file](../admin-manual/configuration.md#general) is now **required**, to prevent reusing the `general.api_key` for cryptographic usage.
 
+### The `stream.outputs.system[].kind` configuration field now defaults to `pulseaudio`
+
+The `stream.outputs.system[].kind` field in the [configuration file](../admin-manual/configuration.md#general) default value changed from `alsa` to `pulseaudio`. Make sure to update your configuration file if you rely on the default system output.
+
 ## :warning: Known issues
 
 The following issues may need a workaround for the time being. Please search the [issues](https://github.com/libretime/libretime/issues) before reporting problems not listed below.

--- a/installer/config.yml
+++ b/installer/config.yml
@@ -324,5 +324,5 @@ stream:
         enabled: false
         # System output kind.
         # > must be one of (alsa, ao, oss, portaudio, pulseaudio)
-        # > default is alsa
-        kind: alsa
+        # > default is pulseaudio
+        kind: pulseaudio

--- a/legacy/application/configs/conf.php
+++ b/legacy/application/configs/conf.php
@@ -207,7 +207,7 @@ class Schema implements ConfigurationInterface
             // System outputs
             /**/->arrayNode('system')->arrayPrototype()->children()
             /*  */->booleanNode('enabled')->defaultFalse()->end()
-            /*  */->scalarNode('kind')->defaultValue('alsa')
+            /*  */->scalarNode('kind')->defaultValue('pulseaudio')
             /*    */->validate()->ifNotInArray(["alsa", "ao", "oss", "portaudio", "pulseaudio"])
             /*    */->thenInvalid('invalid stream.outputs.system.kind %s')
             /*  */->end()->end()

--- a/shared/libretime_shared/config/_models.py
+++ b/shared/libretime_shared/config/_models.py
@@ -226,7 +226,7 @@ class SystemOutputKind(str, Enum):
 
 class SystemOutput(BaseModel):
     enabled: bool = False
-    kind: SystemOutputKind = SystemOutputKind.ALSA
+    kind: SystemOutputKind = SystemOutputKind.PULSEAUDIO
 
 
 # pylint: disable=too-few-public-methods


### PR DESCRIPTION
BREAKING CHANGE: The default system output (`stream.outputs.system[].kind`) changed from `alsa` to `pulseaudio`. Make sure to update your configuration file if you rely on the default system output.

Closes #2542 