### PR TITLE
feat(installer)!: change default listen port to 8080

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,7 +79,6 @@ Vagrant.configure('2') do |config|
     LIBRETIME_POSTGRESQL_PASSWORD=libretime \
     LIBRETIME_RABBITMQ_PASSWORD=libretime \
     bash install \
-      --listen-port 8080 \
       --in-place \
       http://192.168.10.100:8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - ${LIBRETIME_CONFIG_FILEPATH:-./config.yml}:/etc/libretime/config.yml:ro
       - libretime_playout:/app
     environment:
-      LIBRETIME_GENERAL_PUBLIC_URL: http://nginx
+      LIBRETIME_GENERAL_PUBLIC_URL: http://nginx:8080
 
   liquidsoap:
     image: ghcr.io/libretime/libretime-playout:${LIBRETIME_VERSION:-latest}
@@ -48,7 +48,7 @@ services:
       - ${LIBRETIME_CONFIG_FILEPATH:-./config.yml}:/etc/libretime/config.yml:ro
       - libretime_playout:/app
     environment:
-      LIBRETIME_GENERAL_PUBLIC_URL: http://nginx
+      LIBRETIME_GENERAL_PUBLIC_URL: http://nginx:8080
 
   analyzer:
     image: ghcr.io/libretime/libretime-analyzer:${LIBRETIME_VERSION:-latest}
@@ -61,7 +61,7 @@ services:
       - ${LIBRETIME_CONFIG_FILEPATH:-./config.yml}:/etc/libretime/config.yml:ro
       - libretime_storage:/srv/libretime
     environment:
-      LIBRETIME_GENERAL_PUBLIC_URL: http://nginx
+      LIBRETIME_GENERAL_PUBLIC_URL: http://nginx:8080
 
   worker:
     image: ghcr.io/libretime/libretime-worker:${LIBRETIME_VERSION:-latest}
@@ -73,7 +73,7 @@ services:
     volumes:
       - ${LIBRETIME_CONFIG_FILEPATH:-./config.yml}:/etc/libretime/config.yml:ro
     environment:
-      LIBRETIME_GENERAL_PUBLIC_URL: http://nginx
+      LIBRETIME_GENERAL_PUBLIC_URL: http://nginx:8080
 
   api:
     image: ghcr.io/libretime/libretime-api:${LIBRETIME_VERSION:-latest}
@@ -103,7 +103,7 @@ services:
   nginx:
     image: nginx
     ports:
-      - 8080:80
+      - 8080:8080
     depends_on:
       - legacy
     volumes:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,6 +1,6 @@
 server {
-  listen 80;
-  listen [::]:80;
+  listen 8080;
+  listen [::]:8080;
 
   root /var/www/html/public;
 

--- a/docs/admin-manual/install/install-using-the-installer.md
+++ b/docs/admin-manual/install/install-using-the-installer.md
@@ -117,12 +117,12 @@ git checkout {vars.version}
 
 ## Run the installer
 
-By default the installer will configure LibreTime to listen at the port `80`, but this isn't the recommended way to install LibreTime. Instead you should configure a [reverse proxy in front of LibreTime](./reverse-proxy.md) to secure the connection using HTTPS, and route the traffic to the LibreTime server.
+By default the installer will configure LibreTime to listen at the port `8080`. We recommend that you configure a [reverse proxy in front of LibreTime](./reverse-proxy.md) to secure the connection using HTTPS, and route the traffic from the ports `80`/`443` to the LibreTime server.
 
 Install LibreTime with the following command, be sure to replace `https://libretime.example.org` with the public url of your installation:
 
 ```bash
-sudo ./install --listen-port 8080 https://libretime.example.org
+sudo ./install https://libretime.example.org
 ```
 
 :::caution
@@ -136,12 +136,12 @@ If you need to change some configuration, the install script can be configured u
 ```bash
 # Install LibreTime on your system with the following tweaks:
 # - don't install the liquidsoap package (remember to install liquidsoap yourself)
-# - set the listen port to 8080
+# - set the listen port to 8081
 # - don't run the PostgreSQL setup (remember to setup PostgreSQL yourself)
 sudo \
 LIBRETIME_PACKAGES_EXCLUDES='liquidsoap' \
 ./install \
-  --listen-port 8080 \
+  --listen-port 8081 \
   --no-setup-postgresql \
   https://libretime.example.org
 ```
@@ -150,7 +150,7 @@ You can persist the install configuration in a `.env` file next to the install s
 
 ```
 LIBRETIME_PACKAGES_EXCLUDES='liquidsoap'
-LIBRETIME_LISTEN_PORT='8080'
+LIBRETIME_LISTEN_PORT='8081'
 LIBRETIME_SETUP_POSTGRESQL=false
 LIBRETIME_PUBLIC_URL='https://libretime.example.org'
 ```

--- a/docs/admin-manual/install/reverse-proxy.md
+++ b/docs/admin-manual/install/reverse-proxy.md
@@ -36,12 +36,6 @@ flowchart LR
 
 :::warning
 
-By default, the installer configures nginx to listen on port 80, so you need to run the installer with the `--listen-port 8080` option to set the desired port.
-
-:::
-
-:::warning
-
 The current input and output streams are Icecast based protocols and doesn't support being behind a reverse proxy. **Don't attempt** to [reverse proxy Icecast](#icecast) or the Liquidsoap harbor inputs.
 
 You can [secure the Icecast output streams](#securing-the-icecast-output-streams) by adding an additional Icecast socket and reusing the TLS certificates used to secure LibreTime.
@@ -57,8 +51,6 @@ Modern protocols such as [HLS](https://en.wikipedia.org/wiki/HTTP_Live_Streaming
 In this documentation, we will use `libretime.example.org` as domain name pointing to your server, and `localhost:8080` as location for the LibreTime web server.
 
 :::
-
-If LibreTime is running on the same host as the reverse proxy, you need to change the LibreTime web server default listening port because the reverse proxy needs to listen on the `80`and `443` ports.
 
 Be sure that your firewall and network allows communications from the reverse proxy to the services. You can use `ping`, `telnet` and `curl` to check that communication is working.
 

--- a/install
+++ b/install
@@ -99,7 +99,7 @@ EOF
 # > User used to run LibreTime.
 LIBRETIME_USER=${LIBRETIME_USER:-"libretime"}
 # > Listen port for LibreTime.
-LIBRETIME_LISTEN_PORT=${LIBRETIME_LISTEN_PORT:-"80"}
+LIBRETIME_LISTEN_PORT=${LIBRETIME_LISTEN_PORT:-"8080"}
 # > Public URL for LibreTime.
 LIBRETIME_PUBLIC_URL=${LIBRETIME_PUBLIC_URL:-}
 # > Timezone for LibreTime.


### PR DESCRIPTION
Closes #2575
Closes #2543

BREAKING CHANGE: The default listen port for the installer is now `8080`. We recommend that you put a reverse proxy in front of LibreTime.

