### PR TITLE
fix(api): add psql client to api container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,7 @@ RUN set -eux \
     gcc \
     libc6-dev \
     libpq-dev \
+    postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src


### PR DESCRIPTION
### Description

This allows to run the django dbshell command from within the running container.

```
$ sudo docker compose exec -it api libretime-api dbshell
CommandError: You appear not to have the 'psql' program installed or on your path.
```