### PR TITLE
fix(legacy): ensure validation is performed on the track type form

### DIFF
--- a/legacy/application/controllers/TracktypeController.php
+++ b/legacy/application/controllers/TracktypeController.php
@@ -44,7 +44,7 @@ class TracktypeController extends Zend_Controller_Action
                 $formData[$v[0]] = urldecode($v[1]);
             }
 
-            if ($form->validateCode($formData)) {
+            if ($form->isValid($formData)) {
                 $tracktype = new Application_Model_Tracktype($formData['tracktype_id']);
                 if (empty($formData['tracktype_id'])) {
                     $tracktype->setCode($formData['code']);

--- a/legacy/application/controllers/TracktypeController.php
+++ b/legacy/application/controllers/TracktypeController.php
@@ -46,9 +46,7 @@ class TracktypeController extends Zend_Controller_Action
 
             if ($form->isValid($formData)) {
                 $tracktype = new Application_Model_Tracktype($formData['tracktype_id']);
-                if (empty($formData['tracktype_id'])) {
-                    $tracktype->setCode($formData['code']);
-                }
+                $tracktype->setCode($formData['code']);
                 $tracktype->setTypeName($formData['type_name']);
                 $tracktype->setDescription($formData['description']);
                 $tracktype->setVisibility($formData['visibility']);

--- a/legacy/application/forms/AddTracktype.php
+++ b/legacy/application/forms/AddTracktype.php
@@ -28,6 +28,17 @@ class Application_Form_AddTracktype extends Zend_Form
         $code->setAttrib('style', 'width: 40%');
         $code->setRequired(true);
         $code->addValidator($notEmptyValidator);
+
+        $uniqueTrackTypeCodeValidator = new Zend_Validate_Callback(function ($value, $context) {
+            if (strlen($context['tracktype_id']) === 0) { // Only check uniqueness on create
+                return CcTracktypesQuery::create()->filterByDbCode($value)->count() === 0;
+            }
+
+            return true;
+        });
+        $uniqueTrackTypeCodeValidator->setMessage(_('Code is not unique.'));
+        $code->addValidator($uniqueTrackTypeCodeValidator);
+
         $code->addFilter('StringTrim');
         $this->addElement($code);
 
@@ -63,20 +74,5 @@ class Application_Form_AddTracktype extends Zend_Form
         $saveBtn->setIgnore(true);
         $saveBtn->setLabel(_('Save'));
         $this->addElement($saveBtn);
-    }
-
-    public function validateCode($data)
-    {
-        if (strlen($data['tracktype_id']) == 0) {
-            $count = CcTracktypesQuery::create()->filterByDbCode($data['code'])->count();
-
-            if ($count != 0) {
-                $this->getElement('code')->setErrors([_('Code is not unique.')]);
-
-                return false;
-            }
-        }
-
-        return true;
     }
 }


### PR DESCRIPTION
### Description

Fixes #2939

The zend form validation was not performed, only a custom method to validate the code was used. This merge both validation, and leverage the Zend form validation framework.

Also allow updating the track type code from the track type form. Related to #2955
