### PR TITLE
chore: add pre-commit API check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,3 +110,11 @@ repos:
         pass_filenames: false
         language: script
         files: ^legacy
+
+      - id: api-schema-update
+        name: api-schema-update
+        description: Ensure API schema is up to date
+        entry: make -C api schema
+        pass_filenames: false
+        language: script
+        files: ^api

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,5 +116,5 @@ repos:
         description: Ensure API schema is up to date
         entry: make -C api schema
         pass_filenames: false
-        language: script
+        language: system
         files: ^api


### PR DESCRIPTION
### Description

This is a way of ensuring the schema is up to date with every change. This should be extended by fixing the PR api schema pipeline to squash down all PR commits into a single change and checking the API schema for that. Otherwise people will fix the schema after a failed pipeline and the pipeline will continue to fail