### PR TITLE
fix(analyzer): add default error handling for non-UTF8 metadata

### DIFF
--- a/analyzer/libretime_analyzer/pipeline/_utils.py
+++ b/analyzer/libretime_analyzer/pipeline/_utils.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 
 def run_(*args, **kwargs) -> CompletedProcess:
-    kwargs.setdefault("errors", "replace") # don't crash on non-utf8 metadata
+    kwargs.setdefault("errors", "replace")  # don't crash on non-utf8 metadata
     try:
         return run(
             args,


### PR DESCRIPTION
certain podcast episodes could not be imported because of non-utf8 metadata content.