### PR TITLE
feat: rename `airtime-pypo` exchange to `playout`

### DIFF
--- a/legacy/application/models/RabbitMq.php
+++ b/legacy/application/models/RabbitMq.php
@@ -55,7 +55,7 @@ class Application_Model_RabbitMq
     {
         $md['event_type'] = $event_type;
 
-        $exchange = 'airtime-pypo';
+        $exchange = 'playout';
         $data = json_encode($md, JSON_FORCE_OBJECT);
         self::sendMessage($exchange, 'fanout', true, $data);
     }
@@ -71,7 +71,7 @@ class Application_Model_RabbitMq
 
     public static function SendMessageToShowRecorder($event_type)
     {
-        $exchange = 'airtime-pypo';
+        $exchange = 'playout';
 
         $now = new DateTime('@' . time()); // in UTC timezone
         $end_timestamp = new DateTime('@' . (time() + 3600 * 2)); // in UTC timezone

--- a/playout/libretime_playout/message_handler.py
+++ b/playout/libretime_playout/message_handler.py
@@ -27,7 +27,7 @@ class MessageHandler(ConsumerMixin):
         self.fetch_queue = fetch_queue
 
     def get_consumers(self, Consumer, channel):
-        exchange = Exchange("airtime-pypo", "fanout", durable=True, auto_delete=True)
+        exchange = Exchange("playout", "fanout", durable=True, auto_delete=True)
         # RabbitMQ says to avoid temporary queues with well-known names
         # https://www.rabbitmq.com/docs/queues#shared-temporary-queues
         # A server named queue that expires is used so that if the service


### PR DESCRIPTION
### Description

The playout exchange was changed to `fanout` without migrating the previous `direct` exchange. This cause issues during upgrades, such as:

```
amqp.exceptions.PreconditionFailed: Exchange.declare: (406) PRECONDITION_FAILED - inequivalent arg 'type' for exchange 'airtime-pypo' in vhost '/libretime': received 'fanout' but current is 'direct'
```

This is documented upstream in https://www.rabbitmq.com/docs/queues#property-equivalence

This change provides an upgrade path by renaming the exchange, and leave the old exchange behind. Loosing messages is not a concern for the playout queue.

### Testing Notes

- Checkout version `4.4.0`
- Run `make dev`
- Checkout 9e55d3bb6f2fa0f9a4dc858359a99e9d50c826a4
- Run `make dev`
- See the exception in playout: `docker compose logs -f playout`
- Checkout this PR
- Run `make dev`
- See playout fine working.


### **Links**

https://github.com/libretime/libretime/pull/3161
