### PR TITLE
feat: disable uvicorn worker lifespan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,6 +167,7 @@ WORKDIR /app
 CMD ["/usr/local/bin/gunicorn", \
     "--workers=4", \
     "--worker-class=uvicorn.workers.UvicornWorker", \
+    "--lifespan", "off", \
     "--log-file", "-", \
     "--bind=0.0.0.0:9001", \
     "libretime_api.asgi"]

--- a/api/install/systemd/libretime-api.service
+++ b/api/install/systemd/libretime-api.service
@@ -26,6 +26,7 @@ KillMode=mixed
 ExecStart=@@VENV_DIR@@/bin/gunicorn \
         --workers 4 \
         --worker-class uvicorn.workers.UvicornWorker \
+        --lifespan off \
         --log-file - \
         --bind unix:/run/libretime-api.sock \
         libretime_api.asgi


### PR DESCRIPTION
### Description

Fix this Django exception: Django can only handle ASGI/HTTP connections, not lifespan.
