### PR TITLE
fix: pin pip version to <24.1 to allow installing pytz (celery)

### DIFF
--- a/install
+++ b/install
@@ -605,7 +605,7 @@ info "creating python3 venv"
 python3 -m venv "$VENV_DIR"
 
 info "upgrading python3 tools"
-$VENV_DIR/bin/pip install --upgrade "pip<21.4" setuptools wheel
+$VENV_DIR/bin/pip install --upgrade "pip<24.1" setuptools wheel
 
 # Install Shared and API client
 ########################################################################################

--- a/tools/python.mk
+++ b/tools/python.mk
@@ -12,7 +12,7 @@ VENV = .venv
 install: $(VENV)
 $(VENV):
 	python3 -m venv $(VENV)
-	$(VENV)/bin/pip install --upgrade pip setuptools wheel
+	$(VENV)/bin/pip install --upgrade "pip<24.1" setuptools wheel
 	$(VENV)/bin/pip install --prefer-binary \
 		--requirement ../tools/python-requirements.txt \
 		$(PIP_INSTALL)


### PR DESCRIPTION
Related to https://github.com/libretime/libretime/issues/2983
