### PR TITLE
fix(playout): invalid input source disconnect command send to liquidsoap

### DIFF
--- a/playout/libretime_playout/liquidsoap/client/_client.py
+++ b/playout/libretime_playout/liquidsoap/client/_client.py
@@ -100,14 +100,6 @@ class LiquidsoapClient:
             self.conn.write("http.stop")
             self.conn.write("web_stream.set_id -1")
 
-    def source_disconnect(self, name: Literal["master_dj", "live_dj"]) -> None:
-        command_map = {
-            "master_dj": "master_harbor.stop",
-            "live_dj": "live_dj_harbor.stop",
-        }
-        with self.conn:
-            self.conn.write(command_map[name])
-
     def source_switch_status(
         self,
         name: Literal["master_dj", "live_dj", "scheduled_play"],

--- a/playout/libretime_playout/player/liquidsoap.py
+++ b/playout/libretime_playout/player/liquidsoap.py
@@ -111,7 +111,7 @@ class TelnetLiquidsoap:
 
         try:
             logger.debug("Disconnecting source: %s", sourcename)
-            self.liq_client.source_disconnect(sourcename)
+            self.liq_client.source_switch_status(sourcename, False)
         except OSError as exception:
             logger.exception(exception)
 


### PR DESCRIPTION
### Description

The `source_disconnect` method in the liquidsoap client was still using the old names of the 2 harbor input (currently named input_main and input_show).

Remove the `source_disconnect` method, in favor of the `source_switch_status` method, to have a single source name mapping between  playout and liquidsoap.

This is a missing update from a refactor made a while ago: 2f9f60e639f13854094abb0f43730aebc9c89cee

### **Links**

Potential fix for https://github.com/libretime/libretime/issues/2796


