### PR TITLE
docs: add missing v4.2.0 release note

### DIFF
--- a/docs/releases/4.2.0.md
+++ b/docs/releases/4.2.0.md
@@ -1,0 +1,25 @@
+---
+title: LibreTime 4.2.0
+---
+
+import ReleaseHead from './\_release-head.md';
+
+<ReleaseHead date='2024-06-22' version='4.2.0'/>
+
+## :sparkling_heart: Contributors
+
+The LibreTime project wants to thank the following contributors for authoring PRs to this release:
+
+- @conet
+- @dakriy
+- @jooola
+- @paddatrapper
+- @rjhelms
+
+## :rocket: Features
+
+Please see the [changelog](https://github.com/libretime/libretime/blob/main/CHANGELOG.md#420-2024-06-22).
+
+## :bug: Bug fixes
+
+Please see the [changelog](https://github.com/libretime/libretime/blob/main/CHANGELOG.md#420-2024-06-22).


### PR DESCRIPTION
Forgot to prepare the release note for v4.2.0.