### PR TITLE
fix(playout): improve the way hashlib is called in libretime_playout/player

### DIFF
--- a/playout/libretime_playout/player/file.py
+++ b/playout/libretime_playout/player/file.py
@@ -86,7 +86,7 @@ class PypoFile(Thread):
             file_size = os.path.getsize(file_path)
 
             with open(file_path, "rb") as file_fd:
-                hasher = hashlib.md5(usedforsecurity=False)
+                hasher = hashlib.new("md5", usedforsecurity=False)
                 while True:
                     data = file_fd.read(8192)
                     if not data:


### PR DESCRIPTION
### Description

Improves the way hashlib is called in libretime_playout/player so that  is isn't broken on systems with python < 3.9 

The way it is currently called in site-packages/libretime_playout/player/file.py, in the section where scheduled files are copied to the cache dir for playout, specifies the usedforsecurity=False flag as follows:
`hasher = hashlib.md5(usedforsecurity=False)`

hashlib.md5 did not support this flag until Python 3.9.  Attempting to specify the flag directly as an argument to hashlib.md5(), in an older python environment (such as that in Ubuntu Focal 20.04), is unsafe, and can cause hashlib.md5() to balk/throw an exception, which results in file copy operations failing.  This then precipitates into playout problems, as scheduled media is missing from the cache folder.


This PR instead calls using hashlib.new(), and passes the argument to that, as follows:
`hasher = hashlib.new('md5', usedforsecurity=False)`

This method of calling with the flag argument is safer, because the constructor will take it or leave it gracefully, regardless of whether the system has a version of hashlib that supports the `usedforsecurity` flag.  AFAICT, it improves (fixes) function on older systems without negatively impacting others.

### Testing Notes

**What I did:**
Before applying this patch, we were experiencing occasional but fairly regular periods of silence when the system was supposed to be playing a song or track. This behavior was consistent with errors such as the following being present in the playout log:
```
2025-01-15 14:01:28,331 | INFO     | libretime_playout.player.file:copy_file:47 - copying file 19834 to cache /var/lib/libretime/playout/scheduler/19834.mp3
2025-01-15 14:01:28,466 | ERROR    | libretime_playout.player.file:copy_file:77 - could not copy file 19834 to /var/lib/libretime/playout/scheduler/19834.mp3: 'usedforsecurity' is an invalid keyword argument for openssl_md5()
Traceback (most recent call last):
  File "/opt/libretime/lib/python3.8/site-packages/libretime_playout/player/file.py", line 70, in copy_file
    file_event.filesize = self.report_file_size_and_md5_to_api(
  File "/opt/libretime/lib/python3.8/site-packages/libretime_playout/player/file.py", line 89, in report_file_size_and_md5_to_api
    hasher = hashlib.md5(usedforsecurity=False)
TypeError: 'usedforsecurity' is an invalid keyword argument for openssl_md5()
```
_For more information about the characterization and results of this problem, see issue #3134_ 

**Testing on running systems**
After the patch was applied, these errors were no longer seen.  I first tested this on a dev server, and then on a live server, with approximately 100 distinct tracks of playout occurring over about 24 hours. There were no file copy failures, and no related playout problems, which was a major and immediate improvement.  

**Testing installer, fresh installs**
***Ubuntu 20.04***
I deployed a patch to the installer and installed it on a blank system running Ubuntu 20.04 and tested it to make sure the fix was applied and worked.

***Debian 11***
I deployed patch to the installer and installed it on a blank system running Debian Bullseye (which runs python = 3.9) , and tested it there to make sure it did not break anything or introduce a regression.


### **Links**

Closes: #3134 