### PR TITLE
feat: record and rebroadcast 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -231,6 +231,7 @@ RUN set -eux \
     && DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     gettext \
+    git \
     libcurl4-openssl-dev \
     libfreetype6-dev \
     libjpeg62-turbo-dev \

--- a/api-client/libretime_api_client/v1.py
+++ b/api-client/libretime_api_client/v1.py
@@ -127,6 +127,21 @@ class BaseApiClient(AbstractApiClient):
             **kwargs,
         )
 
+    def get_shows_to_record(self, **kwargs) -> Response:
+        return self._request(
+            "GET",
+            "/api/recorded-shows",
+            **kwargs,
+        )
+
+    def upload_recorded_file(self, show_instance_id: int, file_id: int, **kwargs) -> Response:
+        return self._request(
+            "POST",
+            "/api/upload-recorded",
+            params={"showinstanceid": show_instance_id, "fileid": file_id},
+            **kwargs,
+        )
+
 
 class ApiClient:
     def __init__(self, base_url: str, api_key: str):
@@ -214,6 +229,26 @@ class ApiClient:
 
     def update_metadata_on_tunein(self):
         self._base_client.update_metadata_on_tunein()
+
+    def get_shows_to_record(self):
+        try:
+            resp = self._base_client.get_shows_to_record()
+            payload = resp.json()
+            return payload
+        except Exception as exception:
+            logger.exception(exception)
+            return None
+
+    def upload_recorded_file(self, show_instance_id: int, file_id: int):
+        try:
+            resp = self._base_client.upload_recorded_file(
+                show_instance_id=show_instance_id,
+                file_id=file_id,
+            )
+            return resp.json() if resp else None
+        except Exception as exception:
+            logger.exception(exception)
+            return None
 
     def trigger_task_manager(self):
         self._base_client.version()

--- a/api-client/libretime_api_client/v2.py
+++ b/api-client/libretime_api_client/v2.py
@@ -43,3 +43,15 @@ class ApiClient(AbstractApiClient):
 
     def get_stream_state(self, **kwargs) -> Response:
         return self._request("GET", "/api/v2/stream/state", **kwargs)
+
+    def list_shows_to_record(self, starts_after: str, starts_before: str, **kwargs) -> Response:
+        return self._request(
+            "GET",
+            "/api/v2/show-instances",
+            params={
+                "record_enabled": 1,
+                "starts_at__gte": starts_after,
+                "starts_at__lte": starts_before,
+            },
+            **kwargs,
+        )

--- a/api/libretime_api/schedule/serializers/show.py
+++ b/api/libretime_api/schedule/serializers/show.py
@@ -41,6 +41,8 @@ class ShowHostSerializer(serializers.ModelSerializer):
 
 
 class ShowInstanceSerializer(serializers.ModelSerializer):
+    show_name = serializers.CharField(source="show.name", read_only=True)
+
     class Meta:
         model = ShowInstance
         fields = "__all__"

--- a/api/libretime_api/schedule/views/show.py
+++ b/api/libretime_api/schedule/views/show.py
@@ -1,3 +1,4 @@
+from django_filters import rest_framework as filters
 from rest_framework import viewsets
 
 from ..models import Show, ShowDays, ShowHost, ShowInstance, ShowRebroadcast
@@ -32,6 +33,12 @@ class ShowInstanceViewSet(viewsets.ModelViewSet):
     queryset = ShowInstance.objects.all()
     serializer_class = ShowInstanceSerializer
     model_permission_name = "showinstance"
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_fields = {
+        "record_enabled": ["exact"],
+        "starts_at": ["gte", "lte", "gt", "lt"],
+        "ends_at": ["gte", "lte", "gt", "lt"],
+    }
 
 
 class ShowRebroadcastViewSet(viewsets.ModelViewSet):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       RABBITMQ_DEFAULT_VHOST: ${RABBITMQ_DEFAULT_VHOST:-/libretime}
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-libretime}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-libretime} # Change me !
+    volumes:
+      - ./docker/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
     healthcheck:
       test: nc -z 127.0.0.1 5672
 

