### PR TITLE
fix: incorrect docker compose version

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,7 @@
 # This file is used for development. It it not intended for production!
 # See https://libretime.org/docs/developer-manual/development/environment/#docker-compose
 #
-version: "3.9"
+version: "3.8"
 
 services:
   postgres:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,7 @@
 # This file is used for development. It it not intended for production!
 # See https://libretime.org/docs/developer-manual/development/environment/#docker-compose
 #
-version: "3.8"
+version: "3.7"
 
 services:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.7"
 
 services:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.8"
 
 services:
   postgres:


### PR DESCRIPTION
### Description

There is no docker compose file version 3.9, see https://docs.docker.com/compose/compose-file/compose-versioning/. The `init` command is used in the compose file and I wonder if we can set this to 3.7. When I followed the docs here https://libretime.org/docs/admin-manual/install/install-using-docker/, I was unable to get the docker compose to work because of a version issue. So I upgraded docker (on Ubuntu focal) but realised that 3.9 isn't even mentioned on the Docker website. 3.8 is, which I tried to use but it failed. 3.7 worked for me.

**I have updated the documentation to reflect these changes**:

Docs are not affected.

### Testing Notes

**What I did:**

I was following the [docs](https://libretime.org/docs/admin-manual/install/install-using-docker/) but then rand into a docker compose file version error. I'm using docker engine version 26,

```
Client: Docker Engine - Community
 Version:           26.0.0
 API version:       1.45
 Go version:        go1.21.8
 Git commit:        2ae903e
 Built:             Wed Mar 20 15:17:51 2024
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          26.0.0
  API version:      1.45 (minimum version 1.24)
  Go version:       go1.21.8
  Git commit:       8b79278
  Built:            Wed Mar 20 15:17:51 2024
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.28
  GitCommit:        ae07eda36dd25f8a1b98dfbf587313b99c0190bb
 runc:
  Version:          1.1.12
  GitCommit:        v1.1.12-0-g51d5e94
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0

Ubuntu Version
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.6 LTS
Release:	20.04
Codename:	focal
```

which is very recent. When I checked the docker compose version [page](https://docs.docker.com/compose/compose-file/compose-versioning/),  it doesn't even list 3.9 as a version, only 3.8. For whatever reason 3.8 did not work for me, but 3.7 does.

**How you can replicate my testing:**

Follow the docs, https://libretime.org/docs/admin-manual/install/install-using-docker/. If docker compose fails to run, and says 
```
ERROR: Version in "./docker-compose.yml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
```
then change the version to 3.7.

### **Links**

N/A
