### PR TITLE
fix(playout): obey cache ahead hours

### DIFF
--- a/docker/config.template.yml
+++ b/docker/config.template.yml
@@ -21,9 +21,8 @@ general:
   # > default is UTC
   timezone: UTC
 
-  # How many hours ahead Playout should cache scheduled media files.
-  # > default is 24
-  cache_ahead_hours: 24
+  # DEPRECATED: Use [playout.cache_ahead_hours] instead.
+  cache_ahead_hours: 3
 
   # Authentication adaptor to use for the legacy service, specify a class like
   # LibreTime_Auth_Adaptor_FreeIpa to replace the built-in adaptor.
@@ -106,6 +105,10 @@ playout:
   # Liquidsoap connection port.
   # > default is 1234
   liquidsoap_port: 1234
+
+  # How many hours ahead Playout should cache scheduled media files.
+  # > default is 3
+  cache_ahead_hours: 3
 
   # The format for recordings.
   # > must be one of (ogg, mp3)

--- a/docker/config.template.yml
+++ b/docker/config.template.yml
@@ -22,8 +22,8 @@ general:
   timezone: UTC
 
   # How many hours ahead Playout should cache scheduled media files.
-  # > default is 1
-  cache_ahead_hours: 1
+  # > default is 24
+  cache_ahead_hours: 24
 
   # Authentication adaptor to use for the legacy service, specify a class like
   # LibreTime_Auth_Adaptor_FreeIpa to replace the built-in adaptor.

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -21,9 +21,8 @@ general:
   # > default is UTC
   timezone: UTC
 
-  # How many hours ahead Playout should cache scheduled media files.
-  # > default is 24
-  cache_ahead_hours: 24
+  # DEPRECATED: Use [playout.cache_ahead_hours] instead.
+  cache_ahead_hours: 3
 
   # Authentication adaptor to use for the legacy service, specify a class like
   # LibreTime_Auth_Adaptor_FreeIpa to replace the built-in adaptor.
@@ -106,6 +105,10 @@ playout:
   # Liquidsoap connection port.
   # > default is 1234
   liquidsoap_port: 1234
+
+  # How many hours ahead Playout should cache scheduled media files.
+  # > default is 3
+  cache_ahead_hours: 3
 
   # The format for recordings.
   # > must be one of (ogg, mp3)

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -22,8 +22,8 @@ general:
   timezone: UTC
 
   # How many hours ahead Playout should cache scheduled media files.
-  # > default is 1
-  cache_ahead_hours: 1
+  # > default is 24
+  cache_ahead_hours: 24
 
   # Authentication adaptor to use for the legacy service, specify a class like
   # LibreTime_Auth_Adaptor_FreeIpa to replace the built-in adaptor.

--- a/docker/example/config.yml
+++ b/docker/example/config.yml
@@ -21,9 +21,8 @@ general:
   # > default is UTC
   timezone: UTC
 
-  # How many hours ahead Playout should cache scheduled media files.
-  # > default is 24
-  cache_ahead_hours: 24
+  # DEPRECATED: Use [playout.cache_ahead_hours] instead.
+  cache_ahead_hours: 3
 
   # Authentication adaptor to use for the legacy service, specify a class like
   # LibreTime_Auth_Adaptor_FreeIpa to replace the built-in adaptor.
@@ -106,6 +105,10 @@ playout:
   # Liquidsoap connection port.
   # > default is 1234
   liquidsoap_port: 1234
+
+  # How many hours ahead Playout should cache scheduled media files.
+  # > default is 3
+  cache_ahead_hours: 3
 
   # The format for recordings.
   # > must be one of (ogg, mp3)

--- a/docker/example/config.yml
+++ b/docker/example/config.yml
@@ -22,8 +22,8 @@ general:
   timezone: UTC
 
   # How many hours ahead Playout should cache scheduled media files.
-  # > default is 1
-  cache_ahead_hours: 1
+  # > default is 24
+  cache_ahead_hours: 24
 
   # Authentication adaptor to use for the legacy service, specify a class like
   # LibreTime_Auth_Adaptor_FreeIpa to replace the built-in adaptor.

--- a/docs/admin-manual/configuration.md
+++ b/docs/admin-manual/configuration.md
@@ -57,8 +57,8 @@ general:
   timezone: UTC
 
   # How many hours ahead Playout should cache scheduled media files.
