### PR TITLE
fix(api): move gunicorn worker config to python file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,8 +166,7 @@ WORKDIR /app
 
 CMD ["/usr/local/bin/gunicorn", \
     "--workers=4", \
-    "--worker-class=uvicorn.workers.UvicornWorker", \
-    "--lifespan", "off", \
+    "--worker-class=libretime_api.gunicorn.Worker", \
     "--log-file", "-", \
     "--bind=0.0.0.0:9001", \
     "libretime_api.asgi"]

--- a/api/install/systemd/libretime-api.service
+++ b/api/install/systemd/libretime-api.service
@@ -25,8 +25,7 @@ Type=notify
 KillMode=mixed
 ExecStart=@@VENV_DIR@@/bin/gunicorn \
         --workers 4 \
-        --worker-class uvicorn.workers.UvicornWorker \
-        --lifespan off \
+        --worker-class libretime_api.gunicorn.Worker \
         --log-file - \
         --bind unix:/run/libretime-api.sock \
         libretime_api.asgi

--- a/api/libretime_api/gunicorn.py
+++ b/api/libretime_api/gunicorn.py
@@ -1,0 +1,5 @@
+from uvicorn.workers import UvicornWorker  # pylint: disable=import-error
+
+
+class Worker(UvicornWorker):
+    CONFIG_KWARGS = {"lifespan": "off"}


### PR DESCRIPTION
### Description

Passing the --lifespan flag to gunicorn does not forward the option to uvicorn.
