### PR TITLE
chore(playout): install lxml types to satisfy mypy

### DIFF
--- a/playout/setup.py
+++ b/playout/setup.py
@@ -39,6 +39,7 @@ setup(
             "distro>=1.8.0,<2",
             "requests-mock>=1.10.0,<2",
             "syrupy>=4.0.0,<5",
+            "types-lxml==2025.03.30",
             "types-backports>=0.1.3,<1",
             "types-python-dateutil>=2.8.1,<3",
             "types-requests>=2.31.0,<3",


### PR DESCRIPTION
Fixing a mypy warning about missing types.