### PR TITLE
feat(legacy): show filename and size on edit page and add filename datatable column

### DIFF
--- a/legacy/application/assets.json
+++ b/legacy/application/assets.json
@@ -59,7 +59,7 @@
   "js/airtime/dashboard/versiontooltip.js": "53ed1c2f7dd9527cba80bbcdb239ac88",
   "js/airtime/library/events/library_playlistbuilder.js": "7191ee58ad07b8f652be02bb131eb5e6",
   "js/airtime/library/events/library_showbuilder.js": "f3d3f65fe1e7a80cd17c228889c6a1ae",
-  "js/airtime/library/library.js": "bf61a213cf38521d1892034628faf17c",
+  "js/airtime/library/library.js": "869b3117dc2c119fac61775d78f63fa9",
   "js/airtime/library/plupload.js": "0f6be5b133650828b9ffc74e7852dc89",
   "js/airtime/library/podcast.js": "4dedd84cb571cdba2401bfb8ba621e69",
   "js/airtime/library/publish.js": "ab3a1452dd332cdb0773241a1c17b7e0",

--- a/legacy/application/controllers/LibraryController.php
+++ b/legacy/application/controllers/LibraryController.php
@@ -410,15 +410,15 @@ class LibraryController extends Zend_Controller_Action
         $size = $file->getPropelOrm()->getFileSize();
         if ($size < 1000) {
             // Use B up to 1 KB
-            $this->view->file_size = $size . " B";
+            $this->view->file_size = $size . ' B';
         } elseif ($size < (500 * 1000)) {
             // Use KB up to 500 KB
-            $this->view->file_size = round($size / 1000, 1) . " KB";
+            $this->view->file_size = round($size / 1000, 1) . ' KB';
         } elseif ($size < (1 * 1000 * 1000 * 1000)) {
             // Use MB up to 1 GB
-            $this->view->file_size = round($size / 1000 / 1000, 1) . " MB";
+            $this->view->file_size = round($size / 1000 / 1000, 1) . ' MB';
         } else {
-            $this->view->file_size = round($size / 1000 / 1000 / 1000, 1) . " GB";
+            $this->view->file_size = round($size / 1000 / 1000 / 1000, 1) . ' GB';
         }
         $this->view->html = $this->view->render('library/edit-file-md.phtml');
     }

--- a/legacy/application/controllers/LibraryController.php
+++ b/legacy/application/controllers/LibraryController.php
@@ -398,7 +398,6 @@ class LibraryController extends Zend_Controller_Action
         $this->view->id = $file_id;
         $this->view->title = $file->getPropelOrm()->getDbTrackTitle();
         $this->view->artist_name = $file->getPropelOrm()->getDbArtistName();
-        $this->view->file_path = $file->getPropelOrm()->getDbFilepath();
         $this->view->artwork = $file->getPropelOrm()->getDbArtwork();
         $this->view->replay_gain = $file->getPropelOrm()->getDbReplayGain();
         $this->view->cuein = $file->getPropelOrm()->getDbCuein();
@@ -406,6 +405,14 @@ class LibraryController extends Zend_Controller_Action
         $this->view->format = $file->getPropelOrm()->getDbFormat();
         $this->view->bit_rate = $file->getPropelOrm()->getDbBitRate();
         $this->view->sample_rate = $file->getPropelOrm()->getDbSampleRate();
+        $filePath = $file->getPropelOrm()->getDbFilepath();
+        if ($isAdmin) {
+            $this->view->file_name = $filePath;
+        } else {
+            $fileParts = explode(DIRECTORY_SEPARATOR, $filePath);
+            $filename = end($fileParts);
+            $this->view->file_name = $filename;
+        }
         // 1000 B in KB and 1000 KB in MB and 1000 MB in GB
         $size = $file->getPropelOrm()->getFileSize();
         if ($size < 1000) {

--- a/legacy/application/controllers/LibraryController.php
+++ b/legacy/application/controllers/LibraryController.php
@@ -398,7 +398,7 @@ class LibraryController extends Zend_Controller_Action
         $this->view->id = $file_id;
         $this->view->title = $file->getPropelOrm()->getDbTrackTitle();
         $this->view->artist_name = $file->getPropelOrm()->getDbArtistName();
-        $this->view->filePath = $file->getPropelOrm()->getDbFilepath();
+        $this->view->file_path = $file->getPropelOrm()->getDbFilepath();
         $this->view->artwork = $file->getPropelOrm()->getDbArtwork();
         $this->view->replay_gain = $file->getPropelOrm()->getDbReplayGain();
         $this->view->cuein = $file->getPropelOrm()->getDbCuein();
@@ -406,6 +406,20 @@ class LibraryController extends Zend_Controller_Action
         $this->view->format = $file->getPropelOrm()->getDbFormat();
         $this->view->bit_rate = $file->getPropelOrm()->getDbBitRate();
         $this->view->sample_rate = $file->getPropelOrm()->getDbSampleRate();
+        // 1000 B in KB and 1000 KB in MB and 1000 MB in GB
+        $size = $file->getPropelOrm()->getFileSize();
+        if ($size < 1000) {
+            // Use B up to 1 KB
+            $this->view->file_size = $size . " B";
+        } elseif ($size < (500 * 1000)) {
+            // Use KB up to 500 KB
+            $this->view->file_size = round($size / 1000, 1) . " KB";
+        } elseif ($size < (1 * 1000 * 1000 * 1000)) {
+            // Use MB up to 1 GB
+            $this->view->file_size = round($size / 1000 / 1000, 1) . " MB";
+        } else {
+            $this->view->file_size = round($size / 1000 / 1000 / 1000, 1) . " GB";
+        }
         $this->view->html = $this->view->render('library/edit-file-md.phtml');
     }
 

