### PR TITLE
fix(playout): fix ignored replay_gain

### DIFF
--- a/playout/libretime_playout/liquidsoap/1.4/ls_script.liq
+++ b/playout/libretime_playout/liquidsoap/1.4/ls_script.liq
@@ -41,6 +41,8 @@ def create_source()
     source_id := !source_id + 1
 end
 
+enable_replaygain_metadata()
+
 create_source()
 create_source()
 create_source()


### PR DESCRIPTION
fix [#2859](https://github.com/libretime/libretime/issues/2859)
according to doc :https://www.liquidsoap.info/doc-1.4.4/replay_gain.html
```
The replay gain metadata resolver is not enabled by default. You can do it by adding the following code to your script:
enable_replaygain_metadata()
```
## Test bug protocol
Setup and start a show
repeat until you hear a difference:
go to stream settings
set amplification to +10dB and save
restart libretime
listen volume
go to stream settings
set amplification to -10dB and save
restart libretime
listen volume difference (sometimes it require song to changed)

## Note
tested under liquidsoap 2.0 but should be the same for 1.4
 