### PR TITLE
chore: mark php-cs-fixer as dev dependency

### DIFF
--- a/legacy/tools/composer.json
+++ b/legacy/tools/composer.json
@@ -1,5 +1,5 @@
 {
-  "require": {
+  "require-dev": {
     "php": "^7.4",
     "friendsofphp/php-cs-fixer": "<3.53.1"
   }


### PR DESCRIPTION
### Description

This should remove the update entries from the release-please changelog, as renovate will now consider updates for this dep as `chore` and not `fix`.
