### PR TITLE
fix: live DJ not disconnected when show ends

### DIFF
--- a/api-client/libretime_api_client/v2.py
+++ b/api-client/libretime_api_client/v2.py
@@ -20,6 +20,9 @@ class ApiClient(AbstractApiClient):
     def get_show(self, item_id: int, **kwargs) -> Response:
         return self._request("GET", f"/api/v2/shows/{item_id}", **kwargs)
 
+    def list_show_instances(self, **kwargs) -> Response:
+        return self._request("GET", "/api/v2/show-instances", **kwargs)
+
     def get_show_instance(self, item_id: int, **kwargs) -> Response:
         return self._request("GET", f"/api/v2/show-instances/{item_id}", **kwargs)
 

--- a/api/libretime_api/schedule/views/show.py
+++ b/api/libretime_api/schedule/views/show.py
@@ -1,3 +1,4 @@
+from django_filters import rest_framework as filters
 from rest_framework import viewsets
 
 from ..models import Show, ShowDays, ShowHost, ShowInstance, ShowRebroadcast
@@ -8,6 +9,15 @@ from ..serializers import (
     ShowRebroadcastSerializer,
     ShowSerializer,
 )
+
+
+class ShowInstanceFilter(filters.FilterSet):
+    starts_before = filters.IsoDateTimeFilter(field_name="starts_at", lookup_expr="lte")
+    ends_after = filters.IsoDateTimeFilter(field_name="ends_at", lookup_expr="gte")
+
+    class Meta:
+        model = ShowInstance
+        fields = ["starts_before", "ends_after"]
 
 
 class ShowViewSet(viewsets.ModelViewSet):
@@ -32,6 +42,8 @@ class ShowInstanceViewSet(viewsets.ModelViewSet):
     queryset = ShowInstance.objects.all()
     serializer_class = ShowInstanceSerializer
     model_permission_name = "showinstance"
+    filter_backends = [filters.DjangoFilterBackend]
+    filterset_class = ShowInstanceFilter
 
 
 class ShowRebroadcastViewSet(viewsets.ModelViewSet):

--- a/playout/libretime_playout/liquidsoap/client/_client.py
+++ b/playout/libretime_playout/liquidsoap/client/_client.py
@@ -145,6 +145,18 @@ class LiquidsoapClient:
             self.conn.write(f"sources.{action}_{name_map[name]}")
             self.conn.read()  # Flush
 