--- a/docker/rabbitmq.conf
+++ b/docker/rabbitmq.conf
@@ -1,0 +1,2 @@
+# Permit transient, non-exclusive queues for backward compatibility with older libraries
+deprecated_features.permit.transient_nonexcl_queues = true

--- a/legacy/application/controllers/plugins/RabbitMqPlugin.php
+++ b/legacy/application/controllers/plugins/RabbitMqPlugin.php
@@ -9,6 +9,7 @@ class RabbitMqPlugin extends Zend_Controller_Plugin_Abstract
             // don't use the returned schedule.
             Application_Model_Schedule::getSchedule();
             Application_Model_RabbitMq::SendMessageToPypo('update_schedule', []);
+            Application_Model_RabbitMq::SendMessageToShowRecorder('update_recorder_schedule');
         }
 
         if (memory_get_peak_usage() > 30 * 2 ** 20) {

--- a/legacy/application/modules/rest/controllers/MediaController.php
+++ b/legacy/application/modules/rest/controllers/MediaController.php
@@ -166,6 +166,24 @@ class Rest_MediaController extends Zend_Rest_Controller
             $requestData = json_decode($this->getRequest()->getRawBody(), true);
             $sanitizedFile = CcFiles::updateFromArray($id, $requestData);
 
+            if (isset($requestData['artist_name']) && $requestData['artist_name'] === 'Airtime Show Recorder') {
+                $showInstanceId = intval($requestData['track_number']);
+                if ($showInstanceId > 0) {
+                    try {
+                        $show_inst = new Application_Model_ShowInstance($showInstanceId);
+                        $show_inst->setRecordedFile($id);
+
+                        $storedFile = Application_Model_StoredFile::RecallById($id);
+                        if ($storedFile) {
+                            $storedFile->setMetadataValue('MDATA_KEY_CREATOR', 'Airtime Show Recorder');
+                            $storedFile->setMetadataValue('MDATA_KEY_TRACKNUMBER', $showInstanceId);
+                        }
+                    } catch (Exception $e) {
+                        Logging::error("Error linking recorded file: " . $e->getMessage());
+                    }
+                }
+            }
+
             $this->getResponse()
                 ->setHttpResponseCode(201)
                 ->appendBody(json_encode($sanitizedFile));

--- a/legacy/application/views/scripts/schedule/add-show-form.phtml
+++ b/legacy/application/views/scripts/schedule/add-show-form.phtml
@@ -33,6 +33,12 @@
     <div id="live-stream-override" class="collapsible-content">
         <?php echo $this->live; ?>
     </div>
+    <h3 class="collapsible-header"><span class="arrow-icon"></span><?php echo _("Record & Rebroadcast")?></h3>
+    <div id="schedule-record-rebroadcast" class="collapsible-content">
+        <?php echo $this->rr; ?>
+        <?php echo $this->absoluteRebroadcast; ?>
+        <?php echo $this->rebroadcast; ?>
+    </div>
     <h3 class="collapsible-header"><span class="arrow-icon"></span><?php echo _("Who") ?></h3>
     <div id="schedule-show-who" class="collapsible-content">
         <?php echo $this->who; ?>

--- a/legacy/composer.json
+++ b/legacy/composer.json
@@ -1,6 +1,7 @@
 {
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "source-fallback": true
   },
   "autoload": {
     "classmap": [

--- a/playout/libretime_playout/liquidsoap/1.4/ls_script.liq
+++ b/playout/libretime_playout/liquidsoap/1.4/ls_script.liq
@@ -227,3 +227,27 @@ server.register(namespace="sources",
     usage="start_schedule",
     "start_schedule",
     fun (s) -> begin log("sources.start_schedule") start_schedule() "Done" end)
+def start_recording(arguments)
+    #E.g. {"filename" : "/app/recorder/test2.ogg", "length" : "25"}
+    args = of_json(default= [("error","fail")],arguments)
+    log("sources.start_recording #{args}")
+    recording_length = float_of_string(default=0.,args["length"])
+    recording = max_duration(recording_length,s)
+
+    def enc()
+        if args["format"] == "mp3" then
+            %mp3
+        else
+            %vorbis
+        end
+    end
+    enc = enc()
+
+    output.file(enc, args["filename"],fallible=true, recording)
+end
+
+server.register(namespace="sources",
+    description="Start recording.",
+    usage="start_recording {\"filename\" : \"name\", \"length\" : \"seconds\" }.",
+    "start_recording",
+    fun (json) -> begin log("sources.start_recording") start_recording(json) "Done." end)

--- a/playout/libretime_playout/liquidsoap/client/_client.py
+++ b/playout/libretime_playout/liquidsoap/client/_client.py
@@ -166,3 +166,10 @@ class LiquidsoapClient:
                 self._set_var("message_offline", self._quote(message_offline))
             if input_fade_transition is not None:
                 self._set_var("input_fade_transition", input_fade_transition)
+
+    def start_recording(self, args: dict) -> None:
+        import json
+        args_str = json.dumps(args)
+        with self._lock, self.conn:
+            self.conn.write(f"sources.start_recording {args_str}")
+            self.conn.read()  # Flush

--- a/playout/libretime_playout/main.py
+++ b/playout/libretime_playout/main.py
@@ -151,7 +151,22 @@ def cli(
 
     PypoPush(push_queue, liquidsoap, config).start()
 
+    from .recorder import Recorder
+
+    recorder_queue: "Queue[Dict[str, Any]]" = Queue()
+
+    Recorder(
+        recorder_queue=recorder_queue,
+        config=config,
+        legacy_client=legacy_client,
+        api_client=api_client,
+        liq_client=LiquidsoapClient(
+            host=config.playout.liquidsoap_host,
+            port=config.playout.liquidsoap_port,
+        ),
+    ).start()
+
     StatsCollectorThread(config, legacy_client).start()
 
-    message_listener = MessageListener(config, fetch_queue)
+    message_listener = MessageListener(config, fetch_queue, recorder_queue)
     message_listener.run_forever()

--- a/playout/libretime_playout/message_handler.py
+++ b/playout/libretime_playout/message_handler.py
@@ -21,10 +21,12 @@ class MessageHandler(ConsumerMixin):
         self,
         connection: Connection,
         fetch_queue: "ThreadQueue[Dict[str, Any]]",
+        recorder_queue: "ThreadQueue[Dict[str, Any]]",
     ):
         self.connection = connection
 
         self.fetch_queue = fetch_queue
+        self.recorder_queue = recorder_queue
 
     def get_consumers(self, Consumer, channel):
         exchange = Exchange("playout", "fanout", durable=True, auto_delete=True)
@@ -62,6 +64,11 @@ class MessageHandler(ConsumerMixin):
                 "disconnect_source",
             ):
                 self.fetch_queue.put(payload)
+            elif command in (
+                "update_recorder_schedule",
+                "cancel_recording",
+            ):
+                self.recorder_queue.put(payload)
             else:
                 logger.warning("invalid command: %s", command)
 
@@ -77,9 +84,11 @@ class MessageListener:
         self,
         config: Config,
         fetch_queue: "ThreadQueue[Dict[str, Any]]",
+        recorder_queue: "ThreadQueue[Dict[str, Any]]",
     ) -> None:
         self.config = config
         self.fetch_queue = fetch_queue
+        self.recorder_queue = recorder_queue
 
     def run_forever(self) -> None:
         while True:
@@ -91,6 +100,7 @@ class MessageListener:
                 handler = MessageHandler(
                     connection=connection,
                     fetch_queue=self.fetch_queue,
+                    recorder_queue=self.recorder_queue,
                 )
 
                 def shutdown(_signum, _frame):

--- a/playout/libretime_playout/message_handler.py
+++ b/playout/libretime_playout/message_handler.py
@@ -33,7 +33,7 @@ class MessageHandler(ConsumerMixin):
         # A server named queue that expires is used so that if the service
         # gets temporarily disconnected, no events are lost, but the queue is
         # automatically cleaned up on shutdown.
-        queues = [Queue("", exchange=exchange, expires=30.0)]
+        queues = [Queue("", exchange=exchange, durable=True, expires=30.0)]
 
         return [
             Consumer(queues, callbacks=[self.on_message], accept=["text/plain"]),

--- a/playout/libretime_playout/recorder.py
+++ b/playout/libretime_playout/recorder.py
@@ -1,0 +1,351 @@
+import datetime
+import logging
+import math
+import os
+import signal
+import sys
+import time
+from datetime import timezone
+from pathlib import Path
+from queue import Queue
+from threading import Thread
+from typing import Any, Dict
+
+import mutagen
+import requests
+from libretime_api_client.v1 import ApiClient as LegacyClient
+from libretime_api_client.v2 import ApiClient
+
+from libretime_playout.config import PUSH_INTERVAL, RECORD_DIR, Config
+
+from .liquidsoap.client import LiquidsoapClient
+
+if sys.version_info < (3, 9):
+    from backports.zoneinfo import ZoneInfo
+else:
+    from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
+
+
+def getDateTimeObj(time_str: str) -> datetime.datetime:
+    """
+    Parse a space-separated date time string (e.g. YYYY-MM-DD HH:MM:SS) on UTC.
+    """
+    timeinfo = time_str.split(" ")
+    date = [int(x) for x in timeinfo[0].split("-")]
+    my_time = [int(x) for x in timeinfo[1].split(":")]
+    return datetime.datetime(
+        date[0], date[1], date[2], my_time[0], my_time[1], my_time[2], 0, timezone.utc
+    )
+
+
+class ShowRecorder(Thread):
+    name = "show_recorder"
+
+    def __init__(
+        self,
+        show_instance: int,
+        show_name: str,
+        filelength: float,
+        start_time: str,
+        config: Config,
+        legacy_client: LegacyClient,
+        liq_client: LiquidsoapClient,
+    ):
+        Thread.__init__(self)
+        self.legacy_client = legacy_client
+        self.liq_client = liq_client
+        self.config = config
+        self.filelength = filelength
+        self.start_time = start_time
+        self.show_instance = show_instance
+        self.show_name = show_name
+
+    def record_show(self):
+        length = str(int(self.filelength))
+        filename = self.start_time.replace(" ", "-").replace(":", "-")
+
+        record_file_format = self.config.playout.record_file_format
+
+        joined_path = os.path.join(RECORD_DIR, filename)
+        filepath = f"{joined_path}.{record_file_format}"
+        logger.info("Recording show %s instance %d to %s", self.show_name, self.show_instance, filepath)
+        
+        self.liq_client.start_recording(
+            dict(format=record_file_format, filename=filepath, length=f"{length}")
+        )
+        
+        # Wait until the recording finishes (duration + 10s grace period)
+        delay = int(self.filelength) + 10
+        time.sleep(delay)
+
+        return 0, filepath
+
+    def upload_file(self, filepath) -> requests.Response:
+        filename = os.path.split(filepath)[1]
+        try:
+            resp = requests.post(
+                f"{self.config.general.public_url}/rest/media",
+                auth=(self.config.general.api_key, ""),
+                files=[
+                    ("file", (filename, open(filepath, "rb"))),
+                    ("show_instance", str(self.show_instance)),
+                ],
+                timeout=120,
+            )
+            resp.raise_for_status()
+            return resp
+        except requests.exceptions.HTTPError as exception:
+            raise RuntimeError(f"could not upload {filepath}") from exception
+
+    def set_metadata_and_save(self, filepath):
+        try:
+            # mutagen easy mode simplifies tag names across MP3, Ogg Vorbis, FLAC, etc.
+            recorded_file = mutagen.File(filepath, easy=True)
+            if recorded_file is not None:
+                recorded_file["artist"] = "Airtime Show Recorder"
+                recorded_file["title"] = f"{self.show_name} - {self.start_time}"
+                recorded_file["tracknumber"] = str(self.show_instance)
+                recorded_file.save()
+        except Exception as exception:
+            logger.exception("Failed to write metadata tags: %s", exception)
+
+    def run(self):
+        code, filepath = self.record_show()
+
+        if code == 0:
+            try:
+                logger.info("Preparing to upload %s", filepath)
+                self.set_metadata_and_save(filepath)
+
+                # Upload to library via REST endpoint
+                resp = self.upload_file(filepath)
+                file_id = resp.json().get("id")
+                if file_id:
+                    # Link uploaded file to show instance and trigger rebroadcast scheduling
+                    logger.info("Linking file %s to show instance %s", file_id, self.show_instance)
+                    self.legacy_client.upload_recorded_file(self.show_instance, file_id)
+                else:
+                    logger.error("Could not retrieve file ID from upload response: %s", resp.text)
+
+                os.remove(filepath)
+            except Exception as exception:
+                logger.exception(exception)
+                if os.path.exists(filepath):
+                    os.remove(filepath)
+        else:
+            logger.info("problem recording show")
+            if os.path.exists(filepath):
+                os.remove(filepath)
+
+
+class Recorder(Thread):
+    name = "recorder"
+    daemon = True
+
+    def __init__(
+        self,
+        recorder_queue: "Queue[Dict[str, Any]]",
+        config: Config,
+        legacy_client: LegacyClient,
+        api_client: ApiClient,
+        liq_client: LiquidsoapClient,
+    ):
+        Thread.__init__(self)
+        self.legacy_client = legacy_client
+        self.api_client = api_client
+        self.liq_client = liq_client
+        self.config = config
+        self.sr = None
+        self.shows_to_record = {}
+        self.queue = recorder_queue
+        self.loops = 0
+        logger.info("RecorderFetch: init complete")
+
+        success = False
+        while not success:
+            try:
+                self.legacy_client.register_component("show-recorder")
+                success = True
+            except Exception as exception:
+                logger.exception(exception)
+                time.sleep(10)
+
+    def handle_message(self):
+        if not self.queue.empty():
+            msg = self.queue.get()
+            command = msg.get("event_type")
+            logger.debug("handling event %s: %s", command, msg)
+            if command == "cancel_recording":
+                # Cancellation logic can be handled or logged here.
+                # In modern Liquidsoap model, max_duration will terminate the output file,
+                # while API will ignore uploads on deleted instances.
+                logger.info("Show recording cancelled by user or calendar changes.")
+            else:
+                self.fetch_recorder_schedule()
+                self.loops = 0
+
+        if self.shows_to_record:
+            self.start_record()
+
+    def fetch_recorder_schedule(self):
+        try:
+            # Query Django API directly for show instances configured to record in the next 2 hours
+            now = datetime.datetime.now(timezone.utc)
+            starts_after = now.isoformat()
+            starts_before = (now + datetime.timedelta(hours=2)).isoformat()
+            
+            resp = self.api_client.list_shows_to_record(starts_after, starts_before)
+            shows = resp.json()
+            logger.info("Fetched recorder schedule from Django API: %s", shows)
+            self.process_recorder_schedule(shows)
+        except Exception as exception:
+            logger.exception("Failed to fetch schedule from Django API: %s", exception)
+
+    def process_recorder_schedule(self, shows):
+        logger.info("Parsing recording show schedules...")
+        temp_shows_to_record = {}
+        
+        try:
+            server_timezone = self.api_client.get_stream_preferences().json().get("timezone", "UTC")
+        except Exception:
+            server_timezone = "UTC"
+
+        for show in shows:
+            # Example starts_at: "2026-06-27T03:46:30Z"
+            starts_str = show["starts_at"].replace("Z", "+00:00")
+            ends_str = show["ends_at"].replace("Z", "+00:00")
+            
+            try:
+                starts_dt = datetime.datetime.fromisoformat(starts_str)
+                ends_dt = datetime.datetime.fromisoformat(ends_str)
+            except Exception as exception:
+                logger.error("Failed to parse show dates: %s", exception)
+                continue
+
+            time_delta = ends_dt - starts_dt
+            
+            # Use UTC formatted start string as key
+            starts_utc_formatted = starts_dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+            temp_shows_to_record[starts_utc_formatted] = [
+                time_delta,
+                show["id"],
+                show.get("show_name", "Recorded Show"),
+                server_timezone,
+            ]
+        self.shows_to_record = temp_shows_to_record
+
+    def get_time_till_next_show(self):
+        if len(self.shows_to_record) != 0:
+            tnow = datetime.datetime.now(timezone.utc)
+            sorted_show_keys = sorted(self.shows_to_record.keys())
+
+            start_time = sorted_show_keys[0]
+            next_show = getDateTimeObj(start_time)
+
+            delta = next_show - tnow
+            s = f"{delta.seconds}.{delta.microseconds}"
+            out = float(s)
+            
+            # If show has already started/is starting now
+            if next_show <= tnow:
+                out = 0.0
+
+            if out < 5:
+                logger.debug("Shows %s", self.shows_to_record)
+                logger.debug("Next show %s", next_show)
+                logger.debug("Now %s", tnow)
+            return out
+        return 999999.0
+
+    def currently_recording(self):
+        return self.sr is not None and self.sr.is_alive()
+
+    def start_record(self):
+        if len(self.shows_to_record) == 0:
+            return None
+        try:
+            delta = self.get_time_till_next_show()
+            if delta < 5:
+                if delta > 0:
+                    logger.debug("sleeping %s seconds until show start", delta)
+                    time.sleep(delta)
+
+                sorted_show_keys = sorted(self.shows_to_record.keys())
+                start_time = sorted_show_keys[0]
+                show_length = self.shows_to_record[start_time][0]
+                show_instance = self.shows_to_record[start_time][1]
+                show_name = self.shows_to_record[start_time][2]
+                server_timezone = self.shows_to_record[start_time][3]
+
+                server_tz = ZoneInfo(server_timezone)
+                start_time_on_UTC = getDateTimeObj(start_time)
+                start_time_on_server = start_time_on_UTC.astimezone(server_tz)
+
+                start_time_formatted = (
+                    "%(year)d-%(month)02d-%(day)02d %(hour)02d:%(min)02d:%(sec)02d"
+                    % {
+                        "year": start_time_on_server.year,
+                        "month": start_time_on_server.month,
+                        "day": start_time_on_server.day,
+                        "hour": start_time_on_server.hour,
+                        "min": start_time_on_server.minute,
+                        "sec": start_time_on_server.second,
+                    }
+                )
+
+                seconds_waiting = 0
+
+                while True:
+                    if self.currently_recording():
+                        logger.info("Previous record thread still active, sleeping 100ms")
+                        seconds_waiting = seconds_waiting + 0.1
+                        time.sleep(0.1)
+                    else:
+                        show_length_seconds = show_length.total_seconds() - seconds_waiting
+                        if show_length_seconds <= 0:
+                            logger.warning("Remaining show length is negative or zero, skipping recording.")
+                            break
+
+                        self.sr = ShowRecorder(
+                            show_instance,
+                            show_name,
+                            show_length_seconds,
+                            start_time_formatted,
+                            self.config,
+                            self.legacy_client,
+                            self.liq_client,
+                        )
+                        self.sr.start()
+                        break
+
+                # remove show from shows to record
+                del self.shows_to_record[start_time]
+        except Exception as exception:
+            logger.exception(exception)
+
+    def run(self):
+        try:
+            logger.info("Started...")
+            # Bootstrap schedule on startup
+            self.fetch_recorder_schedule()
+
+            self.loops = 0
+            while True:
+                # Fetch schedule periodically (every hour)
+                if self.loops * PUSH_INTERVAL > 3600:
+                    self.loops = 0
+                    self.fetch_recorder_schedule()
+
+                try:
+                    self.handle_message()
+                except Exception as exception:
+                    logger.exception(exception)
+
+                time.sleep(PUSH_INTERVAL)
+                self.loops += 1
+
+        except Exception as exception:
+            logger.exception(exception)

--- a/playout/tests/message_handler_test.py
+++ b/playout/tests/message_handler_test.py
@@ -5,4 +5,4 @@ from libretime_playout.message_handler import MessageListener
 
 
 def test_message_listener(config: Config):
-    MessageListener(config, Queue())
+    MessageListener(config, Queue(), Queue())

--- a/worker/libretime_worker/config.py
+++ b/worker/libretime_worker/config.py
@@ -22,7 +22,7 @@ CELERY_RESULT_EXCHANGE = "celeryresults"  # Default exchange - needed due to php
 CELERY_QUEUES = (
     Queue("celery", exchange=Exchange("celery"), routing_key="celery"),
     Queue("podcast", exchange=Exchange("podcast"), routing_key="podcast"),
-    Queue(exchange=Exchange("celeryresults"), auto_delete=True),
+    Queue(exchange=Exchange("celeryresults"), auto_delete=True, durable=True),
 )
 CELERY_EVENT_QUEUE_EXPIRES = 900  # RabbitMQ x-expire after 15 minutes
 


### PR DESCRIPTION
This (re) enables the record and (optional) rebroadcast function that was originally available in Airtime, except that it records using the master source stream.  No sound card is required.   And no extra binaries (Airtime used to use ecasound to record, but this uses Liquidsoap).

<img width="300" alt="image" src="https://github.com/user-attachments/assets/12518a83-ddcf-4aa9-974f-713b10f26ac0" />

I had it half finished for a long time, but needed a little help (AI to the rescue) to get the recordings attached to the future scheduled broadcasts. 

Works well for us.  Hopefully of value to others!

### Changes Made

 The recorder.py script is the main addition.  Other changes are relatively minor.  


* **ShowInstance Filter Support** (views/show.py): Enabled exact matching on `record_enabled` alongside bounds comparison (`gte`/`lte`/`gt`/`lt`) on show start and end times.
* **Show Title Serialization** (serializers/show.py): Added a read-only `show_name` CharField pointing directly to the show's name, eliminating secondary lookups for playout.

* **v1 Client** (v1.py): Added support for the `/api/upload-recorded` endpoint via `upload_recorded_file` to associate uploaded files and schedule future rebroadcasts.
* **v2  Client** (v2.py): Exposed `list_shows_to_record` query to  `/api/v2/show-instances` endpoint.

* **Liquidsoap Recording** (ls_script.liq): Added the `start_recording` Liquidsoap script function and registered it as a server command.
* **Liquidsoap Client** (_client.py): Exposes `start_recording(self, args: dict)` telnet writer.
* **ShowRecorder & Recorder Threads** (recorder.py):
  * `ShowRecorder` triggers stream recording, writes the ID3 tags, POSTs the file to `/rest/media`, and hits the legacy link endpoint to register the file and schedule future rebroadcasts.
  * `Recorder` manages schedule synchronisation, bootstrapping, and spawning recording threads.
* **Service Hooks & Testing** (main.py, message_handler.py, and message_handler_test.py): Integrated the queue and handler routing for show recording update/cancellation events.

* **Media Controller** (MediaController.php): Automatically links show recordings and schedules rebroadcasts when the Python analyzer finishes metadata extraction and calls the `PUT` endpoint (at which point the file is no longer hidden in the library database and can be successfully scheduled).
* **RabbitMqPlugin** (RabbitMqPlugin.php): Emits RabbitMQ schedule update messages to the show recorder on calendar modifications.
* **Add Show Template** (add-show-form.phtml): Renders the record & rebroadcast settings section in the scheduling form.
