### PR TITLE
feat(api): added filters on genre & md5 for files api

### DIFF
--- a/api/libretime_api/storage/tests/views/test_file.py
+++ b/api/libretime_api/storage/tests/views/test_file.py
@@ -94,15 +94,3 @@ class TestFileViewSet(APITestCase):
         path = "/api/v2/files?genre=R%26B"
         results = self.client.get(path).json()
         self.assertEqual(len(results), 1)
-
-        path = "/api/v2/files?limit=1"
-        results = self.client.get(path).json()
-        self.assertEqual(len(results["results"]), 1)
-
-        path = f"/api/v2/files?md5={file.md5}"
-        results = self.client.get(path).json()
-        self.assertEqual(len(results), 1)
-
-        path = "/api/v2/files?genre=Soul"
-        results = self.client.get(path).json()
-        self.assertEqual(len(results), 1)

--- a/api/libretime_api/storage/views/file.py
+++ b/api/libretime_api/storage/views/file.py
@@ -38,8 +38,7 @@ class FileViewSet(viewsets.ModelViewSet):
         response = HttpResponse()
         # HTTP headers must be USASCII encoded, or Nginx might not find the file and
         # will return a 404.
-        redirect_uri = filepath_to_uri(
-            os.path.join("/api/_media", instance.filepath))
+        redirect_uri = filepath_to_uri(os.path.join("/api/_media", instance.filepath))
         response["X-Accel-Redirect"] = redirect_uri
         return response
 
@@ -49,19 +48,15 @@ class FileViewSet(viewsets.ModelViewSet):
 
         try:
             if instance.filepath is None:
-                logger.warning(
-                    "file does not have a filepath: %d", instance.id)
+                logger.warning("file does not have a filepath: %d", instance.id)
                 return
 
-            path = os.path.join(
-                settings.CONFIG.storage.path, instance.filepath)
+            path = os.path.join(settings.CONFIG.storage.path, instance.filepath)
 
             if not os.path.isfile(path):
-                logger.warning(
-                    "file does not exist in storage: %d", instance.id)
+                logger.warning("file does not exist in storage: %d", instance.id)
                 return
 
             remove(path)
         except OSError as exception:
-            raise APIException(
-                "could not delete file from storage") from exception
+            raise APIException("could not delete file from storage") from exception

--- a/api/schema.yml
+++ b/api/schema.yml
@@ -154,6 +154,15 @@ paths:
   /api/v2/files:
     get:
       operationId: files_list
+      parameters:
+        - in: query
+          name: genre
+          schema:
+            type: string
+        - in: query
+          name: md5
+          schema:
+            type: string
       tags:
         - files
       security:


### PR DESCRIPTION
### Description
Added filters for genre and md5 to the files API, e.g. `/api/v2/files?genre=soul`

**This is a new feature**: Yes

**I have updated the documentation to reflect these changes**: No
There should be a schema and docs that are generated automatically. I don't know where that is.


### Testing Notes

**What I did:**
- Used docker to deploy locally
- Confirmed filters work at http://localhost:8080/api/v2/files?genre=Soul

**How you can replicate my testing:**
- `make clean dev`
- Upload some files!
- Visit http://localhost:8080/api/v2/files
- You can use the filters
<img width="658" alt="Screenshot 2024-12-23 at 01 36 01" src="https://github.com/user-attachments/assets/ba19f7f3-fb3e-495d-8937-d451c70d326c" />
<img width="652" alt="Screenshot 2024-12-23 at 01 35 56" src="https://github.com/user-attachments/assets/c7191131-a963-463a-b52f-9d0952192555" />

_How can the reviewer validate this PR?_
- See above
- wrote tests to confirm filters work
