### PR TITLE
feat: playout - add internal_url parameter

### DIFF
--- a/docker/config.template.yml
+++ b/docker/config.template.yml
@@ -100,6 +100,8 @@ email:
   key_file:
 
 playout:
+  # Internal URL. If not defined, the value will use [general.public_url].
+  internal_url: ""
   # Liquidsoap connection host.
   # > default is localhost
   liquidsoap_host: liquidsoap

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -100,6 +100,8 @@ email:
   key_file:
 
 playout:
+  # Internal URL. If not defined, the value will use [general.public_url].
+  internal_url: ""
   # Liquidsoap connection host.
   # > default is localhost
   liquidsoap_host: liquidsoap

--- a/docker/example/config.yml
+++ b/docker/example/config.yml
@@ -100,6 +100,8 @@ email:
   key_file:
 
 playout:
+  # Internal URL. If not defined, the value will use [general.public_url].
+  internal_url: ""
   # Liquidsoap connection host.
   # > default is localhost
   liquidsoap_host: liquidsoap

--- a/playout/libretime_playout/main.py
+++ b/playout/libretime_playout/main.py
@@ -100,12 +100,12 @@ def cli(
     logger.info("UTC time: %s", datetime.utcnow())
 
     api_client = ApiClient(
-        base_url=config.general.public_url,
+        base_url=config.playout.internal_url or config.general.public_url,
         api_key=config.general.api_key,
     )
 
     legacy_client = LegacyClient(
-        base_url=config.general.public_url,
+        base_url=config.playout.internal_url or config.general.public_url,
         api_key=config.general.api_key,
     )
     wait_for_legacy(legacy_client)


### PR DESCRIPTION
This helps keeping **playout** and **libresoap** traffic internal, by specifying the **internal webservice** as the internal_url instead of the `public_url` (when behind a reverse proxy e.g.).

# Testing

I tested the change in an interactive Python 3.11.6 CLI. Unfortunately I wasn't able to build the containers myself successfully.