### PR TITLE
fix(playout): add vine/five.py Python 3.11 compatibility patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,6 +124,10 @@ COPY playout .
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --editable .[sentry]
 
+RUN set -eux \
+    && _vine_site=$(python3 -c "import site; print(site.getsitepackages()[0])") \
+    && patch -p1 --forward --reject-file=- -d "$_vine_site" < vine-python311.patch || true
+
 # Run
 USER ${UID}:${GID}
 WORKDIR /app

--- a/install
+++ b/install
@@ -647,6 +647,12 @@ link_python_app libretime-liquidsoap
 link_python_app libretime-playout
 link_python_app libretime-playout-notify
 
+if [[ -f "$SCRIPT_DIR/playout/vine-python311.patch" ]]; then
+  info "applying vine Python 3.11 compatibility patch"
+  _vine_site=$(find "$VENV_DIR/lib" -maxdepth 2 -name "site-packages" -type d | head -1)
+  patch -p1 --forward --reject-file=- -d "$_vine_site" < "$SCRIPT_DIR/playout/vine-python311.patch" || true
+fi
+
 info "creating libretime-playout working directory"
 mkdir_and_chown "$LIBRETIME_USER" "$WORKING_DIR/playout"
 

--- a/playout/vine-python311.patch
+++ b/playout/vine-python311.patch
@@ -1,0 +1,45 @@
+--- a/vine/five.py	2026-03-29 13:20:29.870633147 -0600
++++ b/vine/five.py	2026-03-28 19:17:29.250262641 -0600
+@@ -358,7 +358,41 @@
+ 
+ 
+ try:  # pragma: no cover
+-    from inspect import formatargspec, getfullargspec
++    from inspect import getfullargspec
++    try:
++        from inspect import formatargspec
++    except ImportError:  # Python 3.11+
++        def formatargspec(args, varargs=None, varkw=None, defaults=None,
++                          kwonlyargs=(), kwonlydefaults={}, annotations={},
++                          formatarg=str, formatvarargs=lambda name: '*' + name,
++                          formatvarkw=lambda name: '**' + name,
++                          formatvalue=lambda value: '=' + repr(value),
++                          formatreturns=lambda text: ' -> ' + text,
++                          formatannotation=None):
++            specs = []
++            if defaults:
++                firstdefault = len(args) - len(defaults)
++            else:
++                firstdefault = len(args)
++            for i, arg in enumerate(args):
++                spec = formatarg(arg)
++                if i >= firstdefault:
++                    spec = spec + formatvalue(defaults[i - firstdefault])
++                specs.append(spec)
++            if varargs is not None:
++                specs.append(formatvarargs(varargs))
++            if kwonlyargs:
++                if varargs is None:
++                    specs.append("*")
++                for kw in kwonlyargs:
++                    spec = formatarg(kw)
++                    if kwonlydefaults and kw in kwonlydefaults:
++                        spec += formatvalue(kwonlydefaults[kw])
++                    specs.append(spec)
++            if varkw is not None:
++                specs.append(formatvarkw(varkw))
++            result = "(" + ", ".join(specs) + ")"
++            return result
+ except ImportError:  # Py2
+     from collections import namedtuple
+     from inspect import formatargspec, getargspec as _getargspec  # noqa


### PR DESCRIPTION
### Description

inspect.formatargspec was removed in Python 3.11. vine 1.3.0 (pulled in by kombu==4.6.11) imports it unconditionally, crashing libretime-playout on Debian 12. Adds a patch file with a formatargspec polyfill, applied automatically by the installer after the playout pip install.