### PR TITLE
ci: fix broken link check

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -62,6 +62,8 @@ jobs:
             --exclude 'https://www.ascap.com'
             --exclude 'https://www.youtube-nocookie.com'
             --exclude 'github\.com/libretime/libretime/(issues|pulls)'
+            --exclude 'https://packages.ubuntu.com/bionic/php7.2'
+            --exclude 'https://packages.ubuntu.com/bionic/python3'
             --cache
             --max-cache-age 2d
           fail: true


### PR DESCRIPTION
### Description

Ubuntu no longer maintains the package list for bionic. Linked to from old release notes