### PR TITLE
fix(api): disable import-untyped mypy error code

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -28,6 +28,7 @@ plugins = [
   "mypy_drf_plugin.main",
 ]
 ignore_missing_imports = true
+disable_error_code = ["import-untyped"]
 
 [tool.django-stubs]
 django_settings_module = "libretime_api.settings.testing"


### PR DESCRIPTION
mypy is treating [import-untyped] as a separate error code from ignore_missing_imports, causing the lint CI job to fail. 

Adding disable_error_code = ["import-untyped"] to api/pyproject.toml resolves it.

Fixes the failing lint job in: https://github.com/libretime/libretime/actions/runs/25017877262