### PR TITLE
ci: pin docker/metadata-action to working version

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -34,6 +34,7 @@ jobs:
       # This cannot be upgraded until we develop a workaround for medata-action
       # appending cwd:// to the bake-file output. 5.5 is not compatible with
       # upload-artifact
+      # https://github.com/docker/metadata-action/issues/381
       - uses: docker/metadata-action@v5.4
         id: meta
         with:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -31,7 +31,10 @@ jobs:
           repository: libretime/libretime-${{ matrix.target }}
           readme-filepath: ./README.md
 
-      - uses: docker/metadata-action@v5
+      # This cannot be upgraded until we develop a workaround for medata-action
+      # appending cwd:// to the bake-file output. 5.5 is not compatible with
+      # upload-artifact
+      - uses: docker/metadata-action@v5.4
         id: meta
         with:
           bake-target: ${{ matrix.target }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -35,7 +35,7 @@ jobs:
       # appending cwd:// to the bake-file output. 5.5 is not compatible with
       # upload-artifact
       # https://github.com/docker/metadata-action/issues/381
-      - uses: docker/metadata-action@v5.4
+      - uses: docker/metadata-action@v5.4.0
         id: meta
         with:
           bake-target: ${{ matrix.target }}


### PR DESCRIPTION
Pin docker/metadata-action to 5.4 until https://github.com/docker/metadata-action/issues/381 is fixed