### PR TITLE
ci: only check last commit for API schema in PRs

### DIFF
--- a/.github/workflows/api-schema.yml
+++ b/.github/workflows/api-schema.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get pull request commit range
         if: github.event_name == 'pull_request'
-        run: echo "COMMIT_RANGE=origin/${{ github.base_ref }}..${{ github.sha }}" >> $GITHUB_ENV
+        run: echo "COMMIT_RANGE=${{ github.sha }}~1...${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Get push commit range
         if: github.event_name == 'push'


### PR DESCRIPTION
### Description

PRs are intended to be squashed to a single commit. Only checking the last commit gives us the intended state of the repo and ensures that if the author commits the schema fixes later, the CI passes as expected. Currently, the CI will fail because the earlier commits still have an out of date schema.