--- a/legacy/application/models/StoredFile.php
+++ b/legacy/application/models/StoredFile.php
@@ -750,7 +750,7 @@ SQL;
             } elseif ($key === 'filepath') {
                 $plSelect[] = 'NULL::VARCHAR AS ' . $key;
                 $blSelect[] = 'NULL::VARCHAR AS ' . $key;
-                $fileSelect[] = $key;
+                $fileSelect[] = "split_part($key, '/', -1) as $key";
                 $streamSelect[] = 'url AS ' . $key;
             } elseif ($key == 'mime') {
                 $plSelect[] = 'NULL::VARCHAR AS ' . $key;

--- a/legacy/application/models/StoredFile.php
+++ b/legacy/application/models/StoredFile.php
@@ -750,7 +750,7 @@ SQL;
             } elseif ($key === 'filepath') {
                 $plSelect[] = 'NULL::VARCHAR AS ' . $key;
                 $blSelect[] = 'NULL::VARCHAR AS ' . $key;
-                $fileSelect[] = "split_part($key, '/', -1) as $key";
+                $fileSelect[] = "split_part({$key}, '/', -1) as {$key}";
                 $streamSelect[] = 'url AS ' . $key;
             } elseif ($key == 'mime') {
                 $plSelect[] = 'NULL::VARCHAR AS ' . $key;

--- a/legacy/application/views/scripts/library/edit-file-md.phtml
+++ b/legacy/application/views/scripts/library/edit-file-md.phtml
@@ -18,7 +18,7 @@ $baseUrl = Config::getBasePath();
             <div class="inner_track_editor_title" style="width: 100%;">
                 <h2 style="line-height: 26px !important;"><span class="title_obj_name"><?php echo ($this->title); ?></span></h2>
                 <h3 style="line-height: 2px !important;"><span class=""><?php echo ($this->artist_name); ?></span></h3>
-                <h5 style="line-height: 26px !important;"><span class=""><?php $array = explode(DIRECTORY_SEPARATOR, $this->file_path); echo (end($array) . " (" . $this->file_size . ")"); ?></span></h5>
+                <h5 style="line-height: 26px !important;"><span class=""><?php echo ($this->file_name) . " (" . $this->file_size . ")"; ?></span></h5>
             </div>
         </div>
     </div>

--- a/legacy/application/views/scripts/library/edit-file-md.phtml
+++ b/legacy/application/views/scripts/library/edit-file-md.phtml
@@ -18,6 +18,7 @@ $baseUrl = Config::getBasePath();
             <div class="inner_track_editor_title" style="width: 100%;">
                 <h2 style="line-height: 26px !important;"><span class="title_obj_name"><?php echo ($this->title); ?></span></h2>
                 <h3 style="line-height: 2px !important;"><span class=""><?php echo ($this->artist_name); ?></span></h3>
+                <h6 style="line-height: 26px !important;"><span class=""><?php $array = explode('/', $this->filePath); echo (end($array)); ?></span></h6>
             </div>
         </div>
     </div>

--- a/legacy/application/views/scripts/library/edit-file-md.phtml
+++ b/legacy/application/views/scripts/library/edit-file-md.phtml
@@ -18,7 +18,7 @@ $baseUrl = Config::getBasePath();
             <div class="inner_track_editor_title" style="width: 100%;">
                 <h2 style="line-height: 26px !important;"><span class="title_obj_name"><?php echo ($this->title); ?></span></h2>
                 <h3 style="line-height: 2px !important;"><span class=""><?php echo ($this->artist_name); ?></span></h3>
-                <h6 style="line-height: 26px !important;"><span class=""><?php $array = explode('/', $this->filePath); echo (end($array)); ?></span></h6>
+                <h5 style="line-height: 26px !important;"><span class=""><?php $array = explode(DIRECTORY_SEPARATOR, $this->file_path); echo (end($array) . " (" . $this->file_size . ")"); ?></span></h5>
             </div>
         </div>
     </div>

--- a/legacy/public/js/airtime/library/library.js
+++ b/legacy/public/js/airtime/library/library.js
@@ -55,6 +55,7 @@ var AIRTIME = (function (AIRTIME) {
     replay_gain: "n",
     artwork: "s",
     track_type_id: "tt",
+    filepath: "s",
   };
 
   if (AIRTIME.library === undefined) {
@@ -843,6 +844,13 @@ var AIRTIME = (function (AIRTIME) {
         sClass: "library_year",
         sWidth: "60px",
       },
+      /* File Name */ {
+        sTitle: $.i18n._("File Name"),
+        mDataProp: "filepath",
+        bVisible: false,
+        sClass: "library_file",
+        sWidth: "170px",
+      },
     ];
 
     if (onDashboard) {
@@ -858,7 +866,7 @@ var AIRTIME = (function (AIRTIME) {
       );
     }
 
-    var colExclude = onDashboard ? [0, 1, 2, 3, 34] : [0, 1, 2];
+    var colExclude = onDashboard ? [0, 1, 2, 3, 35] : [0, 1, 2];
 
     /*  ############################################
                             DATATABLES


### PR DESCRIPTION
### Description

Add File Name and Size to the metadata editor screen, and added a File Name column to the tracks data table.

**This is a new feature**:

Yes

**I have updated the documentation to reflect these changes**:

No, just some simple UI additions so no documentation needed.

### Testing Notes

**What I did:**

I uploaded some tracks, clicked on edit, and saw that the filename and size showed up at the top. I also went out to the tracks view and added the File Name column and saw that the filename displayed properly.

**How you can replicate my testing:**

Do what I did

### **Links**

Fixes #3053
