### PR TITLE
fix(installer): setup the worker entrypoint

### DIFF
--- a/install
+++ b/install
@@ -683,6 +683,7 @@ install_service "libretime-analyzer.service" "$SCRIPT_DIR/analyzer/install/syste
 section "Worker"
 
 install_python_app "$SCRIPT_DIR/worker"
+link_python_app libretime-worker
 
 info "creating libretime-worker working directory"
 mkdir_and_chown "$LIBRETIME_USER" "$WORKING_DIR/worker"


### PR DESCRIPTION
Worker service fails after upgrade.

Related to #2988

