### PR TITLE
fix(worker): catch mutagen `TypeError` when saving metadata

### DIFF
--- a/worker/tests/tasks_test.py
+++ b/worker/tests/tasks_test.py
@@ -53,7 +53,7 @@ def test_podcast_download_invalid_file(requests_mock):
     assert json.loads(result) == {
         "episodeid": 1,
         "status": 0,
-        "error": "could not determine episode 1 file type",
+        "error": "could not determine podcast episode 1 file type",
     }
 
 


### PR DESCRIPTION
Mutagen may fail with:

```
worker-1  | Traceback (most recent call last):
worker-1  |   File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 412, in trace_task
worker-1  |     R = retval = fun(*args, **kwargs)
worker-1  |   File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 704, in __protected_call__
worker-1  |     return self.run(*args, **kwargs)
worker-1  |   File "/src/libretime_worker/tasks.py", line 114, in podcast_download
worker-1  |     metadata["artist"] = podcast_name
worker-1  |   File "/usr/local/lib/python3.10/site-packages/mutagen/_file.py", line 74, in __setitem__
worker-1  |     self.tags[key] = value
worker-1  |   File "/usr/local/lib/python3.10/site-packages/mutagen/id3/_tags.py", line 341, in __setitem__
worker-1  |     raise TypeError("%r not a Frame instance" % tag)
worker-1  | TypeError: "Infos du soir" not a Frame instance
```

This TypeError was raised when I trying to write metadata to a wave file.

This patch ensures that the error is reported back to the frontend. It also improve the error messages being reported.
