### PR TITLE
fix(playout): restarting liquidsoap lets the connection go stale. also enforces thread safety

### DIFF
--- a/playout/libretime_playout/liquidsoap/client/_client.py
+++ b/playout/libretime_playout/liquidsoap/client/_client.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from pathlib import Path
 from time import sleep
 from typing import Any, Literal, Optional, Tuple, Union
@@ -17,12 +18,29 @@ class LiquidsoapClientError(Exception):
     """
 
 
-class LiquidsoapClient:
+class _OwnedLock:
+    """A non-reentrant lock that records the thread currently holding it.
     """
-    A client to communicate with a running Liquidsoap server.
 
-    The client is not thread safe.
-    """
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._owner: Optional[int] = None
+
+    def __enter__(self) -> "_OwnedLock":
+        self._lock.acquire()
+        self._owner = threading.get_ident()
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self._owner = None
+        self._lock.release()
+
+    def held_by_current_thread(self) -> bool:
+        return self._owner == threading.get_ident()
+
+
+class LiquidsoapClient:
+    """A client to communicate with a running Liquidsoap server."""
 
     conn: LiquidsoapConnection
 
@@ -39,18 +57,23 @@ class LiquidsoapClient:
             path=path,
             timeout=timeout,
         )
+        self._lock = _OwnedLock()
 
     def _quote(self, value: Any) -> str:
         return quote(value, double=True)
 
     def _set_var(self, name: str, value: Any) -> None:
+        if not self._lock.held_by_current_thread():
+            raise RuntimeError(
+                "_set_var must be called with self._lock held"
+            )
         self.conn.write(f"var.set {name} = {value}")
         result = self.conn.read()
         if f"Variable {name} set" not in result:
             logger.error("unexpected response: %s", result)
 
     def version(self) -> Tuple[int, int, int]:
-        with self.conn:
+        with self._lock, self.conn:
             self.conn.write("version")
             return parse_liquidsoap_version(self.conn.read())
 
@@ -68,43 +91,43 @@ class LiquidsoapClient:
         raise LiquidsoapClientError("could not get liquidsoap version")
 
     def queues_remove(self, *queues: int) -> None:
-        with self.conn:
+        with self._lock, self.conn:
             for queue_id in queues:
                 self.conn.write(f"queues.s{queue_id}_skip")
                 self.conn.read()  # Flush
 
     def queue_push(self, queue_id: int, entry: str, show_name: str) -> None:
-        with self.conn:
+        with self._lock, self.conn:
             self.conn.write(f"s{queue_id}.push {entry}")
             self.conn.read()  # Flush
             self._set_var("show_name", self._quote(show_name))
 
     def web_stream_get_id(self) -> str:
-        with self.conn:
+        with self._lock, self.conn:
             self.conn.write("web_stream.get_id")
             return self.conn.read().splitlines()[0]
 
     def web_stream_start(self) -> None:
-        with self.conn:
+        with self._lock, self.conn:
             self.conn.write("sources.start_schedule")
             self.conn.read()  # Flush
             self.conn.write("sources.start_web_stream")
             self.conn.read()  # Flush
 
     def web_stream_start_buffer(self, schedule_id: int, uri: str) -> None:
-        with self.conn:
+        with self._lock, self.conn:
             self.conn.write(f"web_stream.set_id {schedule_id}")
             self.conn.read()  # Flush
             self.conn.write(f"http.restart {uri}")
             self.conn.read()  # Flush
 
     def web_stream_stop(self) -> None:
-        with self.conn:
+        with self._lock, self.conn:
             self.conn.write("sources.stop_web_stream")
             self.conn.read()  # Flush
 
     def web_stream_stop_buffer(self) -> None:
-        with self.conn:
+        with self._lock, self.conn:
             self.conn.write("http.stop")
             self.conn.read()  # Flush
             self.conn.write("web_stream.set_id -1")
@@ -121,7 +144,7 @@ class LiquidsoapClient:
             "scheduled_play": "schedule",
         }
         action = "start" if streaming else "stop"
-        with self.conn:
+        with self._lock, self.conn:
             self.conn.write(f"sources.{action}_{name_map[name]}")
             self.conn.read()  # Flush
 
@@ -133,7 +156,7 @@ class LiquidsoapClient:
         message_offline: Optional[str] = None,
         input_fade_transition: Optional[float] = None,
     ) -> None:
-        with self.conn:
+        with self._lock, self.conn:
             if station_name is not None:
                 self._set_var("station_name", self._quote(station_name))
             if message_format is not None:

