### PR TITLE
fix: remove obsolete docker compose version

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,8 +2,6 @@
 # This file is used for development. It it not intended for production!
 # See https://libretime.org/docs/developer-manual/development/environment/#docker-compose
 #
-version: "3.7"
-
 services:
   postgres:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   postgres:
     image: postgres:15


### PR DESCRIPTION
### Description

```
WARN[0000] /home/jo/code/github.com/libretime/libretime/docker-compose.yml: `version` is obsolete 
WARN[0000] /home/jo/code/github.com/libretime/libretime/docker-compose.override.yml: `version` is obsolete 
```
