### PR TITLE
feat: build schedule events exclusively in playout

### DIFF
--- a/legacy/application/controllers/PreferenceController.php
+++ b/legacy/application/controllers/PreferenceController.php
@@ -197,8 +197,10 @@ class PreferenceController extends Zend_Controller_Action
                 if ($changeRGenabled || $changeRGmodifier) {
                     Application_Model_Preference::SetEnableReplayGain($values['enableReplayGain']);
                     Application_Model_Preference::setReplayGainModifier($values['replayGainModifier']);
-                    $md = ['schedule' => Application_Model_Schedule::getSchedule()];
-                    Application_Model_RabbitMq::SendMessageToPypo('update_schedule', $md);
+                    // The side effects of this function are still required to fill the schedule, we
+                    // don't use the returned schedule.
+                    Application_Model_Schedule::getSchedule();
+                    Application_Model_RabbitMq::SendMessageToPypo('update_schedule', []);
                     // Application_Model_RabbitMq::PushSchedule();
                 }
 

--- a/legacy/application/controllers/plugins/RabbitMqPlugin.php
+++ b/legacy/application/controllers/plugins/RabbitMqPlugin.php
@@ -5,8 +5,10 @@ class RabbitMqPlugin extends Zend_Controller_Plugin_Abstract
     public function dispatchLoopShutdown()
     {
         if (Application_Model_RabbitMq::$doPush) {
-            $md = ['schedule' => Application_Model_Schedule::getSchedule()];
-            Application_Model_RabbitMq::SendMessageToPypo('update_schedule', $md);
+            // The side effects of this function are still required to fill the schedule, we
+            // don't use the returned schedule.
+            Application_Model_Schedule::getSchedule();
+            Application_Model_RabbitMq::SendMessageToPypo('update_schedule', []);
         }
 
         if (memory_get_peak_usage() > 30 * 2 ** 20) {

--- a/legacy/application/models/tests/populator.php
+++ b/legacy/application/models/tests/populator.php
@@ -109,6 +109,8 @@ while ($showTime < $endDate) {
 }
 
 if (Application_Model_RabbitMq::$doPush) {
-    $md = ['schedule' => Application_Model_Schedule::getSchedule()];
-    Application_Model_RabbitMq::SendMessageToPypo('update_schedule', $md);
+    // The side effects of this function are still required to fill the schedule, we
+    // don't use the returned schedule.
+    Application_Model_Schedule::getSchedule();
+    Application_Model_RabbitMq::SendMessageToPypo('update_schedule', []);
 }

--- a/playout/libretime_playout/player/fetch.py
+++ b/playout/libretime_playout/player/fetch.py
@@ -17,7 +17,7 @@ from ..liquidsoap.client import LiquidsoapClient
 from ..liquidsoap.models import Info, MessageFormatKind, StreamPreferences, StreamState
 from .events import Events, FileEvent, FileEvents
 from .liquidsoap import Liquidsoap
-from .schedule import get_schedule, receive_schedule
+from .schedule import get_schedule
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class PypoFetch(Thread):
             logger.debug("handling event %s: %s", command, message)
 
             if command == "update_schedule":
-                self.schedule_data = receive_schedule(message["schedule"]["media"])
+                self.schedule_data = get_schedule(self.api_client)
                 self.process_schedule(self.schedule_data)
             elif command == "reset_liquidsoap_bootstrap":
                 self.set_bootstrap_variables()

--- a/playout/libretime_playout/player/schedule.py
+++ b/playout/libretime_playout/player/schedule.py
@@ -15,7 +15,6 @@ from .events import (
     WebStreamEvent,
     datetime_to_event_key,
     event_isoparse,
-    parse_any_event,
 )
 
 
@@ -213,12 +212,3 @@ def generate_webstream_events(
         show_name=show["name"],
     )
     insert_event(events, schedule_end_event_key, stream_output_end_event)
-
-
-def receive_schedule(schedule: Dict[str, dict]) -> Events:
-    events: Dict[str, AnyEvent] = {}
-
-    for event_key, event in schedule.items():
-        events[event_key] = parse_any_event(event)
-
-    return events


### PR DESCRIPTION
### Description

Build and use the schedule events only in playout, the events generated by legacy are not used anymore.

This ensure that we don't have to maintain 2 different implementation in 2 different languages. We still need the php function to run to make sure the side effects of this function are executed (filling the schedule in the DB).