--- a/playout/libretime_playout/liquidsoap/client/_client.py
+++ b/playout/libretime_playout/liquidsoap/client/_client.py
@@ -19,8 +19,7 @@ class LiquidsoapClientError(Exception):
 
 
 class _OwnedLock:
-    """A non-reentrant lock that records the thread currently holding it.
-    """
+    """A non-reentrant lock that records the thread currently holding it."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
@@ -64,9 +63,7 @@ class LiquidsoapClient:
 
     def _set_var(self, name: str, value: Any) -> None:
         if not self._lock.held_by_current_thread():
-            raise RuntimeError(
-                "_set_var must be called with self._lock held"
-            )
+            raise RuntimeError("_set_var must be called with self._lock held")
         self.conn.write(f"var.set {name} = {value}")
         result = self.conn.read()
         if f"Variable {name} set" not in result:

--- a/playout/libretime_playout/liquidsoap/client/_connection.py
+++ b/playout/libretime_playout/liquidsoap/client/_connection.py
@@ -72,18 +72,23 @@ class LiquidsoapConnection:
             raise
 
     def close(self):
-        if self._sock is not None:
-            logger.debug("closing connection to %s", self.address())
-
+        sock = self._sock
+        if sock is None:
+            return
+        self._sock = None
+        logger.debug("closing connection to %s", self.address())
+        try:
             try:
-                self.write("exit")
-                # Reading for clean exit
-                while self._sock.recv(1024):
+                sock.sendall(b"exit\n")
+                while sock.recv(1024):
                     continue
-
-            finally:
-                self._sock.close()
-                self._sock = None
+            except OSError:
+                pass  # FD already broken; we still need to release it below.
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass
 
     def write(self, *messages: str):
         if self._sock is None:

--- a/playout/libretime_playout/player/queue.py
+++ b/playout/libretime_playout/player/queue.py
@@ -3,6 +3,7 @@ from collections import deque
 from datetime import datetime
 from queue import Empty, Queue
 from threading import Thread
+from time import sleep
 from typing import Any, Dict
 
 from ..utils import seconds_between
@@ -73,7 +74,9 @@ class PypoLiqQueue(Thread):
                     time_until_next_play = None
 
     def run(self) -> None:
-        try:
-            self.main()
-        except Exception as exception:  # pylint: disable=broad-exception-caught
-            logger.exception(exception)
+        while True:
+            try:
+                self.main()
+            except Exception as exception:  # pylint: disable=broad-exception-caught
+                logger.exception(exception)
+                sleep(1)

--- a/playout/tests/liquidsoap/client/client_test.py
+++ b/playout/tests/liquidsoap/client/client_test.py
@@ -1,6 +1,9 @@
+import threading
+
 import pytest
 
 from libretime_playout.liquidsoap.client import LiquidsoapClient, LiquidsoapClientError
+from libretime_playout.liquidsoap.client._client import _OwnedLock
 
 
 def test_liq_client():
@@ -22,3 +25,73 @@ def test_liq_client_wait_for_version_invalid_host():
     )
     with pytest.raises(LiquidsoapClientError):
         liq_client.wait_for_version(timeout=1)
+
+
+def test_owned_lock_tracks_holder_thread():
+    lock = _OwnedLock()
+    assert not lock.held_by_current_thread()
+
+    seen_by_other: list = []
+    with lock:
+        assert lock.held_by_current_thread()
+
+        other = threading.Thread(
+            target=lambda: seen_by_other.append(lock.held_by_current_thread())
+        )
+        other.start()
+        other.join()
+
+    assert seen_by_other == [False]
+    assert not lock.held_by_current_thread()
+
+
+def test_set_var_rejects_calls_without_held_lock():
+    """Internal helpers must refuse to run when the caller doesn't own the lock."""
+    client = LiquidsoapClient(host="localhost", port=1234)
+    with pytest.raises(RuntimeError, match="_set_var must be called"):
+        client._set_var("anything", "value")  # noqa: SLF001
+
+
+def test_liq_client_version_thread_safe(liq_client: LiquidsoapClient):
+    """Concurrent callers must not corrupt the request/response stream.
+
+    Regression: prior to the internal lock, two threads racing through
+    ``with self.conn:`` would overwrite ``self._sock`` for each other, mixing
+    requests and responses so some ``version()`` calls returned ``(0, 0, 0)``
+    or raised ``OSError``. With the lock, all calls return the same valid
+    version tuple.
+    """
+    expected = liq_client.version()
+
+    threads_count = 8
+    iterations = 25
+    start = threading.Barrier(threads_count)
+    collect_lock = threading.Lock()
+    errors: list = []
+    results: list = []
+
+    def worker() -> None:
+        start.wait()  # release all threads at once to maximize contention
+        for _ in range(iterations):
+            try:
+                version = liq_client.version()
+            except Exception as exc:  # noqa: BLE001
+                with collect_lock:
+                    errors.append(exc)
+                return
+            with collect_lock:
+                results.append(version)
+
+    threads = [threading.Thread(target=worker) for _ in range(threads_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+        assert not thread.is_alive(), "worker did not finish — possible deadlock"
+
+    assert errors == [], f"errors raised under concurrent use: {errors}"
+    assert len(results) == threads_count * iterations
+    distinct = set(results)
+    assert distinct == {expected}, (
+        f"inconsistent versions returned (stream corruption): {distinct}"
+    )

--- a/playout/tests/liquidsoap/client/client_test.py
+++ b/playout/tests/liquidsoap/client/client_test.py
@@ -49,6 +49,7 @@ def test_set_var_rejects_calls_without_held_lock():
     """Internal helpers must refuse to run when the caller doesn't own the lock."""
     client = LiquidsoapClient(host="localhost", port=1234)
     with pytest.raises(RuntimeError, match="_set_var must be called"):
+        # pylint: disable=protected-access
         client._set_var("anything", "value")  # noqa: SLF001
 
 
@@ -75,7 +76,8 @@ def test_liq_client_version_thread_safe(liq_client: LiquidsoapClient):
         for _ in range(iterations):
             try:
                 version = liq_client.version()
-            except Exception as exc:  # noqa: BLE001
+            except (OSError, ValueError, IndexError) as exc:
+                # OSError: torn socket; ValueError/IndexError: corrupted parse.
                 with collect_lock:
                     errors.append(exc)
                 return
@@ -89,7 +91,7 @@ def test_liq_client_version_thread_safe(liq_client: LiquidsoapClient):
         thread.join(timeout=60)
         assert not thread.is_alive(), "worker did not finish — possible deadlock"
 
-    assert errors == [], f"errors raised under concurrent use: {errors}"
+    assert not errors, f"errors raised under concurrent use: {errors}"
     assert len(results) == threads_count * iterations
     distinct = set(results)
     assert distinct == {

--- a/playout/tests/liquidsoap/client/client_test.py
+++ b/playout/tests/liquidsoap/client/client_test.py
@@ -92,6 +92,6 @@ def test_liq_client_version_thread_safe(liq_client: LiquidsoapClient):
     assert errors == [], f"errors raised under concurrent use: {errors}"
     assert len(results) == threads_count * iterations
     distinct = set(results)
-    assert distinct == {expected}, (
-        f"inconsistent versions returned (stream corruption): {distinct}"
-    )
+    assert distinct == {
+        expected
+    }, f"inconsistent versions returned (stream corruption): {distinct}"

--- a/playout/tests/liquidsoap/client/connection_close_test.py
+++ b/playout/tests/liquidsoap/client/connection_close_test.py
@@ -6,7 +6,13 @@ went stale and the next __exit__ bubbled OSError out of the `with` block,
 leaving the client unusable. close() now swallows OSError during the shutdown
 handshake; these tests pin that contract and verify a subsequent connect()
 succeeds.
+
+These tests deliberately reach into LiquidsoapConnection._sock to break the
+underlying FD — that is the only way to deterministically reproduce the
+stale-socket scenario in unit-test time.
 """
+
+# pylint: disable=protected-access
 
 import socket
 import threading

--- a/playout/tests/liquidsoap/client/connection_close_test.py
+++ b/playout/tests/liquidsoap/client/connection_close_test.py
@@ -18,9 +18,7 @@ from libretime_playout.liquidsoap.client import LiquidsoapConnection
 
 
 @pytest.fixture(name="tcp_server")
-def tcp_server_fixture() -> Generator[
-    Tuple[str, int, List[socket.socket]], None, None
-]:
+def tcp_server_fixture() -> Generator[Tuple[str, int, List[socket.socket]], None, None]:
     """A minimal TCP server that accepts connections and stays silent.
 
     Yields ``(host, port, accepted)`` where ``accepted`` is the running list of

--- a/playout/tests/liquidsoap/client/connection_close_test.py
+++ b/playout/tests/liquidsoap/client/connection_close_test.py
@@ -1,0 +1,137 @@
+"""
+Regression tests for LiquidsoapConnection.close() resilience.
+
+The original symptom: when liquidsoap was restarted, the existing connection
+went stale and the next __exit__ bubbled OSError out of the `with` block,
+leaving the client unusable. close() now swallows OSError during the shutdown
+handshake; these tests pin that contract and verify a subsequent connect()
+succeeds.
+"""
+
+import socket
+import threading
+from typing import Generator, List, Tuple
+
+import pytest
+
+from libretime_playout.liquidsoap.client import LiquidsoapConnection
+
+
+@pytest.fixture(name="tcp_server")
+def tcp_server_fixture() -> Generator[
+    Tuple[str, int, List[socket.socket]], None, None
+]:
+    """A minimal TCP server that accepts connections and stays silent.
+
+    Yields ``(host, port, accepted)`` where ``accepted`` is the running list of
+    server-side sockets — the test can close them to simulate a peer that went
+    away.
+    """
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(5)
+    host, port = server.getsockname()
+
+    accepted: List[socket.socket] = []
+    stop = threading.Event()
+
+    def accept_loop() -> None:
+        server.settimeout(0.2)
+        while not stop.is_set():
+            try:
+                conn, _ = server.accept()
+            except (socket.timeout, OSError):
+                continue
+            accepted.append(conn)
+
+    thread = threading.Thread(target=accept_loop, daemon=True)
+    thread.start()
+
+    try:
+        yield host, port, accepted
+    finally:
+        stop.set()
+        server.close()
+        thread.join(timeout=1)
+        for conn in accepted:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+
+def _wait_for_accept(accepted: List[socket.socket], expected: int) -> None:
+    for _ in range(50):
+        if len(accepted) >= expected:
+            return
+        threading.Event().wait(0.05)
+    raise AssertionError(
+        f"server only accepted {len(accepted)} of {expected} connections"
+    )
+
+
+def test_close_does_not_raise_when_underlying_socket_is_broken(tcp_server):
+    host, port, _ = tcp_server
+    conn = LiquidsoapConnection(host=host, port=port, timeout=2)
+    conn.connect()
+
+    # Break the FD out from under the connection — sendall/recv inside close()
+    # will raise OSError(EBADF). The fix must swallow it.
+    conn._sock.close()  # type: ignore[union-attr]
+
+    conn.close()
+    assert conn._sock is None
+
+
+def test_context_manager_exit_does_not_raise_on_stale_socket(tcp_server):
+    """The original symptom: __exit__ raised OSError after liquidsoap restarted."""
+    host, port, _ = tcp_server
+    conn = LiquidsoapConnection(host=host, port=port, timeout=2)
+
+    with conn:
+        # Simulate the peer disappearing while we hold the connection open.
+        conn._sock.close()  # type: ignore[union-attr]
+    # Falling out of the `with` must not raise.
+
+    assert conn._sock is None
+
+
+def test_close_does_not_raise_after_peer_disconnect(tcp_server):
+    """Simulate a liquidsoap restart by closing the server-side socket."""
+    host, port, accepted = tcp_server
+    conn = LiquidsoapConnection(host=host, port=port, timeout=2)
+    conn.connect()
+
+    _wait_for_accept(accepted, 1)
+    accepted[0].close()
+
+    conn.close()
+    assert conn._sock is None
+
+
+def test_connect_succeeds_after_stale_socket_close(tcp_server):
+    """The point of the fix: the connection must remain reusable."""
+    host, port, accepted = tcp_server
+    conn = LiquidsoapConnection(host=host, port=port, timeout=2)
+
+    conn.connect()
+    _wait_for_accept(accepted, 1)
+    conn._sock.close()  # type: ignore[union-attr]
+    conn.close()
+
+    conn.connect()
+    _wait_for_accept(accepted, 2)
+    assert conn._sock is not None
+    conn.close()
+
+
+def test_close_is_idempotent_after_break(tcp_server):
+    host, port, _ = tcp_server
+    conn = LiquidsoapConnection(host=host, port=port, timeout=2)
+    conn.connect()
+    conn._sock.close()  # type: ignore[union-attr]
+
+    conn.close()
+    conn.close()  # second close must be a no-op, not raise
+    assert conn._sock is None


### PR DESCRIPTION
### Description

I have an issue with several of my stations, when after weeks of automated operation, the playout would start playing (roughly) every second song with silence in between. Logfile analysis traced it to the liquidsoap process having been restarted a few days earlier and the programmed playlist running out of items eventually. The' emergency' top-up would only produce holes in between the items. While fixing the issue (the telnet connection going stale and not triggering a reconnect) i also noticed 3 processes use the same client without locking. I deducted this may be another reasonf or the connection going stale and added locking, making it essentially thread safe.

**This is a new feature**:

No

**I have updated the documentation to reflect these changes**:

No

### Testing Notes

**What I did:**

Restarted system with patch and forced the disconnect. System reconnected.

**How you can replicate my testing:**

The conenction between playout and liquidsoap should be reconnected on transient connection losses. Restart liquidsoap process and observe log 
