### PR TITLE
fix(legacy): do not send content-type header twice

### DIFF
--- a/legacy/application/controllers/ApiController.php
+++ b/legacy/application/controllers/ApiController.php
@@ -1642,15 +1642,16 @@ class ApiController extends Zend_Controller_Action
 
     private function returnJsonOrJsonp($request, $result)
     {
-        $callback = $request->getParam('callback');
         $response = $this->getResponse();
-        $response->setHeader('Content-Type', 'application/json');
 
         $body = $this->_helper->json->encodeJson($result, false);
 
+        $callback = $request->getParam('callback');
         if ($callback) {
             $response->setHeader('Content-Type', 'application/javascript');
             $body = sprintf('%s(%s)', $callback, $body);
+        } else {
+            $response->setHeader('Content-Type', 'application/json');
         }
         $response->setBody($body);
 


### PR DESCRIPTION
### Description

Nginx complains with a lot of warnings about duplicate headers:

```
nginx-1  | 2025/08/09 10:30:59 [warn] 30#30: *165 upstream sent duplicate header line: "Content-Type: application/javascript", previous value: "Content-Type: application/json", ignored while reading response header from upstream, client: 172.18.0.1, server: , request: "GET /api/live-info?callback=jQuery110208358688475043138_1754723948660&type=interval&limit=5&_=1754723949161 HTTP/1.0", upstream: "fastcgi://172.18.0.5:9000"
```
