### PR TITLE
fix(legacy): migrations from airtime 2.5.1

### DIFF
--- a/api/libretime_api/legacy/migrations/0006_2_5_5.py
+++ b/api/libretime_api/legacy/migrations/0006_2_5_5.py
@@ -8,8 +8,6 @@ UP = """
 -- DELETE FROM cc_pref WHERE keystr = 'system_version';
 -- INSERT INTO cc_pref (keystr, valstr) VALUES ('system_version', '2.5.5');
 
-ALTER TABLE cc_show ADD COLUMN image_path varchar(255) DEFAULT '';
-ALTER TABLE cc_show_instances ADD COLUMN description varchar(255) DEFAULT '';
 """
 
 DOWN = None

--- a/api/libretime_api/legacy/migrations/0015_2_5_17.py
+++ b/api/libretime_api/legacy/migrations/0015_2_5_17.py
@@ -5,7 +5,7 @@ from django.db import migrations
 from ._migrations import legacy_migration_factory
 
 UP = """
-ALTER TABLE cc_files ADD COLUMN artwork TYPE character varying(255);
+ALTER TABLE cc_files ADD COLUMN artwork VARCHAR(255);
 """
 
 DOWN = None

--- a/api/libretime_api/legacy/migrations/0023_3_0_0_alpha_9_1.py
+++ b/api/libretime_api/legacy/migrations/0023_3_0_0_alpha_9_1.py
@@ -4,6 +4,10 @@ from django.db import migrations
 
 from ._migrations import legacy_migration_factory
 
+"""
+This migration is currently an empty placeholder for 3.0.0-alpha.9.1.  Please do not remove it.  There are
+currently no actions, but it needs to remain intact because of the incremental nature of the migrations.
+"""
 UP = """
 
 """

--- a/api/libretime_api/legacy/migrations/0023_3_0_0_alpha_9_1.py
+++ b/api/libretime_api/legacy/migrations/0023_3_0_0_alpha_9_1.py
@@ -4,10 +4,12 @@ from django.db import migrations
 
 from ._migrations import legacy_migration_factory
 
-"""
-This migration is currently an empty placeholder for 3.0.0-alpha.9.1.  Please do not remove it.  There are
-currently no actions, but it needs to remain intact because of the incremental nature of the migrations.
-"""
+# This migration is currently a placeholder for 3.0.0-alpha.9.1.
+# Please do not remove it.  There are currently no actions, but it
+# needs to remain intact so it does not fail when called from the
+# migrations script. Any future migrations that may apply to
+# 3.0.0-alpha.9.1 will be added to this file.
+
 UP = """
 
 """

--- a/api/libretime_api/legacy/migrations/0023_3_0_0_alpha_9_1.py
+++ b/api/libretime_api/legacy/migrations/0023_3_0_0_alpha_9_1.py
@@ -5,11 +5,11 @@ from django.db import migrations
 from ._migrations import legacy_migration_factory
 
 UP = """
-ALTER TABLE cc_files ADD COLUMN artwork VARCHAR(4096);
+
 """
 
 DOWN = """
-ALTER TABLE cc_files DROP COLUMN IF EXISTS artwork;
+
 """
 
 

--- a/api/libretime_api/legacy/migrations/_migrations.py
+++ b/api/libretime_api/legacy/migrations/_migrations.py
@@ -19,8 +19,17 @@ def get_schema_version():
     with connection.cursor() as cursor:
         cursor.execute("SELECT valstr FROM cc_pref WHERE keystr = 'schema_version'")
         row = cursor.fetchone()
-        return row[0] if row else None
+        if row: return row[0]
 
+        # Check to see if this is an airtime 2.5.1 migration which will not return a schema_version
+        # We look for system_version to have a value of 2.5.1
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT valstr FROM cc_pref WHERE keystr = 'system_version'")
+            row = cursor.fetchone()
+            if row and row[0] == '2.5.1':
+                return '0'  # A low schema version that is not None
+
+        return None
 
 def set_schema_version(cursor, version: str):
     cursor.execute(

--- a/api/libretime_api/legacy/migrations/_migrations.py
+++ b/api/libretime_api/legacy/migrations/_migrations.py
@@ -14,7 +14,8 @@ def get_schema_version():
 
     An airtime 2.5.1 migration will not have schema_version, in that case, we look for
     system_version to have a value of 2.5.1 and return that as the schema version value
-    (really just needs to be anything besides None, so that the next migration doesn't overwrite the database)
+    (really just needs to be anything besides None, so that the next migration doesn't overwrite
+    the database)
     """
 
     if "cc_pref" not in connection.introspection.table_names():


### PR DESCRIPTION
### Description

This fixes various problems in legacy migrations that were preventing a successful database migration from Airtime 2.5.1.  Previously, following [the procedure](https://libretime.org/docs/admin-manual/install/migrate-from-airtime/) using the migrations provided in the Libretime 4.2.0 installer, without the fixes in this PR, would either fail completely, or cause all of the imported data to be completely deleted. 


_migrations.py
If schema_version is not found in the table cc_prefs, it then checks for system_version to have a value of '2.5.1' (in case this is an airtime 2.5.1 migration which will not have any schema_version in cc_pref).  If found, it prevents loading of the schema file, which is critical to preserving the imported Airtime data.

0006_2_5_5
Removed a redundant addition of the image_path and description columns to cc_show (done in earlier migration 003_2_5_2)

0015_2_5_17
Fixed a syntax error with adding the artwork column to cc_files

0023_3_0_0_alpha_9_1
Removed a redundant addition of the artwork column to cc_files (done in earlier migration 0015_2_5_7)

### Documentation Changes

The [airtime migration documentation](https://libretime.org/docs/admin-manual/install/migrate-from-airtime/) already suggests a procedure to be followed, it just didn't work because of problems within these migrations.  The procedure as documented should now work for  those coming from Airtime 2.5.1.

### Testing Notes

**What I did:**

I attempted to migrate an actual airtime 2.5.1 database from a production system containing a large amount of shows, tracks, and users.  I observed that the migration completed without errors, and that the expected system state was achieved within Libretime. Specifically, the calendar, library, authentication, and other aspects are populated with the data that was present in the migrated Airtime database, and Libretime is able to function using this data.

**How you can replicate my testing:**

Install Libretime 4.2.0.  Restore a sample postrgresql database backup from an Airtime 2.5.1 server.  Apply the database migration.  Restart the services.  Login and view the library, calender, etc.

### **Links**

Closes: #3121  
May also be related to, or even close (as a duplicate): #2563
