### PR TITLE
feat(legacy): add config option for group separator in header auth

### DIFF
--- a/docs/admin-manual/custom-authentication.md
+++ b/docs/admin-manual/custom-authentication.md
@@ -149,6 +149,7 @@ header_auth:
   groups_header: Remote-Groups # This is the default and could be omitted
   email_header: Remote-Email # This is the default and could be omitted
   name_header: Remote-Name # This is the default and could be omitted
+  group_separator: ',' # This is the default and could be omitted
   proxy_ip: 10.0.0.34
   group_map:
     host: lt-host

--- a/legacy/application/auth/adapters/HeaderAuth.php
+++ b/legacy/application/auth/adapters/HeaderAuth.php
@@ -54,7 +54,9 @@ class LibreTime_Auth_Adaptor_Header implements Zend_Auth_Adapter_Interface
             return UTYPE_GUEST;
         }
 
-        $groups = array_map(fn ($group) => trim($group), explode(',', $groups));
+        $separator = Config::get('header_auth.group_separator');
+
+        $groups = array_map(fn ($group) => trim($group), explode($separator, $groups));
 
         $superAdminGroup = Config::get('header_auth.group_map.superadmin');
         if (in_array($superAdminGroup, $groups)) {

--- a/legacy/application/configs/conf.php
+++ b/legacy/application/configs/conf.php
@@ -105,6 +105,7 @@ class Schema implements ConfigurationInterface
             /**/->scalarNode('groups_header')->defaultValue('Remote-Groups')->end()
             /**/->scalarNode('email_header')->defaultValue('Remote-Email')->end()
             /**/->scalarNode('name_header')->defaultValue('Remote-Name')->end()
+            /**/->scalarNode('group_separator')->defaultValue(',')->end()
             /**/->scalarNode('proxy_ip')->end()
             /**/->scalarNode('locale')->defaultValue('en-US')->end()
             /**/->arrayNode('group_map')->children()


### PR DESCRIPTION
### Description

Not all forward auth solutions use a comma for group seperator.

**This is a new feature**:

Yes

**I have updated the documentation to reflect these changes**:

Yes

### **Links**

[Authentik uses `|` so may as well make the group separator configurable](https://docs.goauthentik.io/docs/add-secure-apps/providers/proxy/)
