### PR TITLE
fix: pin pip version to <21.4 to allow installing pytz (celery)

### DIFF
--- a/install
+++ b/install
@@ -605,7 +605,7 @@ info "creating python3 venv"
 python3 -m venv "$VENV_DIR"
 
 info "upgrading python3 tools"
-$VENV_DIR/bin/pip install --upgrade pip setuptools wheel
+$VENV_DIR/bin/pip install --upgrade "pip<21.4" setuptools wheel
 
 # Install Shared and API client
 ########################################################################################


### PR DESCRIPTION
Related to https://github.com/libretime/libretime/issues/2983