### PR TITLE
ci: downgrade django-stubs to not install v5.x

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -41,7 +41,8 @@ setup(
         ],
         "dev": [
             "django-coverage-plugin>=3.0.0,<4",
-            "django-stubs>=1.14.0,<6",
+            # Cannot upgrade to 5.x until https://github.com/typeddjango/django-stubs/issues/2304 is fixed
+            "django-stubs>=1.14.0,<5",
             "djangorestframework-stubs>=1.8.0,<4",
             "model_bakery>=1.10.1,<2",
             "psycopg[binary]>=3.1.8,<4",


### PR DESCRIPTION
### Description

This is until upstream fixes https://github.com/typeddjango/django-stubs/issues/2304