### PR TITLE
fix(worker): unbound variable when episode url returns HTTP 404

### DIFF
--- a/worker/libretime_worker/tasks.py
+++ b/worker/libretime_worker/tasks.py
@@ -59,6 +59,7 @@ def podcast_download(
         Status of the podcast download as JSON string.
     """
     result: Dict[str, Any] = {"episodeid": episode_id}
+    tmp_file = None
 
     try:
         # Download podcast episode file


### PR DESCRIPTION
### Description

When the episode URL return a 404, the tmp_file is never set, and we have an unbound variable exception.
