### PR TITLE
feat!: use nginx to serve media files

### DIFF
--- a/api/libretime_api/storage/views/file.py
+++ b/api/libretime_api/storage/views/file.py
@@ -1,7 +1,6 @@
 import os
 
-from django.conf import settings
-from django.http import FileResponse
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -21,5 +20,8 @@ class FileViewSet(viewsets.ModelViewSet):
         pk = IntegerField().to_internal_value(data=pk)
 
         file = get_object_or_404(File, pk=pk)
-        path = os.path.join(settings.CONFIG.storage.path, file.filepath)
-        return FileResponse(open(path, "rb"), content_type=file.mime)
+
+        response = HttpResponse()
+        response["Content-Type"] = file.mime
+        response["X-Accel-Redirect"] = os.path.join("/api/_media", file.filepath)
+        return response

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
       - legacy
     volumes:
       - libretime_assets:/var/www/html:ro
+      - libretime_storage:/srv/libretime:ro
       - ${NGINX_CONFIG_FILEPATH:-./nginx.conf}:/etc/nginx/conf.d/default.conf:ro
 
   icecast:

--- a/docker/config.template.yml
+++ b/docker/config.template.yml
@@ -31,7 +31,8 @@ general:
   auth: local
 
 storage:
-  # Path of the storage directory.
+  # Path of the storage directory. Make sure to update the Nginx configuration after
+  # updating the storage path.
   # > default is /srv/libretime
   path: /srv/libretime
 

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -31,7 +31,8 @@ general:
   auth: local
 
 storage:
-  # Path of the storage directory.
+  # Path of the storage directory. Make sure to update the Nginx configuration after
+  # updating the storage path.
   # > default is /srv/libretime
   path: /srv/libretime
 

--- a/docker/example/config.yml
+++ b/docker/example/config.yml
@@ -31,7 +31,8 @@ general:
   auth: local
 
 storage:
-  # Path of the storage directory.
+  # Path of the storage directory. Make sure to update the Nginx configuration after
+  # updating the storage path.
   # > default is /srv/libretime
   path: /srv/libretime
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -40,4 +40,11 @@ server {
     proxy_redirect off;
     proxy_pass http://api:9001;
   }
+
+  # Internal path for serving media files from the API.
+  location /api/_media {
+    internal;
+    # This alias path must match the 'storage.path' configuration field.
+    alias /srv/libretime;
+  }
 }

--- a/docs/admin-manual/configuration.md
+++ b/docs/admin-manual/configuration.md
@@ -72,10 +72,31 @@ The `storage` section configure the project storage.
 
 ```yml
 storage:
-  # Path of the storage directory.
+  # Path of the storage directory. Make sure to update the Nginx configuration after
+  # updating the storage path.
   # > default is /srv/libretime
   path: "/srv/libretime"
 ```
+
+:::caution
+
+After editing the `storage.path` field, make sure to update the LibreTime Nginx configuration file with the new value.
+
+In the example below, we are changing the path from `/srv/libretime` to `/mnt/data`:
+
+```patch
+  ...
+
+  # Internal path for serving media files from the API.
+  location /api/_media {
+    internal;
+    # This alias path must match the 'storage.path' configuration field.
+-   alias /srv/libretime;
++   alias /mnt/data;
+  }
+```
+
+:::
 
 ## Database
 

--- a/install
+++ b/install
@@ -750,7 +750,8 @@ template_file cp_if_different \
   "/etc/nginx/sites-available/libretime.conf" \
   sed \
   -e "s|@@LISTEN_PORT@@|${LIBRETIME_LISTEN_PORT}|g" \
-  -e "s|@@LEGACY_WEB_ROOT@@|${LEGACY_WEB_ROOT}|g"
+  -e "s|@@LEGACY_WEB_ROOT@@|${LEGACY_WEB_ROOT}|g" \
+  -e "s|@@STORAGE_DIR@@|${STORAGE_DIR}|g"
 
 info "enabling libretime nginx config"
 ln -s --force \

--- a/installer/config.yml
+++ b/installer/config.yml
@@ -31,7 +31,8 @@ general:
   auth: local
 
 storage:
-  # Path of the storage directory.
+  # Path of the storage directory. Make sure to update the Nginx configuration after
+  # updating the storage path.
   # > default is /srv/libretime
   path: /srv/libretime
 

--- a/installer/nginx/libretime.conf
+++ b/installer/nginx/libretime.conf
@@ -39,4 +39,11 @@ server {
     proxy_redirect off;
     proxy_pass http://unix:/run/libretime-api.sock;
   }
+
+  # Internal path for serving media files from the API.
+  location /api/_media {
+    internal;
+    # This alias path must match the 'storage.path' configuration field.
+    alias @@STORAGE_DIR@@;
+  }
 }


### PR DESCRIPTION
Closes #2522

To reduce the strain on the API service, we moved the media file serving to the Nginx web server. The API is still handling the authentication, but delegates the serving using the `X-Accel-Redirect` header.

BREAKING CHANGE: The media file serving is now handled by Nginx instead of the API service. The `storage.path` field is now used in the Nginx configuration, so make sure to update the Nginx configuration file if you change it.