-  # > default is 1
-  cache_ahead_hours: 1
+  # > default is 24
+  cache_ahead_hours: 24
 
   # Authentication adaptor to use for the legacy service, specify a class like
   # LibreTime_Auth_Adaptor_FreeIpa to replace the built-in adaptor.

--- a/docs/admin-manual/configuration.md
+++ b/docs/admin-manual/configuration.md
@@ -56,9 +56,8 @@ general:
   # > default is UTC
   timezone: UTC
 
-  # How many hours ahead Playout should cache scheduled media files.
-  # > default is 24
-  cache_ahead_hours: 24
+  # DEPRECATED: Use [playout.cache_ahead_hours] instead.
+  cache_ahead_hours: 3
 
   # Authentication adaptor to use for the legacy service, specify a class like
   # LibreTime_Auth_Adaptor_FreeIpa to replace the built-in adaptor.
@@ -249,6 +248,10 @@ playout:
   # Liquidsoap connection port.
   # > default is 1234
   liquidsoap_port: 1234
+  
+  # How many hours ahead Playout should cache scheduled media files.
+  # > default is 3
+  cache_ahead_hours: 3
 
   # The format for recordings.
   # > must be one of (ogg, mp3)

--- a/docs/releases/4.3.0.mdx
+++ b/docs/releases/4.3.0.mdx
@@ -32,7 +32,7 @@ Please see the [changelog](https://github.com/libretime/libretime/blob/main/CHAN
 
 ### Docker legacy volume
 
-When deploying using Docker, the legacy volume is not updated automatically.
+When deploying using Docker, the legacy volume isn't updated automatically.
 This results in fixes to the legacy service not being run by docker compose. The
 `libretime_assets` volume must be deleted before the upgrade. The bug is tracked
 in https://github.com/libretime/libretime/issues/3150.

--- a/installer/config.yml
+++ b/installer/config.yml
@@ -21,9 +21,8 @@ general:
   # > default is UTC
   timezone: UTC
 
-  # How many hours ahead Playout should cache scheduled media files.
-  # > default is 24
-  cache_ahead_hours: 24
+  # DEPRECATED: Use [playout.cache_ahead_hours] instead.
+  cache_ahead_hours: 3
 
   # Authentication adaptor to use for the legacy service, specify a class like
   # LibreTime_Auth_Adaptor_FreeIpa to replace the built-in adaptor.
@@ -106,6 +105,10 @@ playout:
   # Liquidsoap connection port.
   # > default is 1234
   liquidsoap_port: 1234
+
+  # How many hours ahead Playout should cache scheduled media files.
+  # > default is 3
+  cache_ahead_hours: 3
 
   # The format for recordings.
   # > must be one of (ogg, mp3)

--- a/installer/config.yml
+++ b/installer/config.yml
@@ -22,8 +22,8 @@ general:
   timezone: UTC
 
   # How many hours ahead Playout should cache scheduled media files.
-  # > default is 1
-  cache_ahead_hours: 1
+  # > default is 24
+  cache_ahead_hours: 24
 
   # Authentication adaptor to use for the legacy service, specify a class like
   # LibreTime_Auth_Adaptor_FreeIpa to replace the built-in adaptor.

--- a/legacy/application/configs/conf.php
+++ b/legacy/application/configs/conf.php
@@ -44,7 +44,8 @@ class Schema implements ConfigurationInterface
             /**/->end()
             /**/->scalarNode('dev_env')->defaultValue('production')->end()
             /**/->scalarNode('auth')->defaultValue('local')->end()
-            /**/->integerNode('cache_ahead_hours')->defaultValue(24)->end()
+            /**/// DEPRECATED
+            /**/->integerNode('cache_ahead_hours')->defaultValue(-1)->end()
             ->end()->end()
 
             // Database schema
@@ -364,7 +365,12 @@ class Config
 
         $legacy_values['dev_env'] = $values['general']['dev_env'];
         $legacy_values['auth'] = $values['general']['auth'];
-        $legacy_values['cache_ahead_hours'] = $values['general']['cache_ahead_hours'];
+
+        $cache_ahead_hours = $values['general']['cache_ahead_hours'];
+        if (intval($cache_ahead_hours) < 0) {
+            $cache_ahead_hours = $values['playout']['cache_ahead_hours'];
+        }
+        $legacy_values['cache_ahead_hours'] = $cache_ahead_hours;
 
         // SAAS remaining fields
         $legacy_values['stationId'] = '';

--- a/legacy/application/configs/conf.php
+++ b/legacy/application/configs/conf.php
@@ -44,7 +44,7 @@ class Schema implements ConfigurationInterface
             /**/->end()
             /**/->scalarNode('dev_env')->defaultValue('production')->end()
             /**/->scalarNode('auth')->defaultValue('local')->end()
-            /**/->integerNode('cache_ahead_hours')->defaultValue(1)->end()
+            /**/->integerNode('cache_ahead_hours')->defaultValue(24)->end()
             ->end()->end()
 
             // Database schema

--- a/legacy/application/models/Schedule.php
+++ b/legacy/application/models/Schedule.php
@@ -990,7 +990,7 @@ SQL;
                 // make sure we are not dealing with a float
                 $cache_ahead_hours = intval($cache_ahead_hours);
             } else {
-                $cache_ahead_hours = 24;
+                $cache_ahead_hours = 3;
             }
 
             $t2->add(new DateInterval('PT' . $cache_ahead_hours . 'H'));

