### PR TITLE
feat: add flac support to Web player

### DIFF
--- a/legacy/application/assets.json
+++ b/legacy/application/assets.json
@@ -49,7 +49,7 @@
   "css/users.css": "94c94817a8505ff4dfcd090987859a7e",
   "css/waveform.css": "4ce429708933e6da1a2f3bdb2a01db52",
   "js/airtime/airtime_bootstrap.js": "9575982385f6c74e2b4ec61e30214a7c",
-  "js/airtime/audiopreview/preview_jplayer.js": "133b4b9a3436716a8367d353f1658da3",
+  "js/airtime/audiopreview/preview_jplayer.js": "d3402345279a9f4b86b381bae87d6de8",
   "js/airtime/buttons/buttons.js": "1a984b1e01262816c899c5fa3f12e3cd",
   "js/airtime/common/audioplaytest.js": "93737dabc4cce4fcdcc6d54acf86d16d",
   "js/airtime/common/common.js": "8c0675f5a1c8d95323b2f3983c658f62",

--- a/legacy/public/js/airtime/audiopreview/preview_jplayer.js
+++ b/legacy/public/js/airtime/audiopreview/preview_jplayer.js
@@ -255,7 +255,6 @@ function playOne(uri, mime) {
     key = "flac";
   }
 
-
   if (key) {
     media = {
       title:

--- a/legacy/public/js/airtime/audiopreview/preview_jplayer.js
+++ b/legacy/public/js/airtime/audiopreview/preview_jplayer.js
@@ -27,7 +27,7 @@ $(document).ready(function () {
     [], //array of songs will be filled with below's json call
     {
       swfPath: baseUrl + "js/jplayer",
-      supplied: "oga, mp3, m4v, m4a, wav",
+      supplied: "oga, mp3, m4v, m4a, wav, flac",
       size: {
         width: "0px",
         height: "0px",
@@ -161,6 +161,12 @@ function buildplaylist(p_url, p_playIndex) {
             artist: data[index]["element_artist"],
             wav: data[index]["uri"],
           };
+        } else if (data[index]["element_flac"] != undefined) {
+          media = {
+            title: data[index]["element_title"],
+            artist: data[index]["element_artist"],
+            flac: data[index]["uri"],
+          };
         } else {
           // skip this track since it's not supported
           console.log("continue");
@@ -177,6 +183,8 @@ function buildplaylist(p_url, p_playIndex) {
           key = "m4a";
         } else if (mime.search(/wav/i) > 0) {
           key = "wav";
+        } else if (mime.search(/flac/i) > 0) {
+          key = "flac";
         }
 
         if (key) {
@@ -243,7 +251,10 @@ function playOne(uri, mime) {
     key = "m4a";
   } else if (mime.search(/wav/i) > 0) {
     key = "wav";
+  } else if (mime.search(/flac/i) > 0) {
+    key = "flac";
   }
+
 
   if (key) {
     media = {


### PR DESCRIPTION


### Description

Added support for previewing FLAC files in the web interface, provided in #509 by marmotte32 on Github in the comments for this issue.

I have tested this against a script-installed copy of 4.2.0, and FLAC preview is working, although auto-play isn't.  I haven't tested to confirm if this behavior matches MP3 and OGG uploads.

**This is a new feature**:

_Do the changes in this PR implement a new feature?_

**I have updated the documentation to reflect these changes**:

No changes needed; this bug is a missing file format in preview, and it requires no updates to the documentation.

### Testing Notes

**What I did:**

I installed a LibreTime 4.2.0 system using the default installation script against a fully-updated, brand new Debian 11 system.  I logged into the web interface, uploaded some FLAC files, and attempted to preview them.  They failed to preview.

I then replaced the preview_jplayer.js file with the contents in this PR and then refreshed the page.  I was able to preview the FLAC files and hear the results in my local browser audio output.

**How you can replicate my testing:**

Perform the same steps above, or replace the same file in the libretime_legacy_1 docker image to see the same results.

### **Links**

Closes: #509 