### PR TITLE
fix(legacy): allow deleting file with api token

### DIFF
--- a/legacy/application/models/StoredFile.php
+++ b/legacy/application/models/StoredFile.php
@@ -396,6 +396,7 @@ SQL;
 
         // if we get here from the REST API, there's no valid user. APIKEY is validated already.
         if ($userInfo = Zend_Auth::getInstance()->getStorage()->read()) {
+            // This call will throw "Trying to get property 'id' of non-object"
             $user = new Application_Model_User($userInfo->id);
             $isAdminOrPM = $user->isUserType([UTYPE_SUPERADMIN, UTYPE_ADMIN, UTYPE_PROGRAM_MANAGER]);
             if (!$isAdminOrPM && $this->getFileOwnerId() != $user->getId()) {

--- a/legacy/application/models/StoredFile.php
+++ b/legacy/application/models/StoredFile.php
@@ -405,6 +405,8 @@ SQL;
             $file_id = $this->_file->getDbId();
             Logging::info($file_id);
             Logging::info('User ' . $user->getLogin() . ' is deleting file: ' . $this->_file->getDbTrackTitle() . ' - file id: ' . $file_id);
+        } else {
+            Logging::info('API Auth is deleting file: ' . $this->_file->getDbTrackTitle() . ' - file id: ' . $this->_file->getDbId());
         }
         $filesize = $this->_file->getFileSize();
         if ($filesize < 0) {

--- a/legacy/application/models/StoredFile.php
+++ b/legacy/application/models/StoredFile.php
@@ -394,16 +394,17 @@ SQL;
             throw new DeleteScheduledFileException();
         }
 
-        $userInfo = Zend_Auth::getInstance()->getStorage()->read();
-        $user = new Application_Model_User($userInfo->id);
-        $isAdminOrPM = $user->isUserType([UTYPE_SUPERADMIN, UTYPE_ADMIN, UTYPE_PROGRAM_MANAGER]);
-        if (!$isAdminOrPM && $this->getFileOwnerId() != $user->getId()) {
-            throw new FileNoPermissionException();
+        // if we get here from the REST API, there's no valid user. APIKEY is validated already.
+        if ($userInfo = Zend_Auth::getInstance()->getStorage()->read()) {
+            $user = new Application_Model_User($userInfo->id);
+            $isAdminOrPM = $user->isUserType([UTYPE_SUPERADMIN, UTYPE_ADMIN, UTYPE_PROGRAM_MANAGER]);
+            if (!$isAdminOrPM && $this->getFileOwnerId() != $user->getId()) {
+                throw new FileNoPermissionException();
+            }
+            $file_id = $this->_file->getDbId();
+            Logging::info($file_id);
+            Logging::info('User ' . $user->getLogin() . ' is deleting file: ' . $this->_file->getDbTrackTitle() . ' - file id: ' . $file_id);
         }
-        $file_id = $this->_file->getDbId();
-        Logging::info($file_id);
-        Logging::info('User ' . $user->getLogin() . ' is deleting file: ' . $this->_file->getDbTrackTitle() . ' - file id: ' . $file_id);
-
         $filesize = $this->_file->getFileSize();
         if ($filesize < 0) {
             throw new Exception('Cannot delete file with filesize ' . $filesize);


### PR DESCRIPTION
when calling DELETE /rest/media/<id> the call fails with 'unknown error' if it's not within a GUI session. The StoredFile delete method checks for user permissions regardless of if a user is even known. 