+    def harbor_kick(
+        self,
+        name: Literal["master_dj", "live_dj"],
+    ) -> None:
+        name_map = {
+            "master_dj": "input_main",
+            "live_dj": "input_show",
+        }
+        with self._lock, self.conn:
+            self.conn.write(f"harbor:{name_map[name]}.stop")
+            self.conn.read()  # Flush
+
     def settings_update(
         self,
         *,

--- a/playout/libretime_playout/player/liquidsoap.py
+++ b/playout/libretime_playout/player/liquidsoap.py
@@ -112,6 +112,7 @@ class TelnetLiquidsoap:
         try:
             logger.debug("Disconnecting source: %s", sourcename)
             self.liq_client.source_switch_status(sourcename, False)
+            self.liq_client.harbor_kick(sourcename)
         except OSError as exception:
             logger.exception(exception)
 

--- a/playout/libretime_playout/player/queue.py
+++ b/playout/libretime_playout/player/queue.py
@@ -57,19 +57,45 @@ class PypoLiqQueue(Thread):
             else:
                 logger.info("New schedule received")
 
-                # new schedule received. Replace old one with this.
-                schedule_deque.clear()
+                # Preserve pending future ActionEvents (e.g. kick_out) that are
+                # not represented in the incoming schedule. A pure-live show has
+                # no cc_schedule rows so its kick_out is never rebuilt on refresh.
+                now = datetime.utcnow()
+                from .events import ActionEvent
 
+                new_action_starts = {
+                    item.start
+                    for item in media_schedule.values()
+                    if isinstance(item, ActionEvent)
+                }
+                preserved = [
+                    item
+                    for item in schedule_deque
+                    if isinstance(item, ActionEvent)
+                    and item.start > now
+                    and item.start not in new_action_starts
+                ]
+
+                schedule_deque.clear()
                 keys = sorted(media_schedule.keys())
                 for i in keys:
                     schedule_deque.append(media_schedule[i])
 
-                if len(keys):
+                if preserved:
+                    logger.info(
+                        "Preserving %d pending action event(s) across schedule refresh",
+                        len(preserved),
+                    )
+                    schedule_deque.extend(preserved)
+                    sorted_items = sorted(schedule_deque, key=lambda x: x.start)
+                    schedule_deque.clear()
+                    schedule_deque.extend(sorted_items)
+
+                if len(schedule_deque):
                     time_until_next_play = seconds_between(
                         datetime.utcnow(),
-                        media_schedule[keys[0]].start,
+                        schedule_deque[0].start,
                     )
-
                 else:
                     time_until_next_play = None
 

--- a/playout/libretime_playout/player/schedule.py
+++ b/playout/libretime_playout/player/schedule.py
@@ -73,6 +73,33 @@ def get_schedule(api_client: ApiClient) -> Events:
             webstream = api_client.get_webstream(item["stream"]).json()
             generate_webstream_events(events, item, webstream, show)
 
+    # Generate live events for currently active shows that have no cc_schedule
+    # items — those shows are never iterated above so their kick_out events are
+    # never created by the loop.
+    current_time_str = current_time.isoformat(timespec="seconds")
+    try:
+        active_instances = api_client.list_show_instances(
+            params={
+                "starts_before": f"{current_time_str}Z",
+                "ends_after": f"{current_time_str}Z",
+            }
+        ).json()
+        processed_ids = {item["instance"] for item in schedule if item.get("instance")}
+        for instance in active_instances:
+            if instance["id"] in processed_ids:
+                continue
+            show = api_client.get_show(instance["show"]).json()
+            if show["live_enabled"]:
+                instance["starts_at"] = event_isoparse(instance["starts_at"])
+                instance["ends_at"] = event_isoparse(instance["ends_at"])
+                generate_live_events(events, instance, stream_preferences)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "Could not fetch active show instances: %s", exc
+        )
+
     return dict(sorted(events.items()))
 
 


### PR DESCRIPTION
### Description

Reported by @BrixSat in #3253 

Three separate bugs prevented a connected live DJ from being kicked out at show end:

1. TCP connection never closed — disconnect_source() only flipped the Liquidsoap boolean flag (sources.stop_input_show) but never sent harbor:input_show.stop, so the Icecast/Shoutcast TCP session stayed open. Fixed by adding LiquidsoapClient.harbor_kick() and calling it from TelnetLiquidsoap.disconnect_source().

2. kick_out event lost on schedule refresh — PypoLiqQueue clears and rebuilds the entire deque on each new schedule. If a refresh happens after the last cc_schedule item ends but before show end, the pending kick_out ActionEvent is discarded and never fires. Fixed by preserving future ActionEvents absent from the incoming schedule across refreshes.

3. No kick_out for pure-live shows — get_schedule() generates live events by iterating cc_schedule rows. A show with live_enabled=True but zero pre-scheduled content has no rows, so generate_live_events() is never called. Fixed by querying /api/v2/show-instances for currently active instances after the schedule loop. Added ShowInstanceFilter with starts_before/ends_after filters and a list_show_instances() API client helper.

Note: harbor_kick() is intentionally called only from disconnect_source() (triggered by the scheduled kick_out ActionEvent), not from the periodic heartbeat. Adding harbor:input_show.stop to the Liquidsoap stop_input_show() function definition would create an infinite feedback loop because that function is called by the playout heartbeat every few seconds.

**This is a new feature**:

_Do the changes in this PR implement a new feature?_

**I have updated the documentation to reflect these changes**:

_Are there documentation changes required as a result of these changes? See
https://github.com/libretime/libretime/wiki/Documentation-Requirements_

### Testing Notes

**What I did:**

_What did you do to validate this PR?_

**How you can replicate my testing:**

_How can the reviewer validate this PR?_

### **Links**

Closes: #3253