--- a/legacy/application/models/Schedule.php
+++ b/legacy/application/models/Schedule.php
@@ -990,7 +990,7 @@ SQL;
                 // make sure we are not dealing with a float
                 $cache_ahead_hours = intval($cache_ahead_hours);
             } else {
-                $cache_ahead_hours = 1;
+                $cache_ahead_hours = 24;
             }
 
             $t2->add(new DateInterval('PT' . $cache_ahead_hours . 'H'));

--- a/playout/libretime_playout/config.py
+++ b/playout/libretime_playout/config.py
@@ -20,6 +20,8 @@ class PlayoutConfig(BaseModel):
     liquidsoap_host: str = "localhost"
     liquidsoap_port: int = 1234
 
+    cache_ahead_hours: int = 3
+
     record_file_format: Literal["mp3", "ogg"] = "ogg"  # record_file_type
     record_bitrate: int = 256
     record_samplerate: int = 44100

--- a/playout/libretime_playout/player/fetch.py
+++ b/playout/libretime_playout/player/fetch.py
@@ -71,7 +71,8 @@ class PypoFetch(Thread):
             logger.debug("handling event %s: %s", command, message)
 
             if command == "update_schedule":
-                self.schedule_data = get_schedule(self.api_client)
+                self.schedule_data = get_schedule(self.api_client,
+                    self.config.general.cache_ahead_hours)
                 self.process_schedule(self.schedule_data)
             elif command == "reset_liquidsoap_bootstrap":
                 self.set_bootstrap_variables()
@@ -262,7 +263,8 @@ class PypoFetch(Thread):
 
     def manual_schedule_fetch(self) -> bool:
         try:
-            self.schedule_data = get_schedule(self.api_client)
+            self.schedule_data = get_schedule(self.api_client,
+                self.config.general.cache_ahead_hours)
             logger.debug("Received event from API client: %s", self.schedule_data)
             self.process_schedule(self.schedule_data)
             return True

--- a/playout/libretime_playout/player/fetch.py
+++ b/playout/libretime_playout/player/fetch.py
@@ -71,8 +71,9 @@ class PypoFetch(Thread):
             logger.debug("handling event %s: %s", command, message)
 
             if command == "update_schedule":
-                self.schedule_data = get_schedule(self.api_client,
-                    self.config.general.cache_ahead_hours)
+                self.schedule_data = get_schedule(
+                    self.api_client, self.config.general.cache_ahead_hours
+                )
                 self.process_schedule(self.schedule_data)
             elif command == "reset_liquidsoap_bootstrap":
                 self.set_bootstrap_variables()
@@ -263,8 +264,9 @@ class PypoFetch(Thread):
 
     def manual_schedule_fetch(self) -> bool:
         try:
-            self.schedule_data = get_schedule(self.api_client,
-                self.config.general.cache_ahead_hours)
+            self.schedule_data = get_schedule(
+                self.api_client, self.config.general.cache_ahead_hours
+            )
             logger.debug("Received event from API client: %s", self.schedule_data)
             self.process_schedule(self.schedule_data)
             return True

