### PR TITLE
fix(legacy): allow updating track types code

### DIFF
--- a/legacy/application/assets.json
+++ b/legacy/application/assets.json
@@ -87,7 +87,7 @@
   "js/airtime/showbuilder/main_builder.js": "d1ea3c3d834e47cd35c27efd75516190",
   "js/airtime/showbuilder/tabs.js": "a0b5284afde950a6f32c7e9e75550690",
   "js/airtime/status/status.js": "41456c6ed40f820e1e99215e81eb4bc4",
-  "js/airtime/tracktype/tracktype.js": "9c14bd6df3a0dabdb3b5332d6c460846",
+  "js/airtime/tracktype/tracktype.js": "1d11ec7ba6a79bc7a3cde1f167f4dc6e",
   "js/airtime/user/user.js": "28811eb65c17bc9954900daeaed6c1ad",
   "js/airtime/utilities/utilities.js": "e5d83eea1b38d2ff19bb968d30af9c98",
   "js/airtime/widgets/table-example.js": "77d448b6496adf5be0a360640cd3980c",

--- a/legacy/application/assets.json
+++ b/legacy/application/assets.json
@@ -87,7 +87,7 @@
   "js/airtime/showbuilder/main_builder.js": "d1ea3c3d834e47cd35c27efd75516190",
   "js/airtime/showbuilder/tabs.js": "a0b5284afde950a6f32c7e9e75550690",
   "js/airtime/status/status.js": "41456c6ed40f820e1e99215e81eb4bc4",
-  "js/airtime/tracktype/tracktype.js": "cca00731e212727908bec54f21d4be58",
+  "js/airtime/tracktype/tracktype.js": "9c14bd6df3a0dabdb3b5332d6c460846",
   "js/airtime/user/user.js": "28811eb65c17bc9954900daeaed6c1ad",
   "js/airtime/utilities/utilities.js": "e5d83eea1b38d2ff19bb968d30af9c98",
   "js/airtime/widgets/table-example.js": "77d448b6496adf5be0a360640cd3980c",

--- a/legacy/public/js/airtime/tracktype/tracktype.js
+++ b/legacy/public/js/airtime/tracktype/tracktype.js
@@ -15,12 +15,6 @@ function populateForm(entries) {
   $("#visibility").val(visibility_value);
 
   $("#analyze_cue_points").prop("checked", entries.analyze_cue_points);
-
-  if (entries.id.length != 0) {
-    $("#code").attr("readonly", "readonly");
-  } else {
-    $("#code").removeAttr("readonly");
-  }
 }
 
 function rowClickCallback(row_id) {
@@ -156,6 +150,7 @@ function initTracktypeData() {
     description: "",
     visibility: "1",
     id: "",
+    analyze_cue_points: true,
   };
 
   $("#add_tracktype_button").live("click", function () {

--- a/legacy/public/js/airtime/tracktype/tracktype.js
+++ b/legacy/public/js/airtime/tracktype/tracktype.js
@@ -150,7 +150,6 @@ function initTracktypeData() {
     description: "",
     visibility: "1",
     id: "",
-    analyze_cue_points: true,
   };
 
   $("#add_tracktype_button").live("click", function () {


### PR DESCRIPTION
This is a minor nag i had. Since moving to an indexed track_type model for 3.0 the constraint of the shortlabel being immutable is no longer valid, since it's not used as index any more. This commit removes the readonly flag from that form field.