### PR TITLE
feat(api): implement file deletion

### DIFF
--- a/api/libretime_api/schedule/models/schedule.py
+++ b/api/libretime_api/schedule/models/schedule.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.db import models
 
 
@@ -114,6 +116,13 @@ class Schedule(models.Model):
         if self.instance.ends_at < self.ends_at:
             return self.instance.ends_at
         return self.ends_at
+
+    @staticmethod
+    def is_file_scheduled_in_the_future(file_id):
+        count = Schedule.objects.filter(
+            file_id=file_id, ends_at__gt=datetime.now()
+        ).count()
+        return count > 0
 
     class Meta:
         managed = False

--- a/api/libretime_api/schedule/models/schedule.py
+++ b/api/libretime_api/schedule/models/schedule.py
@@ -1,6 +1,5 @@
-from datetime import datetime
-
 from django.db import models
+from django.utils.timezone import now
 
 
 class Schedule(models.Model):
@@ -120,7 +119,8 @@ class Schedule(models.Model):
     @staticmethod
     def is_file_scheduled_in_the_future(file_id):
         count = Schedule.objects.filter(
-            file_id=file_id, ends_at__gt=datetime.now()
+            file_id=file_id,
+            ends_at__gt=now(),
         ).count()
         return count > 0
 

--- a/api/libretime_api/storage/tests/views/test_file.py
+++ b/api/libretime_api/storage/tests/views/test_file.py
@@ -1,3 +1,5 @@
+import os
+
 from django.conf import settings
 from model_bakery import baker
 from rest_framework.test import APITestCase
@@ -33,3 +35,18 @@ class TestFileViewSet(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.token}")
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
+
+    def test_destroy(self):
+        path = "/api/v2/files/{id}"
+        file = baker.make(
+            "storage.File",
+            mime="audio/mp3",
+            filepath=AUDIO_FILENAME,
+        )
+        path = path.format(id=str(file.pk))
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.token}")
+        response = self.client.delete(path)
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(
+            os.path.isfile(os.path.join(settings.CONFIG.storage.path, file.filepath))
+        )

--- a/api/libretime_api/storage/tests/views/test_file.py
+++ b/api/libretime_api/storage/tests/views/test_file.py
@@ -10,30 +10,22 @@ from ...._fixtures import AUDIO_FILENAME
 class TestFileViewSet(APITestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.path = "/api/v2/files/{id}/download"
         cls.token = settings.CONFIG.general.api_key
 
-    def test_invalid(self):
-        path = self.path.format(id="a")
+    def test_download_invalid(self):
         self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.token}")
-        response = self.client.get(path)
-        self.assertEqual(response.status_code, 400)
-
-    def test_does_not_exist(self):
-        path = self.path.format(id="1")
-        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.token}")
-        response = self.client.get(path)
+        file_id = "1"
+        response = self.client.get(f"/api/v2/files/{file_id}/download")
         self.assertEqual(response.status_code, 404)
 
-    def test_exists(self):
+    def test_download(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.token}")
         file = baker.make(
             "storage.File",
             mime="audio/mp3",
             filepath=AUDIO_FILENAME,
         )
-        path = self.path.format(id=str(file.pk))
-        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.token}")
-        response = self.client.get(path)
+        response = self.client.get(f"/api/v2/files/{file.id}/download")
         self.assertEqual(response.status_code, 200)
 
     def test_destroy(self):

--- a/api/libretime_api/storage/views/file.py
+++ b/api/libretime_api/storage/views/file.py
@@ -1,5 +1,7 @@
+import logging
 import os
 
+from django.conf import settings
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.encoding import filepath_to_uri
@@ -7,8 +9,11 @@ from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.serializers import IntegerField
 
+from ...schedule.models import Schedule
 from ..models import File
 from ..serializers import FileSerializer
+
+logger = logging.getLogger(__name__)
 
 
 class FileViewSet(viewsets.ModelViewSet):
@@ -29,3 +34,24 @@ class FileViewSet(viewsets.ModelViewSet):
         redirect_uri = filepath_to_uri(os.path.join("/api/_media", file.filepath))
         response["X-Accel-Redirect"] = redirect_uri
         return response
+
+    def destroy(self, request, *args, **kwargs):  # pylint: disable=invalid-name
+        pk = kwargs.get("pk", None)
+        pk = IntegerField().to_internal_value(data=pk)
+
+        file = get_object_or_404(File, pk=pk)
+
+        # Check if the file is scheduled to be played in the future
+        if Schedule.is_file_scheduled_in_the_future(file_id=pk) is True:
+            return HttpResponse(status=409)
+
+        path = os.path.join(settings.CONFIG.storage.path, file.filepath)
+
+        try:
+            if os.path.isfile(path):
+                os.remove(path)
+        except OSError as exception:
+            logger.error("Could not delete file from storage: %s", exception)
+            return HttpResponse(status=500)
+        self.perform_destroy(file)
+        return HttpResponse(status=204)

--- a/api/libretime_api/storage/views/file.py
+++ b/api/libretime_api/storage/views/file.py
@@ -23,15 +23,12 @@ class FileViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=["GET"])
     def download(self, request, pk=None):  # pylint: disable=invalid-name
-        pk = IntegerField().to_internal_value(data=pk)
-
-        file = get_object_or_404(File, pk=pk)
+        instance: File = self.get_object()
 
         response = HttpResponse()
-
         # HTTP headers must be USASCII encoded, or Nginx might not find the file and
         # will return a 404.
-        redirect_uri = filepath_to_uri(os.path.join("/api/_media", file.filepath))
+        redirect_uri = filepath_to_uri(os.path.join("/api/_media", instance.filepath))
         response["X-Accel-Redirect"] = redirect_uri
         return response
 


### PR DESCRIPTION
Description

This adds a implementation of file delete to the Django API. Right now the code will only manipulate the database but leave the file in place.

No documentation change is needed as the API Documentation is auto-generated from the code.
Testing Notes

Playground server with new code successfully executed DELETE api call.
