### PR TITLE
fix: docker warnings "keywords casing do not match"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG LIBRETIME_VERSION
 #======================================================================================#
 # Python Builder                                                                       #
 #======================================================================================#
-FROM python:3.10-slim-bullseye as python-builder
+FROM python:3.10-slim-bullseye AS python-builder
 
 WORKDIR /build
 
@@ -18,7 +18,7 @@ RUN pip wheel --wheel-dir . --no-deps .
 #======================================================================================#
 # Python base                                                                          #
 #======================================================================================#
-FROM python:3.10-slim-bullseye as python-base
+FROM python:3.10-slim-bullseye AS python-base
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -48,7 +48,7 @@ RUN set -eux \
 #======================================================================================#
 # Python base with ffmpeg                                                              #
 #======================================================================================#
-FROM python-base as python-base-ffmpeg
+FROM python-base AS python-base-ffmpeg
 
 RUN set -eux \
     && DEBIAN_FRONTEND=noninteractive apt-get update \
@@ -59,7 +59,7 @@ RUN set -eux \
 #======================================================================================#
 # Analyzer                                                                             #
 #======================================================================================#
-FROM python-base-ffmpeg as libretime-analyzer
+FROM python-base-ffmpeg AS libretime-analyzer
 
 COPY tools/packages.py /tmp/packages.py
 COPY analyzer/packages.ini /tmp/packages.ini
@@ -97,7 +97,7 @@ ENV LIBRETIME_VERSION=$LIBRETIME_VERSION
 #======================================================================================#
 # Playout                                                                              #
 #======================================================================================#
-FROM python-base-ffmpeg as libretime-playout
+FROM python-base-ffmpeg AS libretime-playout
 
 COPY tools/packages.py /tmp/packages.py
 COPY playout/packages.ini /tmp/packages.ini
@@ -136,7 +136,7 @@ ENV LIBRETIME_VERSION=$LIBRETIME_VERSION
 #======================================================================================#
 # API                                                                                  #
 #======================================================================================#
-FROM python-base as libretime-api
+FROM python-base AS libretime-api
 
 RUN set -eux \
     && DEBIAN_FRONTEND=noninteractive apt-get update \
@@ -180,7 +180,7 @@ HEALTHCHECK CMD ["curl", "--fail", "http://localhost:9001/api/v2/version"]
 #======================================================================================#
 # Worker                                                                               #
 #======================================================================================#
-FROM python-base as libretime-worker
+FROM python-base AS libretime-worker
 
 WORKDIR /src
 
@@ -208,7 +208,7 @@ ENV LIBRETIME_VERSION=$LIBRETIME_VERSION
 #======================================================================================#
 # Legacy                                                                               #
 #======================================================================================#
-FROM php:7.4-fpm as libretime-legacy
+FROM php:7.4-fpm AS libretime-legacy
 
 ENV LIBRETIME_CONFIG_FILEPATH=/etc/libretime/config.yml
 ENV LIBRETIME_LOG_FILEPATH=php://stderr


### PR DESCRIPTION
### Description

docker wants the 'AS' in uppercase if the 'FROM' is also in uppercase

### Testing Notes

These warnings are eliminated with this patch

``` => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 5)                                                                                                                                    0.1s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 21)                                                                                                                                   0.1s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 51)                                                                                                                                   0.1s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 62)
[...]
```
