### PR TITLE
feat(legacy): make autoloading playlist autofill lead time configurable

### DIFF
--- a/docs/user-manual/playlists.md
+++ b/docs/user-manual/playlists.md
@@ -26,7 +26,7 @@ If you want to edit the playlist content or metadata later, you can find it by *
 
 ### Auto loading playlists
 
-LibreTime will schedule tracks from a selected playlist an hour before a show is scheduled to air. This is a great way to automatically schedule weekly shows which are received via. podcasts.
+By default, LibreTime will schedule tracks from a selected playlist an hour before a show is scheduled to air. This is a great way to automatically schedule weekly shows which are received via. podcasts. This can be configured with the `general.autoload_lead_time` configuration option.
 
 ## Creating a Smartblock
 

--- a/legacy/application/common/AutoPlaylistManager.php
+++ b/legacy/application/common/AutoPlaylistManager.php
@@ -109,9 +109,9 @@ class AutoPlaylistManager
     {
         // setting now so that past shows aren't referenced
         $now = new DateTime('now', new DateTimeZone('UTC'));
-        // only build playlists for shows that start up to an hour from now
+        $leadTimeInterval = DateInterval::createFromDateString(Config::get('general.autoload_lead_time'));
         $future = clone $now;
-        $future->add(new DateInterval('PT1H'));
+        $future->add($leadTimeInterval);
 
         return CcShowInstancesQuery::create()
             ->filterByDbModifiedInstance(false)

--- a/legacy/application/configs/conf.php
+++ b/legacy/application/configs/conf.php
@@ -45,6 +45,16 @@ class Schema implements ConfigurationInterface
             /**/->scalarNode('dev_env')->defaultValue('production')->end()
             /**/->scalarNode('auth')->defaultValue('local')->end()
             /**/->integerNode('cache_ahead_hours')->defaultValue(1)->end()
+            /**/->scalarNode('autoload_lead_time')->defaultValue('1 hour')
+            /*  */->validate()->ifTrue(function ($v) {
+                try {
+                    return DateInterval::createFromDateString($v) === false;
+                } catch (\Exception $e) {
+                    return true;
+                }
+            /*  */})->thenInvalid("Invalid autoload_lead_time interval string: %s. Should be something like '1 day' or '30 minutes'.")
+            /*  */->end()
+            /**/->end()
             ->end()->end()
 
             // Database schema


### PR DESCRIPTION
### Description

Autoloading playlists ruin cache ahead time. In the playout service it is hard coded to be 1 day, but if you make heavy use of autoloading playlists, in reality it is only 1 hour ahead.

**This is a new feature**:

Yes

**I have updated the documentation to reflect these changes**:

Yes

### Testing Notes

**What I did:**

I set the time to an invalid interval and saw the expected error message pop up. I then configured a lead time of 5 days and created a show 2 days out. I then visited the `/api/invalid` endpoint to get tasks to trigger and saw my show had been scheduled.

**How you can replicate my testing:**

See what I did section.

### **Links**

Closes #3174 
