### PR TITLE
fix(analyzer): backslash non utf-8 data when probing replaygain

### DIFF
--- a/analyzer/libretime_analyzer/pipeline/_ffmpeg.py
+++ b/analyzer/libretime_analyzer/pipeline/_ffmpeg.py
@@ -36,7 +36,7 @@ def probe_replaygain(filepath: Path) -> Optional[float]:
     """
     Probe replaygain will probe the given audio file and return the replaygain if available.
     """
-    cmd = _ffprobe("-i", filepath)
+    cmd = _ffprobe("-i", filepath, errors="backslashreplace")
 
     track_gain_match = _PROBE_REPLAYGAIN_RE.search(cmd.stderr)
 


### PR DESCRIPTION
### Description

Fixes #2910
