### PR TITLE
fix(legacy): last played at was not taken into consideration when repeatedly filling an autoplaylist with short smartblock segments.

### DIFF
--- a/api/libretime_api/legacy/migrations/0047_add_cc_schedule_starts_index.py
+++ b/api/libretime_api/legacy/migrations/0047_add_cc_schedule_starts_index.py
@@ -1,0 +1,27 @@
+# pylint: disable=invalid-name
+
+from django.db import migrations
+
+from ._migrations import legacy_migration_factory
+
+UP = """
+CREATE INDEX IF NOT EXISTS cc_schedule_starts_idx ON cc_schedule (starts);
+"""
+
+DOWN = """
+DROP INDEX IF EXISTS cc_schedule_starts_idx;
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("legacy", "0046_add_override_intro_outro_playlists"),
+    ]
+    operations = [
+        migrations.RunPython(
+            code=legacy_migration_factory(
+                target="47",
+                sql=UP,
+            )
+        )
+    ]

--- a/api/libretime_api/legacy/migrations/__init__.py
+++ b/api/libretime_api/legacy/migrations/__init__.py
@@ -1,2 +1,2 @@
 # The schema version is defined using the migration file prefix number
-LEGACY_SCHEMA_VERSION = "46"
+LEGACY_SCHEMA_VERSION = "47"

--- a/api/libretime_api/legacy/migrations/sql/schema.sql
+++ b/api/libretime_api/legacy/migrations/sql/schema.sql
@@ -356,6 +356,8 @@ CREATE TABLE "cc_schedule"
 
 CREATE INDEX "cc_schedule_instance_id_idx" ON "cc_schedule" ("instance_id");
 
+CREATE INDEX "cc_schedule_starts_idx" ON "cc_schedule" ("starts");
+
 -----------------------------------------------------------------------
 -- cc_subjs
 -----------------------------------------------------------------------

--- a/legacy/application/models/Block.php
+++ b/legacy/application/models/Block.php
@@ -1672,16 +1672,6 @@ SQL;
         // [threshold, slot) window as the lptime SQL predicate.
         $hasLptimeCriterion = isset($storedCrit['crit']['lptime']);
         $lptimeScopedExcludes = [];
-        $lptimeInPassExcludes = [];
-
-        Logging::info(sprintf(
-            '[smartblock-lptime] block_id=%s hasLptimeCriterion=%s threshold=%s slotArg=%s inPassCount=%d',
-            (string) $this->id,
-            $hasLptimeCriterion ? 'yes' : 'no',
-            $lptimeEarliestThreshold instanceof DateTime ? $lptimeEarliestThreshold->format('c') : 'null',
-            $showStartTime instanceof DateTime ? $showStartTime->format('c') : 'null',
-            count($inPassPicks)
-        ));
 
         if ($hasLptimeCriterion && $lptimeEarliestThreshold !== null) {
             $slotBoundary = $showStartTime instanceof DateTime
@@ -1702,7 +1692,6 @@ SQL;
                 $pickSlotUtc = clone $pick['slot'];
                 $pickSlotUtc->setTimezone(new DateTimeZone('UTC'));
                 if ($pickSlotUtc >= $thresholdUtc && $pickSlotUtc < $slotBoundary) {
-                    $lptimeInPassExcludes[] = (int) $pick['id'];
                     $lptimeScopedExcludes[] = (int) $pick['id'];
                 }
             }
@@ -1722,32 +1711,13 @@ SQL;
                     ':slot' => $slotBoundary->format(DEFAULT_MICROTIME_FORMAT),
                 ]
             );
-            $scheduledIds = [];
             foreach ($scheduledRows as $scheduledRow) {
                 $lptimeScopedExcludes[] = (int) $scheduledRow['file_id'];
-                $scheduledIds[] = (int) $scheduledRow['file_id'];
             }
-
-            Logging::info(sprintf(
-                '[smartblock-lptime] block_id=%s window=[%s, %s) thresholdUtc=%s slotUtc=%s inPassExcludes=%s scheduleExcludes=%s',
-                (string) $this->id,
-                $thresholdUtc->format(DEFAULT_MICROTIME_FORMAT),
-                $slotBoundary->format(DEFAULT_MICROTIME_FORMAT),
-                $thresholdUtc->format('c'),
-                $slotBoundary->format('c'),
-                empty($lptimeInPassExcludes) ? '[]' : '[' . implode(',', $lptimeInPassExcludes) . ']',
-                empty($scheduledIds) ? '[]' : '[' . implode(',', $scheduledIds) . ']'
-            ));
         }
 
         if (!empty($lptimeScopedExcludes)) {
-            $finalExcludes = array_values(array_unique($lptimeScopedExcludes));
-            Logging::info(sprintf(
-                '[smartblock-lptime] block_id=%s applying NOT IN (%s)',
-                (string) $this->id,
-                implode(',', $finalExcludes)
-            ));
-            $qry->add('cc_files.id', $finalExcludes, Criteria::NOT_IN);
+            $qry->add('cc_files.id', array_values(array_unique($lptimeScopedExcludes)), Criteria::NOT_IN);
         }
 
         // check if file exists

--- a/legacy/application/models/Block.php
+++ b/legacy/application/models/Block.php
@@ -1696,7 +1696,7 @@ SQL;
                 if (!is_array($pick) || !isset($pick['id'], $pick['slot'])) {
                     continue;
                 }
-                if (!($pick['slot'] instanceof DateTime)) {
+                if (!$pick['slot'] instanceof DateTime) {
                     continue;
                 }
                 $pickSlotUtc = clone $pick['slot'];

--- a/legacy/application/models/Block.php
+++ b/legacy/application/models/Block.php
@@ -1295,9 +1295,9 @@ SQL;
         }
     }
 
-    public function getListOfFilesUnderLimit($show = null, $showStartTime = null)
+    public function getListOfFilesUnderLimit($show = null, $showStartTime = null, array $inPassPicks = [])
     {
-        $info = $this->getListofFilesMeetCriteria($show, $showStartTime);
+        $info = $this->getListofFilesMeetCriteria($show, $showStartTime, $inPassPicks);
         $files = $info['files'];
         $limit = $info['limit'];
         $repeat = $info['repeat_tracks'] == 1;
@@ -1480,6 +1480,31 @@ SQL;
         return $storedCrit;
     }
 
+    /**
+     * Resolve a criterion date value against $base (falls back to "now").
+     *
+     * @param mixed         $value Absolute date string, or relative like "5 hours ago"
+     * @param null|DateTime $base  Anchor used for relative expressions
+     */
+    private static function parseRelativeOrAbsoluteDate($value, ?DateTime $base): DateTime
+    {
+        $trimmed = is_string($value) ? trim($value) : $value;
+
+        $isRelative = is_string($trimmed) && (
+            preg_match('/\bago\b\s*$/i', $trimmed)
+            || preg_match('/^[+\-]/', $trimmed)
+        );
+
+        if ($isRelative && $base instanceof DateTime) {
+            $dt = clone $base;
+            $dt->modify($trimmed);
+
+            return $dt;
+        }
+
+        return new DateTime($trimmed);
+    }
+
     private function resolveDate($value, ?DateTime $resolveTo, string $timeZone)
     {
         if (!is_string($value)) {
@@ -1496,8 +1521,17 @@ SQL;
         );
     }
 
-    // this function return list of propel object
-    public function getListofFilesMeetCriteria($showLimit = null, $showStartTime = null)
+    /**
+     * Return the candidate file set for this smart block.
+     *
+     * @param null|int      $showLimit     seconds remaining in the show instance
+     * @param null|DateTime $showStartTime slot being populated; anchors relative dates
+     * @param array         $inPassPicks   tuples ['id' => int, 'slot' => DateTime]
+     *                                     of files already picked in this scheduling
+     *                                     pass (honored only when an lptime criterion
+     *                                     is active)
+     */
+    public function getListofFilesMeetCriteria($showLimit = null, $showStartTime = null, array $inPassPicks = [])
     {
         $storedCrit = $this->getCriteria();
 
@@ -1506,6 +1540,9 @@ SQL;
 
         $allCriteria = BlockCriteria::criteriaMap();
         $timeZone = Application_Model_Preference::GetDefaultTimezone();
+
+        // earliest lptime BEFORE threshold, used for the scheduled-item exclusion below
+        $lptimeEarliestThreshold = null;
 
         // Logging::info($storedCrit);
         if (isset($storedCrit['crit'])) {
@@ -1575,19 +1612,26 @@ SQL;
                     } elseif ($spCriteriaModifier == CriteriaModifier::IS_IN_THE_RANGE) {
                         $spCriteriaValue = "{$spCriteria} >= '{$spCriteriaValue}' AND {$spCriteria} <= '{$spCriteriaExtra}'";
                     } elseif ($spCriteriaModifier == CriteriaModifier::BEFORE) {
-                        // need to pull in the current time and subtract the value or figure out how to make it relative
-                        $relativedate = new DateTime($spCriteriaValue);
+                        // anchor relative values ("5 hours ago") to the slot, not wallclock now
+                        $relativedate = self::parseRelativeOrAbsoluteDate($spCriteriaValue, $showStartTime);
                         $dt = $relativedate->format(DateTime::ISO8601);
                         $spCriteriaValue = "COALESCE({$spCriteria}, DATE '-infinity') <= '{$dt}'";
+
+                        if ($spCriteria === 'lptime') {
+                            if ($lptimeEarliestThreshold === null
+                                || $relativedate < $lptimeEarliestThreshold) {
+                                $lptimeEarliestThreshold = $relativedate;
+                            }
+                        }
                     } elseif ($spCriteriaModifier == CriteriaModifier::AFTER) {
-                        $relativedate = new DateTime($spCriteriaValue);
+                        $relativedate = self::parseRelativeOrAbsoluteDate($spCriteriaValue, $showStartTime);
                         $dt = $relativedate->format(DateTime::ISO8601);
                         $spCriteriaValue = "COALESCE({$spCriteria}, DATE '-infinity') >= '{$dt}'";
                     } elseif ($spCriteriaModifier == CriteriaModifier::BETWEEN) {
-                        $fromrelativedate = new DateTime($spCriteriaValue);
+                        $fromrelativedate = self::parseRelativeOrAbsoluteDate($spCriteriaValue, $showStartTime);
                         $fdt = $fromrelativedate->format(DateTime::ISO8601);
 
-                        $torelativedate = new DateTime($spCriteriaExtra);
+                        $torelativedate = self::parseRelativeOrAbsoluteDate($spCriteriaExtra, $showStartTime);
                         $tdt = $torelativedate->format(DateTime::ISO8601);
                         $spCriteriaValue = "COALESCE({$spCriteria}, DATE '-infinity') >= '{$fdt}' AND COALESCE({$spCriteria}, DATE '-infinity') <= '{$tdt}'";
                     }
@@ -1621,6 +1665,89 @@ SQL;
                     ++$i;
                 }
             }
+        }
+
+        // Duplicate-prevention is gated on an active lptime BEFORE criterion.
+        // In-pass picks and queued cc_schedule rows are filtered by the same
+        // [threshold, slot) window as the lptime SQL predicate.
+        $hasLptimeCriterion = isset($storedCrit['crit']['lptime']);
+        $lptimeScopedExcludes = [];
+        $lptimeInPassExcludes = [];
+
+        Logging::info(sprintf(
+            '[smartblock-lptime] block_id=%s hasLptimeCriterion=%s threshold=%s slotArg=%s inPassCount=%d',
+            (string) $this->id,
+            $hasLptimeCriterion ? 'yes' : 'no',
+            $lptimeEarliestThreshold instanceof DateTime ? $lptimeEarliestThreshold->format('c') : 'null',
+            $showStartTime instanceof DateTime ? $showStartTime->format('c') : 'null',
+            count($inPassPicks)
+        ));
+
+        if ($hasLptimeCriterion && $lptimeEarliestThreshold !== null) {
+            $slotBoundary = $showStartTime instanceof DateTime
+                ? clone $showStartTime
+                : new DateTime('now', new DateTimeZone('UTC'));
+            $slotBoundary->setTimezone(new DateTimeZone('UTC'));
+
+            $thresholdUtc = clone $lptimeEarliestThreshold;
+            $thresholdUtc->setTimezone(new DateTimeZone('UTC'));
+
+            foreach ($inPassPicks as $pick) {
+                if (!is_array($pick) || !isset($pick['id'], $pick['slot'])) {
+                    continue;
+                }
+                if (!($pick['slot'] instanceof DateTime)) {
+                    continue;
+                }
+                $pickSlotUtc = clone $pick['slot'];
+                $pickSlotUtc->setTimezone(new DateTimeZone('UTC'));
+                if ($pickSlotUtc >= $thresholdUtc && $pickSlotUtc < $slotBoundary) {
+                    $lptimeInPassExcludes[] = (int) $pick['id'];
+                    $lptimeScopedExcludes[] = (int) $pick['id'];
+                }
+            }
+
+            $scheduledSql = <<<'SQL'
+SELECT DISTINCT file_id
+FROM cc_schedule
+WHERE file_id IS NOT NULL
+  AND playout_status != -1
+  AND starts >= :threshold
+  AND starts <  :slot
+SQL;
+            $scheduledRows = Application_Common_Database::prepareAndExecute(
+                $scheduledSql,
+                [
+                    ':threshold' => $thresholdUtc->format(DEFAULT_MICROTIME_FORMAT),
+                    ':slot' => $slotBoundary->format(DEFAULT_MICROTIME_FORMAT),
+                ]
+            );
+            $scheduledIds = [];
+            foreach ($scheduledRows as $scheduledRow) {
+                $lptimeScopedExcludes[] = (int) $scheduledRow['file_id'];
+                $scheduledIds[] = (int) $scheduledRow['file_id'];
+            }
+
+            Logging::info(sprintf(
+                '[smartblock-lptime] block_id=%s window=[%s, %s) thresholdUtc=%s slotUtc=%s inPassExcludes=%s scheduleExcludes=%s',
+                (string) $this->id,
+                $thresholdUtc->format(DEFAULT_MICROTIME_FORMAT),
+                $slotBoundary->format(DEFAULT_MICROTIME_FORMAT),
+                $thresholdUtc->format('c'),
+                $slotBoundary->format('c'),
+                empty($lptimeInPassExcludes) ? '[]' : '[' . implode(',', $lptimeInPassExcludes) . ']',
+                empty($scheduledIds) ? '[]' : '[' . implode(',', $scheduledIds) . ']'
+            ));
+        }
+
+        if (!empty($lptimeScopedExcludes)) {
+            $finalExcludes = array_values(array_unique($lptimeScopedExcludes));
+            Logging::info(sprintf(
+                '[smartblock-lptime] block_id=%s applying NOT IN (%s)',
+                (string) $this->id,
+                implode(',', $finalExcludes)
+            ));
+            $qry->add('cc_files.id', $finalExcludes, Criteria::NOT_IN);
         }
 
         // check if file exists

--- a/legacy/application/models/Scheduler.php
+++ b/legacy/application/models/Scheduler.php
@@ -867,9 +867,11 @@ final class Application_Model_Scheduler
                     if (is_null($filesToInsert)) {
                         $filesToInsert = [];
                         foreach ($mediaItems as $media) {
+                            $slotCursor = clone $nextStartDT;
+                            $slotCursor->modify('+' . (int) round($this->timeLengthOfFiles($filesToInsert)) . ' seconds');
                             $filesToInsert = array_merge(
                                 $filesToInsert,
-                                $this->retrieveMediaFiles($media['id'], $media['type'], $schedule['instance'], $nextStartDT)
+                                $this->retrieveMediaFiles($media['id'], $media['type'], $schedule['instance'], $slotCursor)
                             );
                         }
                     }

--- a/legacy/application/models/Scheduler.php
+++ b/legacy/application/models/Scheduler.php
@@ -254,6 +254,7 @@ final class Application_Model_Scheduler
             $data['fadein'] = Application_Model_Preference::GetDefaultFadeIn();
             $data['fadeout'] = Application_Model_Preference::GetDefaultFadeOut();
 
+            $this->trackInPassPick((int) $id, $showStart, $files);
             $files[] = $data;
         } elseif ($type === 'playlist') {
             $pl = new Application_Model_Playlist($id);
@@ -269,6 +270,7 @@ final class Application_Model_Scheduler
                     $data['fadein'] = $plItem['fadein'];
                     $data['fadeout'] = $plItem['fadeout'];
                     $data['type'] = 0;
+                    $this->trackInPassPick((int) $plItem['item_id'], $showStart, $files);
                     $files[] = $data;
                 } elseif ($plItem['type'] == 1) {
                     $data['id'] = $plItem['item_id'];
@@ -291,6 +293,7 @@ final class Application_Model_Scheduler
                             $data['fadein'] = $track['fadein'];
                             $data['fadeout'] = $track['fadeout'];
                             $data['type'] = 0;
+                            $this->trackInPassPick((int) $track['item_id'], $showStart, $files);
                             $files[] = $data;
                         }
                     } else {
@@ -366,6 +369,7 @@ final class Application_Model_Scheduler
                     $data['fadein'] = $track['fadein'];
                     $data['fadeout'] = $track['fadeout'];
                     $data['type'] = 0;
+                    $this->trackInPassPick((int) $track['item_id'], $showStart, $files);
                     $files[] = $data;
                 }
             } else {
@@ -1387,6 +1391,23 @@ final class Application_Model_Scheduler
             fn ($acc, $file) => $acc + Application_Common_DateHelper::playlistTimeToSeconds($file['cliplength']),
             0.0
         );
+    }
+
+    /**
+     * Record a non-dynamic-block pick so later smart blocks in the same
+     * pass see it via their lptime exclusion window. Skip non-file ids
+     * (streams) — the exclusion targets cc_files.
+     *
+     * Slot is anchored at $showStart + accumulated duration of $filesBefore.
+     */
+    private function trackInPassPick(int $fileId, DateTime $showStart, array $filesBefore): void
+    {
+        $slot = clone $showStart;
+        $slot->modify('+' . (int) round($this->timeLengthOfFiles($filesBefore)) . ' seconds');
+        $this->scheduledInPassPicks[] = [
+            'id' => $fileId,
+            'slot' => $slot,
+        ];
     }
 
     /*

--- a/legacy/application/models/Scheduler.php
+++ b/legacy/application/models/Scheduler.php
@@ -23,6 +23,14 @@ final class Application_Model_Scheduler
 
     private $checkUserPermissions = true;
 
+    /**
+     * Files picked this pass with their approximate airing slot, consumed by
+     * later smart blocks in the same pass that have an lptime criterion.
+     *
+     * @var array<int, array{id:int, slot:DateTime}>
+     */
+    private $scheduledInPassPicks = [];
+
     public function __construct($checkUserPermissions = true)
     {
         $this->con = Propel::getConnection(CcSchedulePeer::DATABASE_NAME);
@@ -214,12 +222,13 @@ final class Application_Model_Scheduler
      *
      * @return $files
      */
-    private function retrieveMediaFiles($id, $type, $show)
+    private function retrieveMediaFiles($id, $type, $show, ?DateTime $slotStart = null)
     {
         // if there is a show we need to set a show limit to pass to smart blocks in case they use time remaining
         $showInstance = new Application_Model_ShowInstance($show);
         $showLimit = $showInstance->getSecondsRemaining();
-        $showStart = $showInstance->getShowInstanceStart(null);
+        // prefer the actual slot so lptime criteria anchor to airtime, not wallclock now
+        $showStart = $slotStart ?: $showInstance->getShowInstanceStart(null);
         $originalShowLimit = $showLimit;
 
         $files = [];
@@ -287,7 +296,13 @@ final class Application_Model_Scheduler
                     } else {
                         $defaultFadeIn = Application_Model_Preference::GetDefaultFadeIn();
                         $defaultFadeOut = Application_Model_Preference::GetDefaultFadeOut();
-                        $dynamicFiles = $bl->getListOfFilesUnderLimit($showLimit, $showStart);
+
+                        // block start = overall slot + duration of items already staged
+                        $blockStart = clone $showStart;
+                        $blockStart->modify('+' . (int) round($this->timeLengthOfFiles($files)) . ' seconds');
+
+                        $dynamicFiles = $bl->getListOfFilesUnderLimit($showLimit, $blockStart, $this->scheduledInPassPicks);
+                        $withinBlockOffset = 0.0;
                         foreach ($dynamicFiles as $f) {
                             $fileId = $f['id'];
                             $file = CcFilesQuery::create()->findPk($fileId);
@@ -306,6 +321,14 @@ final class Application_Model_Scheduler
 
                                 $data['type'] = 0;
                                 $files[] = $data;
+
+                                $fileSlot = clone $blockStart;
+                                $fileSlot->modify('+' . (int) round($withinBlockOffset) . ' seconds');
+                                $this->scheduledInPassPicks[] = [
+                                    'id' => (int) $file->getDbId(),
+                                    'slot' => $fileSlot,
+                                ];
+                                $withinBlockOffset += isset($f['length']) ? (float) $f['length'] : 0.0;
                             }
                         }
                     }
@@ -348,7 +371,8 @@ final class Application_Model_Scheduler
             } else {
                 $defaultFadeIn = Application_Model_Preference::GetDefaultFadeIn();
                 $defaultFadeOut = Application_Model_Preference::GetDefaultFadeOut();
-                $dynamicFiles = $bl->getListOfFilesUnderLimit($showLimit, $showStart);
+                $dynamicFiles = $bl->getListOfFilesUnderLimit($showLimit, $showStart, $this->scheduledInPassPicks);
+                $withinBlockOffset = 0.0;
                 foreach ($dynamicFiles as $f) {
                     $fileId = $f['id'];
                     $file = CcFilesQuery::create()->findPk($fileId);
@@ -367,6 +391,14 @@ final class Application_Model_Scheduler
 
                         $data['type'] = 0;
                         $files[] = $data;
+
+                        $fileSlot = clone $showStart;
+                        $fileSlot->modify('+' . (int) round($withinBlockOffset) . ' seconds');
+                        $this->scheduledInPassPicks[] = [
+                            'id' => (int) $file->getDbId(),
+                            'slot' => $fileSlot,
+                        ];
+                        $withinBlockOffset += isset($f['length']) ? (float) $f['length'] : 0.0;
                     }
                 }
             }
@@ -628,6 +660,9 @@ final class Application_Model_Scheduler
             // temporary fix for CC-5665
             set_time_limit(180);
 
+            // fresh in-pass tracker per insertAfter call
+            $this->scheduledInPassPicks = [];
+
             $affectedShowInstances = [];
 
             // dont want to recalculate times for moved items
@@ -830,7 +865,7 @@ final class Application_Model_Scheduler
                         foreach ($mediaItems as $media) {
                             $filesToInsert = array_merge(
                                 $filesToInsert,
-                                $this->retrieveMediaFiles($media['id'], $media['type'], $schedule['instance'])
+                                $this->retrieveMediaFiles($media['id'], $media['type'], $schedule['instance'], $nextStartDT)
                             );
                         }
                     }

--- a/legacy/build/schema.xml
+++ b/legacy/build/schema.xml
@@ -351,6 +351,9 @@
     <index name="cc_schedule_instance_id_idx">
       <index-column name="instance_id" />
     </index>
+    <index name="cc_schedule_starts_idx">
+      <index-column name="starts" />
+    </index>
   </table>
   <table name="cc_subjs" phpName="CcSubjs">
     <column name="id" phpName="DbId" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />

--- a/legacy/tests/application/models/database/BlockLptimeDbTest.php
+++ b/legacy/tests/application/models/database/BlockLptimeDbTest.php
@@ -1,0 +1,215 @@
+<?php
+
+/**
+ * Tests for the lptime-scoped duplicate suppression in
+ * Application_Model_Block::getListofFilesMeetCriteria — covers anchoring
+ * relative dates to $showStartTime and excluding in-pass picks and
+ * scheduled cc_schedule rows whose airtime falls in [threshold, slot).
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+class BlockLptimeDbTest extends Zend_Test_PHPUnit_DatabaseTestCase
+{
+    private $_connectionMock;
+
+    public function setUp()
+    {
+        TestHelper::installTestDatabase();
+        TestHelper::setupZendBootstrap();
+        parent::setUp();
+    }
+
+    public function getConnection()
+    {
+        if ($this->_connectionMock == null) {
+            $config = TestHelper::getDbZendConfig();
+            $connection = Zend_Db::factory('pdo_pgsql', $config);
+            $this->_connectionMock = $this->createZendDbConnection(
+                $connection,
+                'airtimeunittests'
+            );
+            Zend_Db_Table_Abstract::setDefaultAdapter($connection);
+        }
+
+        return $this->_connectionMock;
+    }
+
+    public function getDataSet()
+    {
+        return new PHPUnit_Extensions_Database_DataSet_YamlDataSet(
+            __DIR__ . '/datasets/seed_block_lptime.yml'
+        );
+    }
+
+    private function buildBlock(array $criteria)
+    {
+        $block = new Application_Model_Block();
+        $block->saveSmartBlockCriteria($criteria);
+
+        return $block;
+    }
+
+    private static function slotStart(): DateTime
+    {
+        return new DateTime('2024-01-10 12:00:00', new DateTimeZone('UTC'));
+    }
+
+    private static function extractIds(array $files): array
+    {
+        $ids = [];
+        foreach ($files as $file) {
+            $ids[] = (int) $file['id'];
+        }
+        sort($ids);
+
+        return $ids;
+    }
+
+    /**
+     * lptime BEFORE "1 hour ago" must anchor to $showStartTime, not wallclock now.
+     * With slot = 2024-01-10 12:00 UTC the threshold is 11:00 UTC — file 102
+     * (lptime 11:30) sits inside the excluded window and must be dropped;
+     * the other three (old / NULL / 10:30) must remain eligible.
+     */
+    public function testLptimeBeforeAnchorsToShowStartTime()
+    {
+        TestHelper::loginUser();
+
+        $block = $this->buildBlock(BlockModelData::getCriteriaLptimeBefore1Hour());
+        $files = $block->getListOfFilesUnderLimit(null, self::slotStart());
+
+        $this->assertEquals([101, 103, 104], self::extractIds($files));
+    }
+
+    /**
+     * In-pass picks whose computed slot is inside [threshold, slot) must be
+     * filtered out as if they were already in cc_schedule.
+     */
+    public function testInPassPicksWithinWindowAreExcluded()
+    {
+        TestHelper::loginUser();
+
+        $block = $this->buildBlock(BlockModelData::getCriteriaLptimeBefore1Hour());
+
+        $inPassPicks = [
+            [
+                'id' => 101,
+                'slot' => new DateTime('2024-01-10 11:30:00', new DateTimeZone('UTC')),
+            ],
+        ];
+        $files = $block->getListOfFilesUnderLimit(null, self::slotStart(), $inPassPicks);
+
+        $this->assertEquals([103, 104], self::extractIds($files));
+    }
+
+    /**
+     * In-pass picks whose slot falls outside [threshold, slot) must NOT be
+     * filtered: too-old picks (before threshold) and picks at/after the slot
+     * boundary are out of scope for duplicate prevention against this slot.
+     */
+    public function testInPassPicksOutsideWindowAreKept()
+    {
+        TestHelper::loginUser();
+
+        $block = $this->buildBlock(BlockModelData::getCriteriaLptimeBefore1Hour());
+
+        $inPassPicks = [
+            // before threshold (11:00) — out of scope
+            [
+                'id' => 101,
+                'slot' => new DateTime('2024-01-10 10:00:00', new DateTimeZone('UTC')),
+            ],
+            // at slot boundary (window is half-open) — out of scope
+            [
+                'id' => 103,
+                'slot' => new DateTime('2024-01-10 12:00:00', new DateTimeZone('UTC')),
+            ],
+        ];
+        $files = $block->getListOfFilesUnderLimit(null, self::slotStart(), $inPassPicks);
+
+        $this->assertEquals([101, 103, 104], self::extractIds($files));
+    }
+
+    /**
+     * cc_schedule rows whose starts fall in [threshold, slot) with an active
+     * playout_status must be excluded from the candidate set, even though
+     * they haven't aired yet (and so haven't updated cc_files.lptime).
+     */
+    public function testScheduledRowsWithinWindowAreExcluded()
+    {
+        TestHelper::loginUser();
+
+        $sched = new CcSchedule();
+        $sched->setDbStarts('2024-01-10 11:30:00')
+            ->setDbEnds('2024-01-10 11:31:00')
+            ->setDbFileId(104)
+            ->setDbCueIn('00:00:00')
+            ->setDbCueOut('00:01:00')
+            ->setDbClipLength('00:01:00')
+            ->setDbInstanceId(1)
+            ->setDbPlayoutStatus(1)
+            ->setDbBroadcasted(0)
+            ->setDbPosition(0)
+            ->save();
+
+        $block = $this->buildBlock(BlockModelData::getCriteriaLptimeBefore1Hour());
+        $files = $block->getListOfFilesUnderLimit(null, self::slotStart());
+
+        $this->assertEquals([101, 103], self::extractIds($files));
+    }
+
+    /**
+     * cc_schedule rows whose starts fall in the window but whose
+     * playout_status is -1 (cancelled / filler) must NOT be excluded.
+     */
+    public function testCancelledScheduledRowsAreNotExcluded()
+    {
+        TestHelper::loginUser();
+
+        $sched = new CcSchedule();
+        $sched->setDbStarts('2024-01-10 11:30:00')
+            ->setDbEnds('2024-01-10 11:31:00')
+            ->setDbFileId(104)
+            ->setDbCueIn('00:00:00')
+            ->setDbCueOut('00:01:00')
+            ->setDbClipLength('00:01:00')
+            ->setDbInstanceId(1)
+            ->setDbPlayoutStatus(-1)
+            ->setDbBroadcasted(0)
+            ->setDbPosition(0)
+            ->save();
+
+        $block = $this->buildBlock(BlockModelData::getCriteriaLptimeBefore1Hour());
+        $files = $block->getListOfFilesUnderLimit(null, self::slotStart());
+
+        $this->assertEquals([101, 103, 104], self::extractIds($files));
+    }
+
+    /**
+     * Without an lptime BEFORE criterion the in-pass / cc_schedule
+     * suppression must not kick in — the gate is the lptime criterion,
+     * not the presence of $inPassPicks.
+     */
+    public function testInPassPicksIgnoredWithoutLptimeCriterion()
+    {
+        TestHelper::loginUser();
+
+        $block = $this->buildBlock(BlockModelData::getCriteriaLabelOnly());
+
+        $inPassPicks = [
+            [
+                'id' => 101,
+                'slot' => new DateTime('2024-01-10 11:30:00', new DateTimeZone('UTC')),
+            ],
+            [
+                'id' => 102,
+                'slot' => new DateTime('2024-01-10 11:45:00', new DateTimeZone('UTC')),
+            ],
+        ];
+        $files = $block->getListOfFilesUnderLimit(null, self::slotStart(), $inPassPicks);
+
+        $this->assertEquals([101, 102, 103, 104], self::extractIds($files));
+    }
+}

--- a/legacy/tests/application/models/database/datasets/seed_block_lptime.yml
+++ b/legacy/tests/application/models/database/datasets/seed_block_lptime.yml
@@ -1,0 +1,120 @@
+cc_files:
+  - id: "101"
+    mime: "audio/mp3"
+    ftype: "audioclip"
+    filepath: "imported/1/lptime_old.mp3"
+    mtime: "2024-01-01 00:00:00"
+    utime: "2024-01-01 00:00:00"
+    lptime: "2024-01-01 00:00:00"
+    track_title: "lptime_old"
+    bit_rate: "320000"
+    sample_rate: "44100"
+    length: "00:01:00"
+    channels: "2"
+    genre: "test"
+    label: "nada"
+    owner_id: "1"
+    file_exists: "t"
+    hidden: "f"
+    silan_check: "f"
+    is_scheduled: "f"
+    is_playlist: "f"
+    filesize: "2586748"
+
+  - id: "102"
+    mime: "audio/mp3"
+    ftype: "audioclip"
+    filepath: "imported/1/lptime_recent.mp3"
+    mtime: "2024-01-01 00:00:00"
+    utime: "2024-01-01 00:00:00"
+    lptime: "2024-01-10 11:30:00"
+    track_title: "lptime_recent"
+    bit_rate: "320000"
+    sample_rate: "44100"
+    length: "00:01:00"
+    channels: "2"
+    genre: "test"
+    label: "nada"
+    owner_id: "1"
+    file_exists: "t"
+    hidden: "f"
+    silan_check: "f"
+    is_scheduled: "f"
+    is_playlist: "f"
+    filesize: "2586748"
+
+  - id: "103"
+    mime: "audio/mp3"
+    ftype: "audioclip"
+    filepath: "imported/1/lptime_null.mp3"
+    mtime: "2024-01-01 00:00:00"
+    utime: "2024-01-01 00:00:00"
+    lptime: null
+    track_title: "lptime_null"
+    bit_rate: "320000"
+    sample_rate: "44100"
+    length: "00:01:00"
+    channels: "2"
+    genre: "test"
+    label: "nada"
+    owner_id: "1"
+    file_exists: "t"
+    hidden: "f"
+    silan_check: "f"
+    is_scheduled: "f"
+    is_playlist: "f"
+    filesize: "2586748"
+
+  - id: "104"
+    mime: "audio/mp3"
+    ftype: "audioclip"
+    filepath: "imported/1/lptime_edge.mp3"
+    mtime: "2024-01-01 00:00:00"
+    utime: "2024-01-01 00:00:00"
+    lptime: "2024-01-10 10:30:00"
+    track_title: "lptime_edge"
+    bit_rate: "320000"
+    sample_rate: "44100"
+    length: "00:01:00"
+    channels: "2"
+    genre: "test"
+    label: "nada"
+    owner_id: "1"
+    file_exists: "t"
+    hidden: "f"
+    silan_check: "f"
+    is_scheduled: "f"
+    is_playlist: "f"
+    filesize: "2586748"
+
+cc_show:
+  - id: "1"
+    name: "lptime test show"
+    url: null
+    genre: null
+    description: null
+    color: ffffff
+    background_color: "364492"
+    live_stream_using_airtime_auth: false
+    live_stream_using_custom_auth: false
+    live_stream_user: null
+    live_stream_pass: null
+    linked: false
+    is_linkable: true
+    image_path: ""
+    has_autoplaylist: false
+    autoplaylist_id: null
+    autoplaylist_repeat: false
+    override_intro_playlist: false
+    intro_playlist_id: null
+    override_outro_playlist: false
+    outro_playlist_id: null
+
+cc_show_instances:
+  - id: "1"
+    starts: "2024-01-10 12:00:00"
+    ends: "2024-01-10 13:00:00"
+    show_id: "1"
+    modified_instance: false
+    created: "2024-01-01 00:00:00"
+    autoplaylist_built: false

--- a/legacy/tests/application/models/database/datasets/seed_block_lptime.yml
+++ b/legacy/tests/application/models/database/datasets/seed_block_lptime.yml
@@ -95,19 +95,19 @@ cc_show:
     description: null
     color: ffffff
     background_color: "364492"
-    live_stream_using_airtime_auth: false
-    live_stream_using_custom_auth: false
+    live_stream_using_airtime_auth: "f"
+    live_stream_using_custom_auth: "f"
     live_stream_user: null
     live_stream_pass: null
-    linked: false
-    is_linkable: true
+    linked: "f"
+    is_linkable: "t"
     image_path: ""
-    has_autoplaylist: false
+    has_autoplaylist: "f"
     autoplaylist_id: null
-    autoplaylist_repeat: false
-    override_intro_playlist: false
+    autoplaylist_repeat: "f"
+    override_intro_playlist: "f"
     intro_playlist_id: null
-    override_outro_playlist: false
+    override_outro_playlist: "f"
     outro_playlist_id: null
 
 cc_show_instances:
@@ -115,6 +115,6 @@ cc_show_instances:
     starts: "2024-01-10 12:00:00"
     ends: "2024-01-10 13:00:00"
     show_id: "1"
-    modified_instance: false
+    modified_instance: "f"
     created: "2024-01-01 00:00:00"
-    autoplaylist_built: false
+    autoplaylist_built: "f"

--- a/legacy/tests/application/testdata/BlockModelData.php
+++ b/legacy/tests/application/testdata/BlockModelData.php
@@ -47,4 +47,47 @@ class BlockModelData
             ['name' => 'sp_criteria_value_2_0', 'value' => '00:01:00'],
         ];
     }
+
+    /**
+     * Dynamic smart block: "label contains nada AND lptime before 1 hour ago".
+     * The lptime BEFORE clause is what activates the in-pass / cc_schedule
+     * exclusion window in getListofFilesMeetCriteria.
+     */
+    public static function getCriteriaLptimeBefore1Hour()
+    {
+        return [
+            ['name' => 'sp_type', 'value' => 0],
+            ['name' => 'sp_repeat_tracks', 'value' => 0],
+            ['name' => 'sp_sort_options', 'value' => 'random'],
+            ['name' => 'sp_limit_value', 'value' => 10],
+            ['name' => 'sp_limit_options', 'value' => 'items'],
+            ['name' => 'sp_overflow_tracks', 'value' => 0],
+            ['name' => 'sp_criteria_field_0_0', 'value' => 'label'],
+            ['name' => 'sp_criteria_modifier_0_0', 'value' => 'contains'],
+            ['name' => 'sp_criteria_value_0_0', 'value' => 'nada'],
+            ['name' => 'sp_criteria_field_1_0', 'value' => 'lptime'],
+            ['name' => 'sp_criteria_modifier_1_0', 'value' => 'before'],
+            ['name' => 'sp_criteria_value_1_0', 'value' => '1'],
+            ['name' => 'sp_criteria_datetime_select_1_0', 'value' => 'hours'],
+        ];
+    }
+
+    /**
+     * Same shape as getCriteriaLptimeBefore1Hour but without the lptime row,
+     * used to verify in-pass exclusion is gated on the lptime criterion.
+     */
+    public static function getCriteriaLabelOnly()
+    {
+        return [
+            ['name' => 'sp_type', 'value' => 0],
+            ['name' => 'sp_repeat_tracks', 'value' => 0],
+            ['name' => 'sp_sort_options', 'value' => 'random'],
+            ['name' => 'sp_limit_value', 'value' => 10],
+            ['name' => 'sp_limit_options', 'value' => 'items'],
+            ['name' => 'sp_overflow_tracks', 'value' => 0],
+            ['name' => 'sp_criteria_field_0_0', 'value' => 'label'],
+            ['name' => 'sp_criteria_modifier_0_0', 'value' => 'contains'],
+            ['name' => 'sp_criteria_value_0_0', 'value' => 'nada'],
+        ];
+    }
 }


### PR DESCRIPTION
### Description

When evaluating SmartBlocks during auto-populating playlists, the 'last played' constraint in the smart block was evaluated at runtime of the insertion process, not at actual playout time. Furthermore only songs that have actually played were taken into consideration for the suppression period, not songs scheduled between the current playout time and the insertion point. Since auto playlists run an hour before the start of the block, this would not consider songs from the previous hour (or indeed the running 'populate' process) as being 'played'. This effectively undermines repeat playout suppression with this mechanism.

**This is a new feature**:

No

**I have updated the documentation to reflect these changes**:

No

### Testing Notes

**What I did:**

I left the new code runnign for 2 weeks with a small random set of songs and checked the playout log for duplicates.

**How you can replicate my testing:**

Configure a Smart Block with one song 'last played before 6 hours' and let it repeat-fill a block.
