### PR TITLE
fix(worker): ensure celery beat is started

### DIFF
--- a/worker/libretime_worker/main.py
+++ b/worker/libretime_worker/main.py
@@ -16,6 +16,7 @@ def cli(log_level: str, log_filepath: Optional[Path]):
     Run celery.
     """
     args = [
+        "worker",
         f"--config={config_module}",
         "--beat",
         "--time-limit=1800",


### PR DESCRIPTION
The celery seem to ignore the first flag when `worker` is not part of the `argv`.
