### PR TITLE
feat(legacy): add aac/opus support to dashboard player

### DIFF
--- a/legacy/application/views/scripts/dashboard/stream-player.phtml
+++ b/legacy/application/views/scripts/dashboard/stream-player.phtml
@@ -41,6 +41,8 @@
                 $serverType = $streamData["${id}_output"];
                 if ($type == "ogg")
                     $type = "oga";
+                if ($type == "aac")
+                    $type = "m4a";
                 echo "setjPlayer('$url', '$type', '$serverType');";
             }
             ?>
@@ -73,6 +75,8 @@
                     $serverType = $streamData["${id}_output"];
                     if ($type == "ogg")
                         $type = "oga";
+                    if ($type == "aac")
+                        $type = "m4a";
 
                     $label = "(" . $streamData["${id}_host"] . ") " . $streamData["${id}_description"] . " - " . $streamData["${id}_bitrate"] . " kbit/s";
                     echo sprintf("<option class='stream' value='%s' data-url='%s' data-type='%s' server-type='%s'>%s</option>", $id, $url, $type, $serverType, $label);

--- a/legacy/application/views/scripts/dashboard/stream-player.phtml
+++ b/legacy/application/views/scripts/dashboard/stream-player.phtml
@@ -39,7 +39,7 @@
                 $url = $streamData["${id}_public_url"];
                 $type = $streamData["${id}_type"];
                 $serverType = $streamData["${id}_output"];
-                if ($type == "ogg")
+                if ($type == "ogg" || $type == "opus")
                     $type = "oga";
                 if ($type == "aac")
                     $type = "m4a";
@@ -73,7 +73,7 @@
                     $url = $streamData["${id}_public_url"];
                     $type = $streamData["${id}_type"];
                     $serverType = $streamData["${id}_output"];
-                    if ($type == "ogg")
+                    if ($type == "ogg" || $type == "opus")
                         $type = "oga";
                     if ($type == "aac")
                         $type = "m4a";


### PR DESCRIPTION
### Description

The Player on the dashbaord does not correctly play an AAC stream. The rewritng logic only takes into account the ogg format. Add rewriting from aac to m4a in the javascript calls so the player works.

**This is a new feature**:

AAC output currently only works with replacing liquidsoap, so technically this is a new feature.

**I have updated the documentation to reflect these changes**:

The dashboard player is not documented. The player widget works with AAC streams already.

### Testing Notes

**What I did:**

Swapped liquidsoap and reconfigured the default mp3 stream as AAC

**How you can replicate my testing:**

on ubuntu focal, drop in the upstream liquidsoap deb to enable aac, then configure the secondary output to use 128kbit aac instead of mp3. Restart the target, login to the dashboard and open the dashboard player. Both streams from the dropdown should work.


