### PR TITLE
feat(legacy): order by filename when lptime is null

### DIFF
--- a/legacy/application/models/Block.php
+++ b/legacy/application/models/Block.php
@@ -1628,9 +1628,7 @@ SQL;
             $qry->addDescendingOrderByColumn('utime');
         } elseif ($sortTracks == 'oldest') {
             $qry->addAscendingOrderByColumn('utime');
-        }
-        // these sort additions are needed to override the default postgres NULL sort behavior
-        elseif ($sortTracks == 'mostrecentplay') {
+        } elseif ($sortTracks == 'mostrecentplay') {
             $qry->addAscendingOrderByColumn('lptime DESC NULLS LAST, filepath');
         } elseif ($sortTracks == 'leastrecentplay') {
             $qry->addAscendingOrderByColumn('lptime ASC NULLS FIRST, filepath');

--- a/legacy/application/models/Block.php
+++ b/legacy/application/models/Block.php
@@ -1631,9 +1631,9 @@ SQL;
         }
         // these sort additions are needed to override the default postgres NULL sort behavior
         elseif ($sortTracks == 'mostrecentplay') {
-            $qry->addDescendingOrderByColumn('(lptime IS NULL), lptime');
+            $qry->addAscendingOrderByColumn('lptime DESC NULLS LAST, filepath');
         } elseif ($sortTracks == 'leastrecentplay') {
-            $qry->addAscendingOrderByColumn('(lptime IS NOT NULL), lptime');
+            $qry->addAscendingOrderByColumn('lptime ASC NULLS FIRST, filepath');
         } elseif ($sortTracks == 'random') {
             $qry->addAscendingOrderByColumn('random()');
         } else {


### PR DESCRIPTION
### Description

It is good to have a deterministic order when doing explicit file sorting. This sorts by filename when last played time is null. I would expect filename to be the next sort after last played time in case of a tie, and was surprised to find it was not explicit. It should not break any existing use cases.

**This is a new feature**:

Kind of?

**I have updated the documentation to reflect these changes**:

I did not update any documentation as this way seems like the logical expected way to do the sort.

### Testing Notes

**What I did:**

I loaded up some tracks into a local libretime instance, let some of them play, and tested that all the old sorts worked as before as well as tracks getting sorted by filepath in case of a last played time

