### PR TITLE
refactor(playout): revert prefer datetime.now(timezone.utc) over datetime.utcnow() 

### DIFF
--- a/playout/libretime_playout/history/stats.py
+++ b/playout/libretime_playout/history/stats.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from threading import Thread
 from time import sleep
 from typing import Any, Dict, List, Optional, Union
@@ -92,7 +92,7 @@ class StatsCollector:
         _timestamp: Optional[datetime] = None,
     ) -> None:
         if _timestamp is None:
-            _timestamp = datetime.now(timezone.utc)
+            _timestamp = datetime.utcnow()
 
         stats: List[Dict[str, Any]] = []
         stats_timestamp = _timestamp.strftime("%Y-%m-%d %H:%M:%S")

--- a/playout/libretime_playout/main.py
+++ b/playout/libretime_playout/main.py
@@ -6,7 +6,7 @@ import logging
 import os
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from queue import Queue
 from typing import Any, Dict, Optional
@@ -98,7 +98,7 @@ def cli(
     # the local machine is, so that we have a reference for what time the actual
     # log entries were made
     logger.info("Timezone: %s", time.tzname)
-    logger.info("UTC time: %s", datetime.now(timezone.utc))
+    logger.info("UTC time: %s", datetime.utcnow())
 
     api_client = ApiClient(
         base_url=config.general.public_url,

--- a/playout/libretime_playout/player/events.py
+++ b/playout/libretime_playout/player/events.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Dict, Literal, Optional, Union
@@ -54,7 +54,7 @@ class BaseEvent(BaseModel):
         return datetime_to_event_key(self.end)
 
     def ended(self) -> bool:
-        return datetime.now(timezone.utc) > self.end
+        return datetime.utcnow() > self.end
 
 
 class FileEvent(BaseEvent):

--- a/playout/libretime_playout/player/liquidsoap.py
+++ b/playout/libretime_playout/player/liquidsoap.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Set
 
 from ..liquidsoap.client import LiquidsoapClient
@@ -317,7 +317,7 @@ class Liquidsoap:
     def modify_cue_point(self, file_event: FileEvent) -> None:
         assert file_event.type == EventKind.FILE
 
-        lateness = seconds_between(file_event.start, datetime.now(timezone.utc))
+        lateness = seconds_between(file_event.start, datetime.utcnow())
 
         if lateness > 0:
             logger.debug("media item was supposed to start %ss ago", lateness)

--- a/playout/libretime_playout/player/push.py
+++ b/playout/libretime_playout/player/push.py
@@ -1,7 +1,7 @@
 import logging
 import math
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 from queue import Queue
 from threading import Thread
 from typing import List, Tuple
@@ -64,7 +64,7 @@ class PypoPush(Thread):
             loops += 1
 
     def separate_present_future(self, events: Events) -> Tuple[List[AnyEvent], Events]:
-        now = datetime.now(timezone.utc)
+        now = datetime.utcnow()
 
         present: List[AnyEvent] = []
         future: Events = {}

--- a/playout/libretime_playout/player/queue.py
+++ b/playout/libretime_playout/player/queue.py
@@ -1,6 +1,6 @@
 import logging
 from collections import deque
-from datetime import datetime, timezone
+from datetime import datetime
 from queue import Empty, Queue
 from threading import Thread
 from typing import Any, Dict
@@ -48,7 +48,7 @@ class PypoLiqQueue(Thread):
                 self.liquidsoap.play(media_item)
                 if len(schedule_deque):
                     time_until_next_play = seconds_between(
-                        datetime.now(timezone.utc),
+                        datetime.utcnow(),
                         schedule_deque[0].start,
                     )
                 else:
@@ -65,7 +65,7 @@ class PypoLiqQueue(Thread):
 
                 if len(keys):
                     time_until_next_play = seconds_between(
-                        datetime.now(timezone.utc),
+                        datetime.utcnow(),
                         media_schedule[keys[0]].start,
                     )
 

--- a/playout/libretime_playout/player/schedule.py
+++ b/playout/libretime_playout/player/schedule.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time, timedelta, timezone
+from datetime import datetime, time, timedelta
 from operator import itemgetter
 from typing import Dict
 
@@ -37,7 +37,7 @@ def insert_event(events: Events, event_key: str, event: AnyEvent) -> None:
 def get_schedule(api_client: ApiClient) -> Events:
     stream_preferences = StreamPreferences(**api_client.get_stream_preferences().json())
 
-    current_time = datetime.now(timezone.utc)
+    current_time = datetime.utcnow()
     end_time = current_time + timedelta(days=1)
 
     current_time_str = current_time.isoformat(timespec="seconds")


### PR DESCRIPTION
This reverts commit 8bd2db16617bb90d9a3b00ec48a8836a6bafa4f1.

The API does not support timezone aware query parameters.