### PR TITLE
docs: add root override for init

### DIFF
--- a/docs/contributor-manual/development-environment.md
+++ b/docs/contributor-manual/development-environment.md
@@ -18,7 +18,7 @@ DOCKER_BUILDKIT=1 docker-compose build
 
 # Setup
 make dev-certs
-docker-compose run --rm legacy make build
+docker-compose run --user=root --rm legacy make build
 docker-compose run --rm api libretime-api migrate
 
 # Run


### PR DESCRIPTION
when following this guide, i was running inter 'permission denied' errors without adding the --user=root flag for the setup run.
