### PR TITLE
test: ensure the context cleanup is executed

### DIFF
--- a/playout/tests/liquidsoap/client/conftest.py
+++ b/playout/tests/liquidsoap/client/conftest.py
@@ -119,9 +119,10 @@ def run_liq_server(
         if process.poll() is not None:
             pytest.fail(process.stdout.read())
 
-        yield manager
-
-        process.terminate()
+        try:
+            yield manager
+        finally:
+            process.terminate()
 
 
 @pytest.fixture(


### PR DESCRIPTION
See https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/contextmanager-generator-missing-cleanup.html