### PR TITLE
feat: include nginx config inside libretime-nginx container

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,2 @@
 LIBRETIME_VERSION=main
 LIBRETIME_CONFIG_FILEPATH=./dev/config.yml
-NGINX_CONFIG_FILEPATH=./docker/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -284,6 +284,8 @@ ENV LIBRETIME_VERSION=$LIBRETIME_VERSION
 #======================================================================================#
 FROM nginx AS libretime-nginx
 
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+
 COPY --from=libretime-legacy /var/www/html /var/www/html
 
 ARG LIBRETIME_VERSION

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -72,6 +72,7 @@ services:
       target: libretime-nginx
     volumes:
       - ./legacy:/var/www/html
+      - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf:ro
 
   icecast:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,6 @@ services:
       - legacy
     volumes:
       - libretime_storage:/srv/libretime:ro
-      - ${NGINX_CONFIG_FILEPATH:-./nginx.conf}:/etc/nginx/conf.d/default.conf:ro
 
   icecast:
     image: ghcr.io/libretime/icecast:2.4.4

--- a/docs/admin-manual/install/install-using-docker.mdx
+++ b/docs/admin-manual/install/install-using-docker.mdx
@@ -28,7 +28,6 @@ Download the docker compose files from the repository:
 source .env
 
 wget "https://raw.githubusercontent.com/libretime/libretime/$LIBRETIME_VERSION/docker-compose.yml"
-wget "https://raw.githubusercontent.com/libretime/libretime/$LIBRETIME_VERSION/docker/nginx.conf"
 wget "https://raw.githubusercontent.com/libretime/libretime/$LIBRETIME_VERSION/docker/config.template.yml"
 ```
 


### PR DESCRIPTION
### Description

- Removes the need to download the nginx config file during the install,
- Can be overridden by mounting your own config file.


**This is a new feature**:

Reduce the amount of steps and files to install LibreTime using docker-compose.

**I have updated the documentation to reflect these changes**:

Yes

### Testing Notes

**What I did:**

Do not mount the `./docker/nginx.conf` file in `docker-compose.override.yml` and run:

```
make dev
```

### **Links**

Related to #3155

