### PR TITLE
feat: use fanout queue type for playout queue

### DIFF
--- a/legacy/application/models/RabbitMq.php
+++ b/legacy/application/models/RabbitMq.php
@@ -57,7 +57,7 @@ class Application_Model_RabbitMq
 
         $exchange = 'airtime-pypo';
         $data = json_encode($md, JSON_FORCE_OBJECT);
-        self::sendMessage($exchange, 'direct', true, $data);
+        self::sendMessage($exchange, 'fanout', true, $data);
     }
 
     public static function SendMessageToMediaMonitor($event_type, $md)
@@ -88,7 +88,7 @@ class Application_Model_RabbitMq
         }
         $data = json_encode($temp);
 
-        self::sendMessage($exchange, 'direct', true, $data);
+        self::sendMessage($exchange, 'fanout', true, $data);
     }
 
     public static function SendMessageToAnalyzer(


### PR DESCRIPTION
### Description

Currently, only one service can listen to libretime schedule change events. This change allows for as many services as desired to listen for schedule change events.

**This is a new feature**:

Yes

**I have updated the documentation to reflect these changes**:

No, as this seems like the obvious default

### Testing Notes

**What I did:**

I created 2 playout blocks, connected them both to the fanout queue and saw that they could all connect and receive schedule change events at the same time.

**How you can replicate my testing:**

See testing notes
