### PR TITLE
feat(legacy): persist database connections

### DIFF
--- a/legacy/application/configs/airtime-conf-production.php
+++ b/legacy/application/configs/airtime-conf-production.php
@@ -23,6 +23,9 @@ $conf = [
             'adapter' => 'pgsql',
             'connection' => [
                 'dsn' => "pgsql:host={$dbhost};port={$dbport};dbname={$dbname};user={$dbuser};password={$dbpass}",
+                'options' => [
+                    'ATTR_PERSISTENT' => true,
+                ],
             ],
         ],
         'default' => 'airtime',


### PR DESCRIPTION
### Description

Persist the database connection to reduce the load on Postgresql, and improve performances.

https://www.php.net/manual/en/pdo.connections.php
https://www.php.net/manual/en/pdo.constants.php#pdo.constants.attr-persistent