--- a/playout/libretime_playout/player/fetch.py
+++ b/playout/libretime_playout/player/fetch.py
@@ -62,6 +62,12 @@ class PypoFetch(Thread):
         self.schedule_data: Events = {}
         logger.info("PypoFetch: init complete")
 
+    def _get_cache_ahead_hours(self):
+        cache_ahead_hours = self.config.general.cache_ahead_hours
+        if cache_ahead_hours < 0:
+            cache_ahead_hours = self.config.playout.cache_ahead_hours
+        return cache_ahead_hours
+
     # Handle a message from RabbitMQ, put it into our yucky global var.
     # Hopefully there is a better way to do this.
 
@@ -72,7 +78,7 @@ class PypoFetch(Thread):
 
             if command == "update_schedule":
                 self.schedule_data = get_schedule(
-                    self.api_client, self.config.general.cache_ahead_hours
+                    self.api_client, self._get_cache_ahead_hours()
                 )
                 self.process_schedule(self.schedule_data)
             elif command == "reset_liquidsoap_bootstrap":
@@ -265,7 +271,7 @@ class PypoFetch(Thread):
     def manual_schedule_fetch(self) -> bool:
         try:
             self.schedule_data = get_schedule(
-                self.api_client, self.config.general.cache_ahead_hours
+                self.api_client, self._get_cache_ahead_hours()
             )
             logger.debug("Received event from API client: %s", self.schedule_data)
             self.process_schedule(self.schedule_data)

--- a/playout/libretime_playout/player/schedule.py
+++ b/playout/libretime_playout/player/schedule.py
@@ -34,11 +34,11 @@ def insert_event(events: Events, event_key: str, event: AnyEvent) -> None:
     events[key] = event
 
 
-def get_schedule(api_client: ApiClient) -> Events:
+def get_schedule(api_client: ApiClient, cache_ahead_hours: int) -> Events:
     stream_preferences = StreamPreferences(**api_client.get_stream_preferences().json())
 
     current_time = datetime.utcnow()
-    end_time = current_time + timedelta(days=1)
+    end_time = current_time + timedelta(hours=cache_ahead_hours)
 
     current_time_str = current_time.isoformat(timespec="seconds")
     end_time_str = end_time.isoformat(timespec="seconds")

--- a/playout/tests/player/schedule_test.py
+++ b/playout/tests/player/schedule_test.py
@@ -447,7 +447,7 @@ def test_get_schedule(schedule, requests_mock, api_client: ApiClient):
     requests_mock.get(f"{base_url}/api/v2/files/5", json=FILE_5)
     requests_mock.get(f"{base_url}/api/v2/webstreams/1", json=WEBSTREAM_1)
 
-    assert get_schedule(api_client) == {
+    assert get_schedule(api_client, 24) == {
         "2022-09-05-11-00-00": FileEvent(
             start=datetime(2022, 9, 5, 11, 0),
             end=datetime(2022, 9, 5, 11, 5, 2),

--- a/shared/libretime_shared/config/_models.py
+++ b/shared/libretime_shared/config/_models.py
@@ -23,7 +23,7 @@ class GeneralConfig(BaseModel):
     api_key: str
     secret_key: str
 
-    cache_ahead_hours: int = 24
+    cache_ahead_hours: int = -1
 
     timezone: str = "UTC"
 

--- a/shared/libretime_shared/config/_models.py
+++ b/shared/libretime_shared/config/_models.py
@@ -23,6 +23,8 @@ class GeneralConfig(BaseModel):
     api_key: str
     secret_key: str
 
+    cache_ahead_hours: int = 24
+
     timezone: str = "UTC"
 
     allowed_cors_origins: List[AnyHttpUrlStr] = []


### PR DESCRIPTION
### Description

Playout does not obey the general.cache_ahead_hours configuration option. It is hard coded to 1 day.

**This is a new feature**:

No

**I have updated the documentation to reflect these changes**:

Yes

### Testing Notes

**What I did:**

I created a show in libretime that went for 8 hours. I then set the cache ahead time to 1 hour and noted that only 1 hour's worth of tracks were downloaded. I then set the cache_ahead_hours to 10 and saw that all files in the show were downloaded.

**How you can replicate my testing:**

See what I did

### **Links**

Closes #3177 
