### PR TITLE
fix: trigger legacy tasks manager every 5m

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -203,6 +203,7 @@ WORKDIR /app
 CMD ["/usr/local/bin/celery", "worker", \
     "--app=libretime_worker.tasks:worker", \
     "--config=libretime_worker.config", \
+    "--beat", \
     "--time-limit=1800", \
     "--concurrency=1", \
     "--loglevel=info"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,6 +189,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-compile -r requirements.txt
 
 COPY --from=python-builder /build/shared/*.whl .
+COPY --from=python-builder /build/api-client/*.whl .
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-compile *.whl && rm -Rf *.whl
 

--- a/api-client/libretime_api_client/v1.py
+++ b/api-client/libretime_api_client/v1.py
@@ -214,3 +214,6 @@ class ApiClient:
 
     def update_metadata_on_tunein(self):
         self._base_client.update_metadata_on_tunein()
+
+    def trigger_task_manager(self):
+        self._base_client.version()

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -3,6 +3,7 @@ all: lint test
 include ../tools/python.mk
 
 PIP_INSTALL := \
+	--editable ../api-client \
 	--editable ../shared \
 	--editable .[dev,sentry]
 PYLINT_ARG := libretime_worker

--- a/worker/install/systemd/libretime-worker.service
+++ b/worker/install/systemd/libretime-worker.service
@@ -25,6 +25,7 @@ WorkingDirectory=@@WORKING_DIR@@/worker
 ExecStart=/usr/bin/sh -c '@@VENV_DIR@@/bin/celery worker \
     --app=libretime_worker.tasks:worker \
     --config=libretime_worker.config \
+    --beat \
     --time-limit=1800 \
     --concurrency=1 \
     --loglevel=INFO \

--- a/worker/libretime_worker/config.py
+++ b/worker/libretime_worker/config.py
@@ -20,6 +20,7 @@ CELERY_RESULT_PERSISTENT = True  # Persist through a broker restart
 CELERY_TASK_RESULT_EXPIRES = 900  # Expire task results after 15 minutes
 CELERY_RESULT_EXCHANGE = "celeryresults"  # Default exchange - needed due to php-celery
 CELERY_QUEUES = (
+    Queue("celery", exchange=Exchange("celery"), routing_key="celery"),
     Queue("podcast", exchange=Exchange("podcast"), routing_key="podcast"),
     Queue(exchange=Exchange("celeryresults"), auto_delete=True),
 )


### PR DESCRIPTION
### Description

This ensures that when the LibreTime interface is not used for a long
time, we still have the task manager run essential tasks for the schedule.

Related to #2670

